### PR TITLE
support classes for python converter and other goodies

### DIFF
--- a/libs/core/buffer.cpp
+++ b/libs/core/buffer.cpp
@@ -12,7 +12,13 @@ enum class NumberFormat {
     Int16BE,
     UInt16BE,
     Int32BE,
-    // UInt32,
+
+    UInt32LE,
+    UInt32BE,
+    Float32LE,
+    Float64LE,
+    Float32BE,
+    Float64BE,
 };
 
 //% indexerGet=BufferMethods::getByte indexerSet=BufferMethods::setByte
@@ -36,42 +42,59 @@ uint8_t *getBytes(Buffer buf) {
  * Write a number in specified format in the buffer.
  */
 //%
-void setNumber(Buffer buf, NumberFormat format, int offset, int value) {
+void setNumber(Buffer buf, NumberFormat format, int offset, TNumber value) {
     int8_t i8;
     uint8_t u8;
     int16_t i16;
     uint16_t u16;
     int32_t i32;
+    uint32_t u32;
+    float f32;
+    double f64;
 
     ManagedBuffer b(buf);
 
 // Assume little endian
-#define WRITEBYTES(isz, swap)                                                                      \
-    isz = value;                                                                                   \
+#define WRITEBYTES(isz, swap, toInt)                                                               \
+    isz = toInt(value);                                                                            \
     b.writeBytes(offset, (uint8_t *)&isz, sizeof(isz), swap);                                      \
     break
 
     switch (format) {
     case NumberFormat::Int8LE:
-        WRITEBYTES(i8, false);
+        WRITEBYTES(i8, false, toInt);
     case NumberFormat::UInt8LE:
-        WRITEBYTES(u8, false);
+        WRITEBYTES(u8, false, toInt);
     case NumberFormat::Int16LE:
-        WRITEBYTES(i16, false);
+        WRITEBYTES(i16, false, toInt);
     case NumberFormat::UInt16LE:
-        WRITEBYTES(u16, false);
+        WRITEBYTES(u16, false, toInt);
     case NumberFormat::Int32LE:
-        WRITEBYTES(i32, false);
+        WRITEBYTES(i32, false, toInt);
+    case NumberFormat::UInt32LE:
+        WRITEBYTES(u32, false, toUInt);
+
     case NumberFormat::Int8BE:
-        WRITEBYTES(i8, true);
+        WRITEBYTES(i8, true, toInt);
     case NumberFormat::UInt8BE:
-        WRITEBYTES(u8, true);
+        WRITEBYTES(u8, true, toInt);
     case NumberFormat::Int16BE:
-        WRITEBYTES(i16, true);
+        WRITEBYTES(i16, true, toInt);
     case NumberFormat::UInt16BE:
-        WRITEBYTES(u16, true);
+        WRITEBYTES(u16, true, toInt);
     case NumberFormat::Int32BE:
-        WRITEBYTES(i32, true);
+        WRITEBYTES(i32, true, toInt);
+    case NumberFormat::UInt32BE:
+        WRITEBYTES(u32, true, toUInt);
+
+    case NumberFormat::Float32LE:
+        WRITEBYTES(f32, false, toFloat);
+    case NumberFormat::Float32BE:
+        WRITEBYTES(f32, true, toFloat);
+    case NumberFormat::Float64LE:
+        WRITEBYTES(f64, false, toDouble);
+    case NumberFormat::Float64BE:
+        WRITEBYTES(f64, true, toDouble);
     }
 }
 
@@ -79,41 +102,58 @@ void setNumber(Buffer buf, NumberFormat format, int offset, int value) {
  * Read a number in specified format from the buffer.
  */
 //%
-int getNumber(Buffer buf, NumberFormat format, int offset) {
+TNumber getNumber(Buffer buf, NumberFormat format, int offset) {
     int8_t i8;
     uint8_t u8;
     int16_t i16;
     uint16_t u16;
     int32_t i32;
+    uint32_t u32;
+    float f32;
+    double f64;
 
     ManagedBuffer b(buf);
 
 // Assume little endian
-#define READBYTES(isz, swap)                                                                       \
+#define READBYTES(isz, swap, conv)                                                                 \
     b.readBytes((uint8_t *)&isz, offset, sizeof(isz), swap);                                       \
-    return isz
+    return conv(isz)
 
     switch (format) {
     case NumberFormat::Int8LE:
-        READBYTES(i8, false);
+        READBYTES(i8, false, fromInt);
     case NumberFormat::UInt8LE:
-        READBYTES(u8, false);
+        READBYTES(u8, false, fromInt);
     case NumberFormat::Int16LE:
-        READBYTES(i16, false);
+        READBYTES(i16, false, fromInt);
     case NumberFormat::UInt16LE:
-        READBYTES(u16, false);
+        READBYTES(u16, false, fromInt);
     case NumberFormat::Int32LE:
-        READBYTES(i32, false);
+        READBYTES(i32, false, fromInt);
+    case NumberFormat::UInt32LE:
+        READBYTES(u32, false, fromUInt);
+
     case NumberFormat::Int8BE:
-        READBYTES(i8, true);
+        READBYTES(i8, true, fromInt);
     case NumberFormat::UInt8BE:
-        READBYTES(u8, true);
+        READBYTES(u8, true, fromInt);
     case NumberFormat::Int16BE:
-        READBYTES(i16, true);
+        READBYTES(i16, true, fromInt);
     case NumberFormat::UInt16BE:
-        READBYTES(u16, true);
+        READBYTES(u16, true, fromInt);
     case NumberFormat::Int32BE:
-        READBYTES(i32, true);
+        READBYTES(i32, true, fromInt);
+    case NumberFormat::UInt32BE:
+        READBYTES(u32, true, fromUInt);
+
+    case NumberFormat::Float32LE:
+        READBYTES(f32, false, fromFloat);
+    case NumberFormat::Float32BE:
+        READBYTES(f32, true, fromFloat);
+    case NumberFormat::Float64LE:
+        READBYTES(f64, false, fromDouble);
+    case NumberFormat::Float64BE:
+        READBYTES(f64, true, fromDouble);
     }
 
     return 0;

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -15,4 +15,11 @@ namespace control {
      */
     // shim=pxtrt::assert
     export function assert(cond: boolean, code: number) { }
+
+    export function fail(message: string) {
+        serial.writeString("Fatal failure: ")
+        serial.writeString(message)
+        serial.writeString("\r\n")
+        panic(108)
+    }
 }

--- a/libs/core/enums.d.ts
+++ b/libs/core/enums.d.ts
@@ -59,7 +59,13 @@
     Int16BE = 8,
     UInt16BE = 9,
     Int32BE = 10,
-    // UInt32,
+
+    UInt32LE = 11,
+    UInt32BE = 12,
+    Float32LE = 13,
+    Float64LE = 14,
+    Float32BE = 15,
+    Float64BE = 16,
     }
 
 

--- a/libs/core/i2c.cpp
+++ b/libs/core/i2c.cpp
@@ -9,7 +9,11 @@ namespace pins {
     Buffer i2cReadBuffer(int address, int size, bool repeat = false)
     {
       Buffer buf = createBuffer(size);
-      io->i2c.read(address << 1, (char*)buf->payload, size, repeat);
+      int ok = io->i2c.read(address << 1, (char*)buf->payload, size, repeat);
+      if (!ok) {
+        free(buf);
+        buf = 0;
+      }
       return buf;
     }
 
@@ -17,8 +21,8 @@ namespace pins {
      * Write bytes to a 7-bit I2C `address`.
      */
     //%
-    void i2cWriteBuffer(int address, Buffer buf, bool repeat = false)
+    int i2cWriteBuffer(int address, Buffer buf, bool repeat = false)
     {
-      io->i2c.write(address << 1, (char*)buf->payload, buf->length, repeat);
+      return io->i2c.write(address << 1, (char*)buf->payload, buf->length, repeat);
     }
 }

--- a/libs/core/i2c.ts
+++ b/libs/core/i2c.ts
@@ -26,13 +26,17 @@ namespace pins {
         constructor(address: number) {
             this.address = address
         }
-        public readInto(buf: Buffer, repeat = false) {
-            let res = i2cReadBuffer(this.address, buf.length, repeat)
+        public readInto(buf: Buffer, repeat = false, start = 0, end: number = null) {
+            if (end === null)
+                end = buf.length
+            if (start >= end)
+                return
+            let res = i2cReadBuffer(this.address, end - start, repeat)
             if (!res) {
                 this._hasError = true
                 return
             }
-            buf.write(0, res)
+            buf.write(start, res)
         }
         public write(buf: Buffer, repeat = false) {
             let res = i2cWriteBuffer(this.address, buf, repeat)

--- a/libs/core/i2c.ts
+++ b/libs/core/i2c.ts
@@ -19,4 +19,34 @@ namespace pins {
         buf.setNumber(format, 0, value)
         pins.i2cWriteBuffer(address, buf, repeated)
     }
+
+    export class I2CDevice {
+        public address: number;
+        private _hasError: boolean;
+        constructor(address: number) {
+            this.address = address
+        }
+        public readInto(buf: Buffer, repeat = false) {
+            let res = i2cReadBuffer(this.address, buf.length, repeat)
+            if (!res) {
+                this._hasError = true
+                return
+            }
+            buf.write(0, res)
+        }
+        public write(buf: Buffer, repeat = false) {
+            let res = i2cWriteBuffer(this.address, buf, repeat)
+            if (res) {
+                this._hasError = true
+            }
+        }
+        public begin() {
+            this._hasError = false
+        }
+        public end() {
+        }
+        public ok() {
+            return !this._hasError
+        }
+    }
 }

--- a/libs/core/pins.ts
+++ b/libs/core/pins.ts
@@ -21,11 +21,109 @@ namespace pins {
                 return 2;
             case NumberFormat.Int32LE:
             case NumberFormat.Int32BE:
+            case NumberFormat.UInt32BE:
+            case NumberFormat.UInt32LE:
+            case NumberFormat.Float32BE:
+            case NumberFormat.Float32LE:
                 return 4;
+            case NumberFormat.Float64BE:
+            case NumberFormat.Float64LE:
+                return 8;
         }
         return 0;
     }
+
+    /**
+     * Create a new buffer initalized to bytes from given array.
+     * @param bytes data to initalize with
+     */
+    //%
+    export function createBufferFromArray(bytes: number[]) {
+        let buf = createBuffer(bytes.length)
+        for (let i = 0; i < bytes.length; ++i)
+            buf[i] = bytes[i]
+        return buf
+    }
+
+    function getFormat(pychar: string, isBig: boolean) {
+        switch (pychar) {
+            case 'B':
+                return NumberFormat.UInt8LE
+            case 'b':
+                return NumberFormat.Int8LE
+            case 'H':
+                return isBig ? NumberFormat.UInt16BE : NumberFormat.UInt16LE
+            case 'h':
+                return isBig ? NumberFormat.Int16BE : NumberFormat.Int16LE
+            case 'I':
+            case 'L':
+                return isBig ? NumberFormat.UInt32BE : NumberFormat.UInt32LE
+            case 'i':
+            case 'l':
+                return isBig ? NumberFormat.Int32BE : NumberFormat.Int32LE
+            case 'f':
+                return isBig ? NumberFormat.Float32BE : NumberFormat.Float32LE
+            case 'd':
+                return isBig ? NumberFormat.Float64BE : NumberFormat.Float64LE
+            default:
+                return null as NumberFormat
+        }
+    }
+
+    function packUnpackCore(format: string, nums: number[], buf: Buffer, isPack: boolean, off = 0) {
+        let isBig = false
+        let idx = 0
+        for (let i = 0; i < format.length; ++i) {
+            switch (format[i]) {
+                case ' ':
+                case '<':
+                case '=':
+                    isBig = false
+                    break
+                case '>':
+                case '!':
+                    isBig = true
+                    break
+                case 'x':
+                    off++
+                    break
+                default:
+                    let fmt = getFormat(format[i], isBig)
+                    if (fmt === null) {
+                        control.fail("Not supported format character: " + format[i])
+                    } else {
+                        if (buf) {
+                            if (isPack)
+                                buf.setNumber(fmt, off, nums[idx++])
+                            else
+                                nums.push(buf.getNumber(fmt, off))
+                        }
+
+                        off += pins.sizeOf(fmt)
+                    }
+                    break
+            }
+        }
+        return off
+    }
+
+    export function packedSize(format: string) {
+        return packUnpackCore(format, null, null, true)
+    }
+
+    export function packBuffer(format: string, nums: number[]) {
+        let buf = createBuffer(packedSize(format))
+        packUnpackCore(format, nums, buf, true)
+        return buf
+    }
+
+    export function unpackBuffer(format: string, buf: Buffer, offset = 0) {
+        let res: number[] = []
+        packUnpackCore(format, res, buf, false, offset)
+        return res
+    }
 }
+
 
 //% noRefCounting fixedInstances
 interface DigitalPin {


### PR DESCRIPTION
This PR adds:
* support for uint32 and float NumberFormats when operating on buffers
* pins.packBuffer, unpackBuffer (similar for Python struct.pack)
* I2CDevice class (encapsulates address and in future lock)
* adds return codes to I2C functions
* adds control.fail

Please takes a look and see if the APIs and their names make sense.
CC @pelikhan @abchatra @microsoftsam @riknoll @tballmsft 