### PR TITLE
Moving simulator code into common packages

### DIFF
--- a/libs/accelerometer/sim/accelerometer.ts
+++ b/libs/accelerometer/sim/accelerometer.ts
@@ -1,60 +1,13 @@
-const enum CODAL {
-    REDLED = 13,
-    NEOPIXEL_PIN = 17,
-    SLIDE_SWITCH_PIN = 21,
-    LEFT_BUTTON = 4,
-    RIGHT_BUTTON = 19,
-    //LIGHT_SENSOR = A5,
-    LIS3DH_CS = 8,
-    //THERMISTOR_PIN = A0,
-    BUZZER = 5,
-
-    ID_BUTTON_A = 1,
-    ID_BUTTON_B = 2,
-    ID_BUTTON_RESET = 3,
-    ID_ACCELEROMETER = 4,
-    ID_BUTTON_AB = 26,
-    ID_GESTURE = 27,
-    ID_THERMOMETER = 28,
-
-    CAPSENSE_SHARED = 30,
-    ACCELEROMETER_EVT_DATA_UPDATE = 1,
-    ACCELEROMETER_EVT_NONE = 0,
-    ACCELEROMETER_EVT_TILT_UP = 1,
-    ACCELEROMETER_EVT_TILT_DOWN = 2,
-    ACCELEROMETER_EVT_TILT_LEFT = 3,
-    ACCELEROMETER_EVT_TILT_RIGHT = 4,
-    ACCELEROMETER_EVT_FACE_UP = 5,
-    ACCELEROMETER_EVT_FACE_DOWN = 6,
-    ACCELEROMETER_EVT_FREEFALL = 7,
-    ACCELEROMETER_EVT_3G = 8,
-    ACCELEROMETER_EVT_6G = 9,
-    ACCELEROMETER_EVT_8G = 10,
-    ACCELEROMETER_EVT_SHAKE = 11,
-    ACCELEROMETER_REST_TOLERANCE = 200,
-    ACCELEROMETER_TILT_TOLERANCE = 200,
-    ACCELEROMETER_FREEFALL_TOLERANCE = 400,
-    ACCELEROMETER_SHAKE_TOLERANCE = 400,
-    ACCELEROMETER_3G_TOLERANCE = 3072,
-    ACCELEROMETER_6G_TOLERANCE = 6144,
-    ACCELEROMETER_8G_TOLERANCE = 8192,
-    ACCELEROMETER_GESTURE_DAMPING = 5,
-    ACCELEROMETER_SHAKE_DAMPING = 10,
-    ACCELEROMETER_SHAKE_RTX = 30,
-    ACCELEROMETER_SHAKE_COUNT_THRESHOLD = 4
-}
-
-
 namespace pxsim.input {
     export function onGesture(gesture: number, handler: RefAction) {
         let b = accelerometer();
         b.accelerometer.activate();
 
-        if (gesture == CODAL.ACCELEROMETER_EVT_SHAKE && !b.useShake) {
+        if (gesture == DAL.ACCELEROMETER_EVT_SHAKE && !b.useShake) {
             b.useShake = true;
             runtime.queueDisplayUpdate();
         }
-        pxtcore.registerWithDal(CODAL.ID_GESTURE, gesture, handler);
+        pxtcore.registerWithDal(DAL.DEVICE_ID_GESTURE, gesture, handler);
     }
 
     export function rotation(kind: number): number {
@@ -159,7 +112,7 @@ namespace pxsim {
         public sampleRange = 2;
 
         constructor(public runtime: Runtime) {
-            this.id = CODAL.ID_ACCELEROMETER;
+            this.id = DAL.DEVICE_ID_ACCELEROMETER;
         }
 
         public setSampleRange(range: number) {
@@ -188,7 +141,7 @@ namespace pxsim {
             this.updateGesture();
 
             // Indicate that a new sample is available
-            board().bus.queue(this.id, CODAL.ACCELEROMETER_EVT_DATA_UPDATE)
+            board().bus.queue(this.id, DAL.ACCELEROMETER_EVT_DATA_UPDATE)
         }
 
         public instantaneousAccelerationSquared() {
@@ -212,25 +165,25 @@ namespace pxsim {
             //
             // If we see enough zero crossings in succession (MICROBIT_ACCELEROMETER_SHAKE_COUNT_THRESHOLD), then we decide that the device
             // has been shaken.
-            if ((this.getX() < -CODAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.x) || (this.getX() > CODAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.x)) {
+            if ((this.getX() < -DAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.x) || (this.getX() > DAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.x)) {
                 shakeDetected = true;
                 this.shake.x = !this.shake.x;
             }
 
-            if ((this.getY() < -CODAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.y) || (this.getY() > CODAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.y)) {
+            if ((this.getY() < -DAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.y) || (this.getY() > DAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.y)) {
                 shakeDetected = true;
                 this.shake.y = !this.shake.y;
             }
 
-            if ((this.getZ() < -CODAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.z) || (this.getZ() > CODAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.z)) {
+            if ((this.getZ() < -DAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.z) || (this.getZ() > DAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.z)) {
                 shakeDetected = true;
                 this.shake.z = !this.shake.z;
             }
 
-            if (shakeDetected && this.shake.count < CODAL.ACCELEROMETER_SHAKE_COUNT_THRESHOLD && ++this.shake.count == CODAL.ACCELEROMETER_SHAKE_COUNT_THRESHOLD)
+            if (shakeDetected && this.shake.count < DAL.ACCELEROMETER_SHAKE_COUNT_THRESHOLD && ++this.shake.count == DAL.ACCELEROMETER_SHAKE_COUNT_THRESHOLD)
                 this.shake.shaken = 1;
 
-            if (++this.shake.timer >= CODAL.ACCELEROMETER_SHAKE_DAMPING) {
+            if (++this.shake.timer >= DAL.ACCELEROMETER_SHAKE_DAMPING) {
                 this.shake.timer = 0;
                 if (this.shake.count > 0) {
                     if (--this.shake.count == 0)
@@ -239,40 +192,40 @@ namespace pxsim {
             }
 
             if (this.shake.shaken)
-                return CODAL.ACCELEROMETER_EVT_SHAKE;
+                return DAL.ACCELEROMETER_EVT_SHAKE;
 
             let sq = (n: number) => n * n
 
-            if (force < sq(CODAL.ACCELEROMETER_FREEFALL_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_FREEFALL;
+            if (force < sq(DAL.ACCELEROMETER_FREEFALL_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_FREEFALL;
 
-            if (force > sq(CODAL.ACCELEROMETER_3G_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_3G;
+            if (force > sq(DAL.ACCELEROMETER_3G_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_3G;
 
-            if (force > sq(CODAL.ACCELEROMETER_6G_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_6G;
+            if (force > sq(DAL.ACCELEROMETER_6G_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_6G;
 
-            if (force > sq(CODAL.ACCELEROMETER_8G_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_8G;
+            if (force > sq(DAL.ACCELEROMETER_8G_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_8G;
 
             // Determine our posture.
-            if (this.getX() < (-1000 + CODAL.ACCELEROMETER_TILT_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_TILT_LEFT;
+            if (this.getX() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_TILT_LEFT;
 
-            if (this.getX() > (1000 - CODAL.ACCELEROMETER_TILT_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_TILT_RIGHT;
+            if (this.getX() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_TILT_RIGHT;
 
-            if (this.getY() < (-1000 + CODAL.ACCELEROMETER_TILT_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_TILT_DOWN;
+            if (this.getY() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_TILT_DOWN;
 
-            if (this.getY() > (1000 - CODAL.ACCELEROMETER_TILT_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_TILT_UP;
+            if (this.getY() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_TILT_UP;
 
-            if (this.getZ() < (-1000 + CODAL.ACCELEROMETER_TILT_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_FACE_UP;
+            if (this.getZ() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_FACE_UP;
 
-            if (this.getZ() > (1000 - CODAL.ACCELEROMETER_TILT_TOLERANCE))
-                return CODAL.ACCELEROMETER_EVT_FACE_DOWN;
+            if (this.getZ() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_FACE_DOWN;
 
             return 0;
         }
@@ -283,7 +236,7 @@ namespace pxsim {
 
             // Perform some low pass filtering to reduce jitter from any detected effects
             if (g == this.currentGesture) {
-                if (this.sigma < CODAL.ACCELEROMETER_GESTURE_DAMPING)
+                if (this.sigma < DAL.ACCELEROMETER_GESTURE_DAMPING)
                     this.sigma++;
             }
             else {
@@ -292,9 +245,9 @@ namespace pxsim {
             }
 
             // If we've reached threshold, update our record and raise the relevant event...
-            if (this.currentGesture != this.lastGesture && this.sigma >= CODAL.ACCELEROMETER_GESTURE_DAMPING) {
+            if (this.currentGesture != this.lastGesture && this.sigma >= DAL.ACCELEROMETER_GESTURE_DAMPING) {
                 this.lastGesture = this.currentGesture;
-                board().bus.queue(CODAL.ID_GESTURE, this.lastGesture);
+                board().bus.queue(DAL.DEVICE_ID_GESTURE, this.lastGesture);
             }
         }
 

--- a/libs/accelerometer/sim/accelerometer.ts
+++ b/libs/accelerometer/sim/accelerometer.ts
@@ -1,0 +1,436 @@
+const enum CODAL {
+    REDLED = 13,
+    NEOPIXEL_PIN = 17,
+    SLIDE_SWITCH_PIN = 21,
+    LEFT_BUTTON = 4,
+    RIGHT_BUTTON = 19,
+    //LIGHT_SENSOR = A5,
+    LIS3DH_CS = 8,
+    //THERMISTOR_PIN = A0,
+    BUZZER = 5,
+
+    ID_BUTTON_A = 1,
+    ID_BUTTON_B = 2,
+    ID_BUTTON_RESET = 3,
+    ID_ACCELEROMETER = 4,
+    ID_BUTTON_AB = 26,
+    ID_GESTURE = 27,
+    ID_THERMOMETER = 28,
+
+    CAPSENSE_SHARED = 30,
+    ACCELEROMETER_EVT_DATA_UPDATE = 1,
+    ACCELEROMETER_EVT_NONE = 0,
+    ACCELEROMETER_EVT_TILT_UP = 1,
+    ACCELEROMETER_EVT_TILT_DOWN = 2,
+    ACCELEROMETER_EVT_TILT_LEFT = 3,
+    ACCELEROMETER_EVT_TILT_RIGHT = 4,
+    ACCELEROMETER_EVT_FACE_UP = 5,
+    ACCELEROMETER_EVT_FACE_DOWN = 6,
+    ACCELEROMETER_EVT_FREEFALL = 7,
+    ACCELEROMETER_EVT_3G = 8,
+    ACCELEROMETER_EVT_6G = 9,
+    ACCELEROMETER_EVT_8G = 10,
+    ACCELEROMETER_EVT_SHAKE = 11,
+    ACCELEROMETER_REST_TOLERANCE = 200,
+    ACCELEROMETER_TILT_TOLERANCE = 200,
+    ACCELEROMETER_FREEFALL_TOLERANCE = 400,
+    ACCELEROMETER_SHAKE_TOLERANCE = 400,
+    ACCELEROMETER_3G_TOLERANCE = 3072,
+    ACCELEROMETER_6G_TOLERANCE = 6144,
+    ACCELEROMETER_8G_TOLERANCE = 8192,
+    ACCELEROMETER_GESTURE_DAMPING = 5,
+    ACCELEROMETER_SHAKE_DAMPING = 10,
+    ACCELEROMETER_SHAKE_RTX = 30,
+    ACCELEROMETER_SHAKE_COUNT_THRESHOLD = 4
+}
+
+
+namespace pxsim.input {
+    export function onGesture(gesture: number, handler: RefAction) {
+        let b = accelerometer();
+        b.accelerometer.activate();
+
+        if (gesture == CODAL.ACCELEROMETER_EVT_SHAKE && !b.useShake) {
+            b.useShake = true;
+            runtime.queueDisplayUpdate();
+        }
+        pxtcore.registerWithDal(CODAL.ID_GESTURE, gesture, handler);
+    }
+
+    export function rotation(kind: number): number {
+        let b = accelerometer();
+        let acc = b.accelerometer;
+        acc.activate();
+        let x = acc.getX(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
+        let y = acc.getY(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
+        let z = acc.getZ(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
+
+        let roll = Math.atan2(y, z);
+        let pitch = Math.atan(-x / (y * Math.sin(roll) + z * Math.cos(roll)));
+
+        let r = 0;
+        switch (kind) {
+            case 0: r = pitch; break;
+            case 1: r = roll; break;
+        }
+        return Math.floor(r / Math.PI * 180);
+    }
+
+    export function setAccelerometerRange(range: number) {
+        let b = accelerometer();
+        b.accelerometer.setSampleRange(range);
+    }
+
+    export function acceleration(dimension: number): number {
+        let b = accelerometer();
+        let acc = b.accelerometer;
+        acc.activate();
+        switch (dimension) {
+            case 0: return acc.getX();
+            case 1: return acc.getY();
+            case 2: return acc.getZ();
+            default: return Math.floor(Math.sqrt(acc.instantaneousAccelerationSquared()));
+        }
+    }
+}
+
+namespace pxsim {
+    interface AccelerometerSample {
+        x: number;
+        y: number;
+        z: number;
+    }
+
+    interface ShakeHistory {
+        x: boolean;
+        y: boolean;
+        z: boolean;
+        count: number;
+        shaken: number;
+        timer: number;
+    }
+
+    /**
+      * Co-ordinate systems that can be used.
+      * RAW: Unaltered data. Data will be returned directly from the accelerometer.
+      *
+      * SIMPLE_CARTESIAN: Data will be returned based on an easy to understand alignment, consistent with the cartesian system taught in schools.
+      * When held upright, facing the user:
+      *
+      *                            /
+      *    +--------------------+ z
+      *    |                    |
+      *    |       .....        |
+      *    | *     .....      * |
+      * ^  |       .....        |
+      * |  |                    |
+      * y  +--------------------+  x-->
+      *
+      *
+      * NORTH_EAST_DOWN: Data will be returned based on the industry convention of the North East Down (NED) system.
+      * When held upright, facing the user:
+      *
+      *                            z
+      *    +--------------------+ /
+      *    |                    |
+      *    |       .....        |
+      *    | *     .....      * |
+      * ^  |       .....        |
+      * |  |                    |
+      * x  +--------------------+  y-->
+      *
+      */
+    export enum MicroBitCoordinateSystem {
+        RAW,
+        SIMPLE_CARTESIAN,
+        NORTH_EAST_DOWN
+    }
+
+    export class Accelerometer {
+        private sigma: number = 0;              // the number of ticks that the instantaneous gesture has been stable.
+        private lastGesture: number = 0;       // the last, stable gesture recorded.
+        private currentGesture: number = 0     // the instantaneous, unfiltered gesture detected.
+        private sample: AccelerometerSample = { x: 0, y: 0, z: -1023 }
+        private shake: ShakeHistory = { x: false, y: false, z: false, count: 0, shaken: 0, timer: 0 }; // State information needed to detect shake events.
+        private pitch: number;
+        private roll: number;
+        private id: number;
+        public isActive = false;
+        public sampleRange = 2;
+
+        constructor(public runtime: Runtime) {
+            this.id = CODAL.ID_ACCELEROMETER;
+        }
+
+        public setSampleRange(range: number) {
+            this.activate();
+            this.sampleRange = Math.max(1, Math.min(8, range));
+        }
+
+        public activate() {
+            if (!this.isActive) {
+                this.isActive = true;
+                this.runtime.queueDisplayUpdate();
+            }
+        }
+
+        /**
+         * Reads the acceleration data from the accelerometer, and stores it in our buffer.
+         * This is called by the tick() member function, if the interrupt is set!
+         */
+        public update(x: number, y: number, z: number) {
+            // read MSB values...
+            this.sample.x = Math.floor(x);
+            this.sample.y = Math.floor(y);
+            this.sample.z = Math.floor(z);
+
+            // Update gesture tracking
+            this.updateGesture();
+
+            // Indicate that a new sample is available
+            board().bus.queue(this.id, CODAL.ACCELEROMETER_EVT_DATA_UPDATE)
+        }
+
+        public instantaneousAccelerationSquared() {
+            // Use pythagoras theorem to determine the combined force acting on the device.
+            return this.sample.x * this.sample.x + this.sample.y * this.sample.y + this.sample.z * this.sample.z;
+        }
+
+        /**
+         * Service function. Determines the best guess posture of the device based on instantaneous data.
+         * This makes no use of historic data (except for shake), and forms this input to the filter implemented in updateGesture().
+         *
+         * @return A best guess of the current posture of the device, based on instantaneous data.
+         */
+        private instantaneousPosture(): number {
+            let force = this.instantaneousAccelerationSquared();
+            let shakeDetected = false;
+
+            // Test for shake events.
+            // We detect a shake by measuring zero crossings in each axis. In other words, if we see a strong acceleration to the left followed by
+            // a string acceleration to the right, then we can infer a shake. Similarly, we can do this for each acxis (left/right, up/down, in/out).
+            //
+            // If we see enough zero crossings in succession (MICROBIT_ACCELEROMETER_SHAKE_COUNT_THRESHOLD), then we decide that the device
+            // has been shaken.
+            if ((this.getX() < -CODAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.x) || (this.getX() > CODAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.x)) {
+                shakeDetected = true;
+                this.shake.x = !this.shake.x;
+            }
+
+            if ((this.getY() < -CODAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.y) || (this.getY() > CODAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.y)) {
+                shakeDetected = true;
+                this.shake.y = !this.shake.y;
+            }
+
+            if ((this.getZ() < -CODAL.ACCELEROMETER_SHAKE_TOLERANCE && this.shake.z) || (this.getZ() > CODAL.ACCELEROMETER_SHAKE_TOLERANCE && !this.shake.z)) {
+                shakeDetected = true;
+                this.shake.z = !this.shake.z;
+            }
+
+            if (shakeDetected && this.shake.count < CODAL.ACCELEROMETER_SHAKE_COUNT_THRESHOLD && ++this.shake.count == CODAL.ACCELEROMETER_SHAKE_COUNT_THRESHOLD)
+                this.shake.shaken = 1;
+
+            if (++this.shake.timer >= CODAL.ACCELEROMETER_SHAKE_DAMPING) {
+                this.shake.timer = 0;
+                if (this.shake.count > 0) {
+                    if (--this.shake.count == 0)
+                        this.shake.shaken = 0;
+                }
+            }
+
+            if (this.shake.shaken)
+                return CODAL.ACCELEROMETER_EVT_SHAKE;
+
+            let sq = (n: number) => n * n
+
+            if (force < sq(CODAL.ACCELEROMETER_FREEFALL_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_FREEFALL;
+
+            if (force > sq(CODAL.ACCELEROMETER_3G_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_3G;
+
+            if (force > sq(CODAL.ACCELEROMETER_6G_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_6G;
+
+            if (force > sq(CODAL.ACCELEROMETER_8G_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_8G;
+
+            // Determine our posture.
+            if (this.getX() < (-1000 + CODAL.ACCELEROMETER_TILT_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_TILT_LEFT;
+
+            if (this.getX() > (1000 - CODAL.ACCELEROMETER_TILT_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_TILT_RIGHT;
+
+            if (this.getY() < (-1000 + CODAL.ACCELEROMETER_TILT_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_TILT_DOWN;
+
+            if (this.getY() > (1000 - CODAL.ACCELEROMETER_TILT_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_TILT_UP;
+
+            if (this.getZ() < (-1000 + CODAL.ACCELEROMETER_TILT_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_FACE_UP;
+
+            if (this.getZ() > (1000 - CODAL.ACCELEROMETER_TILT_TOLERANCE))
+                return CODAL.ACCELEROMETER_EVT_FACE_DOWN;
+
+            return 0;
+        }
+
+        updateGesture() {
+            // Determine what it looks like we're doing based on the latest sample...
+            let g = this.instantaneousPosture();
+
+            // Perform some low pass filtering to reduce jitter from any detected effects
+            if (g == this.currentGesture) {
+                if (this.sigma < CODAL.ACCELEROMETER_GESTURE_DAMPING)
+                    this.sigma++;
+            }
+            else {
+                this.currentGesture = g;
+                this.sigma = 0;
+            }
+
+            // If we've reached threshold, update our record and raise the relevant event...
+            if (this.currentGesture != this.lastGesture && this.sigma >= CODAL.ACCELEROMETER_GESTURE_DAMPING) {
+                this.lastGesture = this.currentGesture;
+                board().bus.queue(CODAL.ID_GESTURE, this.lastGesture);
+            }
+        }
+
+        /**
+          * Reads the X axis value of the latest update from the accelerometer.
+          * @param system The coordinate system to use. By default, a simple cartesian system is provided.
+          * @return The force measured in the X axis, in milli-g.
+          *
+          * Example:
+          * @code
+          * uBit.accelerometer.getX();
+          * uBit.accelerometer.getX(RAW);
+          * @endcode
+          */
+        public getX(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
+            this.activate();
+            switch (system) {
+                case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
+                    return -this.sample.x;
+
+                case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
+                    return this.sample.y;
+                //case MicroBitCoordinateSystem.SIMPLE_CARTESIAN.RAW:
+                default:
+                    return this.sample.x;
+            }
+        }
+
+        /**
+          * Reads the Y axis value of the latest update from the accelerometer.
+          * @param system The coordinate system to use. By default, a simple cartesian system is provided.
+          * @return The force measured in the Y axis, in milli-g.
+          *
+          * Example:
+          * @code
+          * uBit.accelerometer.getY();
+          * uBit.accelerometer.getY(RAW);
+          * @endcode
+          */
+        public getY(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
+            this.activate();
+            switch (system) {
+                case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
+                    return -this.sample.y;
+
+                case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
+                    return -this.sample.x;
+                //case RAW:
+                default:
+                    return this.sample.y;
+            }
+        }
+
+        /**
+          * Reads the Z axis value of the latest update from the accelerometer.
+          * @param system The coordinate system to use. By default, a simple cartesian system is provided.
+          * @return The force measured in the Z axis, in milli-g.
+          *
+          * Example:
+          * @code
+          * uBit.accelerometer.getZ();
+          * uBit.accelerometer.getZ(RAW);
+          * @endcode
+          */
+        public getZ(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
+            this.activate();
+            switch (system) {
+                case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
+                    return -this.sample.z;
+                //case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
+                //case MicroBitCoordinateSystem.RAW:
+                default:
+                    return this.sample.z;
+            }
+        }
+
+        /**
+          * Provides a rotation compensated pitch of the device, based on the latest update from the accelerometer.
+          * @return The pitch of the device, in degrees.
+          *
+          * Example:
+          * @code
+          * uBit.accelerometer.getPitch();
+          * @endcode
+          */
+        public getPitch(): number {
+            this.activate();
+            return Math.floor((360 * this.getPitchRadians()) / (2 * Math.PI));
+        }
+
+        getPitchRadians(): number {
+            this.recalculatePitchRoll();
+            return this.pitch;
+        }
+
+        /**
+          * Provides a rotation compensated roll of the device, based on the latest update from the accelerometer.
+          * @return The roll of the device, in degrees.
+          *
+          * Example:
+          * @code
+          * uBit.accelerometer.getRoll();
+          * @endcode
+          */
+        public getRoll(): number {
+            this.activate();
+            return Math.floor((360 * this.getRollRadians()) / (2 * Math.PI));
+        }
+
+        getRollRadians(): number {
+            this.recalculatePitchRoll();
+            return this.roll;
+        }
+
+        /**
+         * Recalculate roll and pitch values for the current sample.
+         * We only do this at most once per sample, as the necessary trigonemteric functions are rather
+         * heavyweight for a CPU without a floating point unit...
+         */
+        recalculatePitchRoll() {
+            let x = this.getX(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
+            let y = this.getY(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
+            let z = this.getZ(MicroBitCoordinateSystem.NORTH_EAST_DOWN);
+
+            this.roll = Math.atan2(y, z);
+            this.pitch = Math.atan(-x / (y * Math.sin(this.roll) + z * Math.cos(this.roll)));
+        }
+
+    }
+
+    export class AccelerometerState {
+        accelerometer: Accelerometer;
+        useShake = false;
+
+        constructor(runtime: Runtime) {
+           this.accelerometer = new Accelerometer(runtime);
+        }
+    }
+}

--- a/libs/accelerometer/sim/state.ts
+++ b/libs/accelerometer/sim/state.ts
@@ -1,0 +1,9 @@
+namespace pxsim {
+    export interface AccelerometerBoard extends CommonBoard {
+        accelerometerState: AccelerometerState;
+    }
+
+    export function accelerometer(): AccelerometerState {
+        return (board() as AccelerometerBoard).accelerometerState;
+    }
+}

--- a/libs/core/sim/analogSensor.ts
+++ b/libs/core/sim/analogSensor.ts
@@ -1,0 +1,81 @@
+namespace pxsim {
+    enum ThresholdState {
+        High,
+        Low,
+        Normal
+    }
+
+    export class AnalogSensorState {
+        public sensorUsed: boolean = false;
+
+        private level: number;
+        private state = ThresholdState.Normal;
+
+        constructor(public id: number, private min = 0, private max = 255, private lowThreshold = 64, private highThreshold = 192) {
+            this.level = Math.ceil((max - min) / 2);
+        }
+
+        public setUsed() {
+            if (!this.sensorUsed) {
+                this.sensorUsed = true;
+                runtime.queueDisplayUpdate();
+            }
+        }
+
+        public setLevel(level: number) {
+            this.level = this.clampValue(level);
+
+            if (this.level >= this.highThreshold) {
+                this.setState(ThresholdState.High);
+            }
+            else if (this.level <= this.lowThreshold) {
+                this.setState(ThresholdState.Low);
+            }
+            else {
+                this.setState(ThresholdState.Normal);
+            }
+        }
+
+        public getLevel(): number {
+            return this.level;
+        }
+
+        public setLowThreshold(value: number) {
+            this.lowThreshold = this.clampValue(value);
+            this.highThreshold = Math.max(this.lowThreshold + 1, this.highThreshold);
+        }
+
+        public setHighThreshold(value: number) {
+            this.highThreshold = this.clampValue(value);
+            this.lowThreshold = Math.min(this.highThreshold - 1, this.lowThreshold);
+        }
+
+        private clampValue(value: number) {
+            if (value < this.min) {
+                return this.min;
+            }
+            else if (value > this.max) {
+                return this.max;
+            }
+            return value;
+        }
+
+        private setState(state: ThresholdState) {
+            if (this.state === state) {
+                return;
+            }
+
+            this.state = state;
+            switch (state) {
+                case ThresholdState.High:
+                    board().bus.queue(this.id, DAL.ANALOG_THRESHOLD_HIGH);
+                    break;
+                case ThresholdState.Low:
+                    board().bus.queue(this.id, DAL.ANALOG_THRESHOLD_LOW);
+                    break;
+                case ThresholdState.Normal:
+                    break;
+            }
+        }
+    }
+}

--- a/libs/core/sim/buttons.ts
+++ b/libs/core/sim/buttons.ts
@@ -1,0 +1,95 @@
+/// <reference path="../dal.d.ts"/>
+
+namespace pxsim {
+    const DOUBLE_CLICK_TIME = 500;
+    export class CommonButton extends Button {
+        private _pressedTime: number = -1;
+        private _clickedTime: number = -1;
+        private _wasPressed: boolean;
+
+        setPressed(p: boolean) {
+            if (this.pressed === p) {
+                return;
+            }
+            this.pressed = p;
+
+            if (p) {
+                this._wasPressed = true;
+                board().bus.queue(this.id, DAL.DEVICE_BUTTON_EVT_DOWN);
+                this._pressedTime = runtime.runningTime();
+            }
+            else if (this._pressedTime !== -1) {
+                board().bus.queue(this.id, DAL.DEVICE_BUTTON_EVT_UP);
+                const current = runtime.runningTime();
+
+                if (current - this._pressedTime >= DAL.DEVICE_BUTTON_LONG_CLICK_TIME) {
+                    board().bus.queue(this.id, DAL.DEVICE_BUTTON_EVT_LONG_CLICK);
+                }
+                else {
+                    board().bus.queue(this.id, DAL.DEVICE_BUTTON_EVT_CLICK);
+                }
+
+
+                if (this._clickedTime !== -1) {
+                    if (current - this._clickedTime <= DOUBLE_CLICK_TIME) {
+                        board().bus.queue(this.id, DAL.DEVICE_BUTTON_EVT_DOUBLE_CLICK);
+                    }
+                }
+
+                this._clickedTime = current;
+            }
+
+        }
+
+        public wasPressed() {
+            const temp = this._wasPressed;
+            this._wasPressed = false;
+            return temp;
+        }
+
+        public isPressed() {
+            return this.pressed;
+        }
+    }
+
+    export class CommonButtonState {
+        usesButtonAB: boolean = false;
+        buttons: CommonButton[];
+
+        constructor() {
+            this.buttons = [
+                new CommonButton(DAL.DEVICE_ID_BUTTON_A),
+                new CommonButton(DAL.DEVICE_ID_BUTTON_B),
+                new CommonButton(DAL.DEVICE_ID_BUTTON_AB)
+            ];
+        }
+    }
+}
+namespace pxsim.pxtcore {
+    export function getButton(buttonId: number): Button {
+        const buttons = board().buttonState.buttons;
+        if (buttonId === 2) {
+            board().buttonState.usesButtonAB = true;
+            runtime.queueDisplayUpdate();
+        }
+        if (buttonId < buttons.length && buttonId >= 0) {
+            return buttons[buttonId];
+        }
+        // panic
+        return undefined;
+    }
+}
+
+namespace pxsim.ButtonMethods {
+    export function onEvent(button: pxsim.Button, ev: number, body: pxsim.RefAction): void {
+        pxsim.pxtcore.registerWithDal(button.id, ev, body);
+    }
+
+    export function isPressed(button: pxsim.Button): boolean {
+        return button.pressed;
+    }
+
+    export function wasPressed(button: pxsim.Button): boolean {
+        return (<CommonButton>button).wasPressed();
+    }
+}

--- a/libs/core/sim/control.ts
+++ b/libs/core/sim/control.ts
@@ -1,0 +1,52 @@
+namespace pxsim.control {
+    export var runInBackground = thread.runInBackground;
+    export var delay = thread.pause;
+
+    export function reset() {
+        U.userError("reset not implemented in simulator yet")
+    }
+    export function waitMicros(micros: number) {
+        thread.pause(micros / 1000); // it prempts not much we can do here.
+    }
+    export function deviceName(): string {
+        let b = board();
+        return b && b.id
+            ? b.id.slice(0, 4)
+            : "abcd";
+    }
+    export function deviceSerialNumber(): number {
+        let b = board();
+        return parseInt(b && b.id
+            ? b.id.slice(1)
+            : "42");
+    }
+    export function deviceDalVersion(): string {
+        return "0.0.0";
+    }
+    export function onEvent(id: number, evid: number, handler: RefAction) {
+        pxtcore.registerWithDal(id, evid, handler)
+    }
+
+    export function waitForEvent(id: number, evid: number) {
+        const cb = getResume();
+        board().bus.wait(id, evid, cb);
+    }
+
+    export function allocateNotifyEvent() : number {
+        let b = board();
+        return b.bus.nextNotifyEvent++;
+    }
+
+    export function raiseEvent(id: number, evid: number, mode: number) {
+        // TODO mode?
+        board().bus.queue(id, evid)
+    }
+
+    export function millis(): number {
+        return runtime.runningTime();
+    }
+
+    export function delayMicroseconds(us: number) {
+        delay(us / 0.001);
+    }
+}

--- a/libs/core/sim/core.ts
+++ b/libs/core/sim/core.ts
@@ -1,0 +1,23 @@
+/// <reference path="../../../node_modules/pxt-core/built/pxtsim.d.ts" />
+
+namespace pxsim {
+    export interface CommonBoard extends CoreBoard {
+        id: string;
+        buttonState: CommonButtonState;
+        edgeConnectorState: EdgeConnectorState;
+    }
+
+    export function board(): CommonBoard {
+        return runtime.board as CommonBoard;
+    }
+}
+
+
+namespace pxsim.pxtcore {
+    export function registerWithDal(id: number, evid: number, handler: RefAction) {
+        board().bus.listen(id, evid, handler);
+    }
+    export function getPin(id: number) : pxsim.Pin {
+        return board().edgeConnectorState.getPin(id);
+    }
+}

--- a/libs/core/sim/loops.ts
+++ b/libs/core/sim/loops.ts
@@ -1,0 +1,4 @@
+namespace pxsim.loops {
+    export var pause = thread.pause;
+    export var forever = thread.forever;
+}

--- a/libs/core/sim/pins.ts
+++ b/libs/core/sim/pins.ts
@@ -1,0 +1,177 @@
+
+namespace pxsim.pins {
+    export class CommonPin extends Pin {
+        used: boolean;
+    }
+
+    export class DigitalPin extends CommonPin {
+    }
+
+    export class AnalogPin extends CommonPin {
+
+    }
+
+    export function markUsed(name: CommonPin) {
+        if (!name.used) {
+            name.used = true;
+            runtime.queueDisplayUpdate();
+        }
+    }
+}
+
+namespace pxsim.DigitalPinMethods {
+    export function digitalRead(name: pins.DigitalPin): number {
+        return name.digitalReadPin();
+    }
+
+    /**
+    * Set a pin or connector value to either 0 or 1.
+    * @param value value to set on the pin, 1 eg,0
+    */
+    export function digitalWrite(name: pins.DigitalPin, value: number): void {
+        name.digitalWritePin(value);
+    }
+
+    /**
+    * Configures this pin to a digital input, and generates events where the timestamp is the duration
+    * that this pin was either ``high`` or ``low``.
+    */
+    export function onPulsed(name: pins.DigitalPin, pulse: number, body: RefAction): void {
+        // TODO
+    }
+
+    /**
+    * Returns the duration of a pulse in microseconds
+    * @param value the value of the pulse (default high)
+    * @param maximum duration in micro-seconds
+    */
+    export function pulseIn(name: pins.DigitalPin, pulse: number, maxDuration = 2000000): number {
+        // TODO
+        return 500;
+    }
+
+    /**
+    * Configures the pull of this pin.
+    * @param pull one of the mbed pull configurations: PullUp, PullDown, PullNone
+    */
+    export function setPull(name: pins.DigitalPin, pull: number): void {
+        name.setPull(pull);
+    }
+
+    /**
+    * Do something when a pin is pressed.
+    * @param body the code to run when the pin is pressed
+    */
+    export function onPressed(name: pins.DigitalPin, body: RefAction): void {
+    }
+
+    /**
+     * Do something when a pin is released.
+     * @param body the code to run when the pin is released
+     */
+    export function onReleased(name: pins.DigitalPin, body: RefAction): void {
+    }
+
+    /**
+     * Get the pin state (pressed or not). Requires to hold the ground to close the circuit.
+     * @param name pin used to detect the touch
+     */
+    export function isPressed(name: pins.DigitalPin): boolean {
+        return name.isTouched();
+    }
+}
+
+namespace pxsim.AnalogPinMethods {
+    /**
+     * Read the connector value as analog, that is, as a value comprised between 0 and 1023.
+     */
+    export function analogRead(name: pins.AnalogPin): number {
+        pins.markUsed(name);
+        return name.analogReadPin();
+    }
+
+    /**
+     * Set the connector value as analog. Value must be comprised between 0 and 1023.
+     * @param value value to write to the pin between ``0`` and ``1023``. eg:1023,0
+     */
+    export function analogWrite(name: pins.AnalogPin, value: number): void {
+        pins.markUsed(name);
+        name.analogWritePin(value);
+
+    }
+
+    /**
+     * Configures the Pulse-width modulation (PWM) of the analog output to the given value in
+     * **microseconds** or `1/1000` milliseconds.
+     * If this pin is not configured as an analog output (using `analog write pin`), the operation has
+     * no effect.
+     * @param micros period in micro seconds. eg:20000
+     */
+    export function analogSetPeriod(name: pins.AnalogPin, micros: number): void {
+        pins.markUsed(name);
+        name.analogSetPeriod(micros);
+    }
+
+    /**
+     * Writes a value to the servo, controlling the shaft accordingly. On a standard servo, this will
+     * set the angle of the shaft (in degrees), moving the shaft to that orientation. On a continuous
+     * rotation servo, this will set the speed of the servo (with ``0`` being full-speed in one
+     * direction, ``180`` being full speed in the other, and a value near ``90`` being no movement).
+     * @param value angle or rotation speed, eg:180,90,0
+     */
+    export function servoWrite(name: pins.AnalogPin, value: number): void {
+        pins.markUsed(name);
+        name.servoWritePin(value);
+    }
+
+    /**
+     * Configures this IO pin as an analog/pwm output, configures the period to be 20 ms, and sets the
+     * pulse width, based on the value it is given **microseconds** or `1/1000` milliseconds.
+     * @param micros pulse duration in micro seconds, eg:1500
+     */
+    export function servoSetPulse(name: pins.AnalogPin, micros: number): void {
+        pins.markUsed(name);
+        // TODO fix pxt
+        // name.servoSetPulse(micros);
+    }
+}
+
+namespace pxsim.PwmPinMethods {
+    export function analogSetPeriod(name: pins.AnalogPin, micros: number): void {
+        name.analogSetPeriod(micros);
+    }
+
+    export function servoWrite(name: pins.AnalogPin, value: number): void {
+        name.servoWritePin(value);
+    }
+
+    export function servoSetPulse(name: pins.AnalogPin, micros: number): void {
+        name.servoSetPulse(name.id, micros);
+    }
+}
+
+namespace pxsim.pins {
+    export function pulseDuration(): number {
+        // bus last event timestamp
+        return 500;
+    }
+
+    export function createBuffer(sz: number) {
+        return pxsim.BufferMethods.createBuffer(sz)
+    }
+
+    export function spiWrite(value: number): number {
+        // TODO
+        return 0;
+    }
+
+    export function i2cReadBuffer(address: number, size: number, repeat?: boolean): RefBuffer {
+        // fake reading zeros
+        return createBuffer(size)
+    }
+
+    export function i2cWriteBuffer(address: number, buf: RefBuffer, repeat?: boolean): void {
+        // fake - noop
+    }
+}
+

--- a/libs/core/sim/serial.ts
+++ b/libs/core/sim/serial.ts
@@ -1,0 +1,18 @@
+namespace pxsim.serial {
+    export function writeLine(line: string) {
+        writeString(line + "\n");
+    }
+
+    export function writeString(str: string) {
+        console.log(str);
+        runtime.board.writeSerial(str);
+    }
+
+    export function writeNumber(num: number) {
+        writeString(num.toString());
+    }
+
+    export function writeValue(name: string, value: number) {
+        writeString(name + ": " + value);
+    }
+}

--- a/libs/light/sim/neopixel.ts
+++ b/libs/light/sim/neopixel.ts
@@ -1,0 +1,141 @@
+
+namespace pxsim {
+    export class CommonNeoPixelState {
+        public NUM_PIXELS = 10;
+        private neopixels: [number, number, number][] = [];
+        private CPLAY_NEOPIXELPIN = 17;
+        private brightness: number = 20;
+
+        public setPixelColor(pixel: number, red: number, green: number, blue: number) {
+            this.neopixels[pixel] = [red, green, blue];
+        }
+
+        public setBrightness(brightness: number) {
+            this.brightness = brightness;
+        }
+
+        public getBrightness(): number{
+            return this.brightness;
+        }
+
+        public getNeoPixels(): [number, number, number][] {
+            return this.neopixels;
+        }
+
+        public rotate(offset: number = 1, reverse?: boolean) {
+            for (let i = 0; i < offset; i++) {
+                if(reverse)
+                    this.neopixels.unshift(this.neopixels.pop());
+                else
+                    this.neopixels.push(this.neopixels.shift());
+            }
+        }
+
+        public clearPixels() {
+            this.neopixels = [];
+        }
+    }
+}
+
+namespace pxsim.light {
+    // Currently only modifies the builtin pixels
+    export function sendBuffer(pin: pins.DigitalPin, b: RefBuffer) {
+        const state = neopixelState();
+        const stride = 3;
+        const numberOfPixels = b.data.length / stride;
+
+        for (let i = 0; i < numberOfPixels; i++) {
+            const offset = stride * i;
+
+            const green = b.data[offset];
+            const red = b.data[offset + 1];
+            const blue = b.data[offset + 2];
+
+            state.setPixelColor(i, red, green, blue);
+        }
+
+        runtime.updateDisplay();
+    }
+
+    export function defaultPin() {
+        return (board() as LightBoard).defaultNeopixelPin();
+    }
+}
+
+namespace pxsim.light {
+
+    function setPixelColor(pixel: number, rgb: number) {
+        let state = neopixelState();
+        if (pixel < 0
+            || pixel >= state.NUM_PIXELS)
+            return;
+        state.setPixelColor(pixel, unpackR(rgb), unpackG(rgb), unpackB(rgb));
+        runtime.queueDisplayUpdate()
+    }
+
+    export function setPixelColorWheel(pixel: number, WheelPos: number) {
+        setPixelColor(pixel,colorWheel(WheelPos))
+    }
+
+    export function setPixelColorRgb(pixel: number, red: number, green: number, blue: number) {
+        let state = neopixelState();
+        if (pixel < 0
+            || pixel >= state.NUM_PIXELS)
+            return;
+        state.setPixelColor(pixel, red, green, blue);
+        runtime.queueDisplayUpdate()
+    }
+
+    export function setStripPixelColorRgb(pixel: number, red: number, green: number, blue: number) {
+        setPixelColorRgb(pixel, red, green, blue);
+    }
+
+    export function showStrip() {
+        runtime.queueDisplayUpdate()
+    }
+
+    export function clearPixels() {
+        let state = neopixelState();
+        state.clearPixels();
+        runtime.queueDisplayUpdate()
+    }
+
+    export function rotate(offset: number = 1, reverse?: boolean) {
+        let state = neopixelState();
+        state.rotate(offset, reverse);
+        runtime.queueDisplayUpdate()
+    }
+
+    function colorWheel(WheelPos: number): number {
+        WheelPos = 255 - WheelPos;
+        if (WheelPos < 85) {
+            return packRGB(255 - WheelPos * 3, 0, WheelPos * 3);
+        }
+        if (WheelPos < 170) {
+            WheelPos -= 85;
+            return packRGB(0, WheelPos * 3, 255 - WheelPos * 3);
+        }
+        WheelPos -= 170;
+        return packRGB(WheelPos * 3, 255 - WheelPos * 3, 0);
+    }
+
+    function rgb(r: number, g: number, b: number): number {
+        return packRGB(r, g, b);
+    }
+
+    function packRGB(a: number, b: number, c: number): number {
+        return ((a & 0xFF) << 16) | ((b & 0xFF) << 8) | (c & 0xFF);
+    }
+    function unpackR(rgb: number): number {
+        let r = (rgb >> 16) & 0xFF;
+        return r;
+    }
+    function unpackG(rgb: number): number {
+        let g = (rgb >> 8) & 0xFF;
+        return g;
+    }
+    function unpackB(rgb: number): number {
+        let b = (rgb) & 0xFF;
+        return b;
+    }
+}

--- a/libs/light/sim/state.ts
+++ b/libs/light/sim/state.ts
@@ -1,0 +1,11 @@
+namespace pxsim {
+    export interface LightBoard extends CommonBoard {
+        neopixelState: CommonNeoPixelState;
+
+        defaultNeopixelPin(): Pin;
+    }
+
+    export function neopixelState() {
+        return (board() as LightBoard).neopixelState;
+    }
+}

--- a/libs/lightsensor/sim/lightsensor.ts
+++ b/libs/lightsensor/sim/lightsensor.ts
@@ -1,0 +1,15 @@
+namespace pxsim.input {
+    export function lightLevel(): number {
+        let b = lightSensorState();
+        b.setUsed();
+
+        return b.getLevel();
+    }
+
+    export function onLightConditionChanged(condition: number, body: RefAction) {
+        let b = lightSensorState();
+        b.setUsed();
+
+        pxtcore.registerWithDal(b.id, condition, body);
+    }
+}

--- a/libs/lightsensor/sim/state.ts
+++ b/libs/lightsensor/sim/state.ts
@@ -1,0 +1,9 @@
+namespace pxsim {
+    export interface LightSensorBoard extends CommonBoard {
+        lightSensorState: AnalogSensorState;
+    }
+
+    export function lightSensorState() {
+        return (board() as LightSensorBoard).lightSensorState;
+    }
+}

--- a/libs/microphone/sim/microphone.ts
+++ b/libs/microphone/sim/microphone.ts
@@ -1,0 +1,13 @@
+namespace pxsim.input {
+    export function soundLevel(): number {
+        let b = microphoneState();
+        b.setUsed();
+        return b.getLevel();
+    }
+
+    export function onLoudSound(body: RefAction) {
+        let b = microphoneState();
+        b.setUsed();
+        pxtcore.registerWithDal(b.id, DAL.LEVEL_THRESHOLD_HIGH, body);
+    }
+}

--- a/libs/microphone/sim/state.ts
+++ b/libs/microphone/sim/state.ts
@@ -1,0 +1,9 @@
+namespace pxsim {
+    export interface MicrophoneBoard extends CommonBoard {
+        microphoneState: AnalogSensorState;
+    }
+
+    export function microphoneState() {
+        return (board() as MicrophoneBoard).microphoneState;
+    }
+}

--- a/libs/music/sim/music.ts
+++ b/libs/music/sim/music.ts
@@ -1,0 +1,80 @@
+namespace pxsim {
+
+    export class AudioState {
+        private playing: boolean;
+        public outputDestination_ = 0;
+        public pitchPin_: Pin;
+        public volume = 100;
+        constructor() {
+            this.playing = false;
+        }
+
+        startPlaying() {
+            this.playing = true;
+        }
+        stopPlaying() {
+            this.playing = false;
+        }
+        isPlaying() {
+            return this.playing;
+        }
+    }
+}
+
+namespace pxsim.music {
+
+    export function noteFrequency(note: number) {
+        return note;
+    }
+
+    export function setOutput(mode: number) {
+        const audioState = getAudioState();
+        audioState.outputDestination_ = mode;
+    }
+
+    export function setVolume(volume: number) {
+        const audioState = getAudioState();
+        audioState.volume = Math.max(0, 1024, volume * 4);
+    }
+
+    export function setPitchPin(pin: Pin) {
+        const audioState = getAudioState();
+        audioState.pitchPin_ = pin;
+    }
+
+    export function setTone(buffer: RefBuffer) {
+        // TODO
+    }
+
+    export function playTone(frequency: number, ms: number) {
+        const b = board();
+        if (!b) return;
+
+        const audioState = getAudioState();
+
+        const currentOutput = audioState.outputDestination_;
+
+        audioState.startPlaying();
+        runtime.queueDisplayUpdate();
+        AudioContextManager.tone(frequency, 1);
+        let cb = getResume();
+        if (ms <= 0) cb();
+        else {
+            setTimeout(() => {
+                AudioContextManager.stop();
+                audioState.stopPlaying();
+
+                runtime.queueDisplayUpdate();
+                cb()
+            }, ms);
+        }
+    }
+
+    function getPitchPin() {
+        const audioState = getAudioState();
+        if (!audioState.pitchPin_) {
+            audioState.pitchPin_ = (board() as MusicBoard).getDefaultPitchPin();
+        }
+        return audioState.pitchPin_;
+    }
+}

--- a/libs/music/sim/state.ts
+++ b/libs/music/sim/state.ts
@@ -1,0 +1,11 @@
+namespace pxsim {
+    export interface MusicBoard extends CommonBoard {
+        audioState: AudioState;
+
+        getDefaultPitchPin(): Pin;
+    }
+
+    export function getAudioState() {
+        return (board() as MusicBoard).audioState;
+    }
+}

--- a/libs/switch/sim/state.ts
+++ b/libs/switch/sim/state.ts
@@ -1,0 +1,5 @@
+namespace pxsim {
+    export interface SlideSwitchBoard extends CommonBoard {
+        slideSwitchState: SlideSwitchState;
+    }
+}

--- a/libs/switch/sim/switch.ts
+++ b/libs/switch/sim/switch.ts
@@ -1,0 +1,34 @@
+namespace pxsim {
+    export class SlideSwitchState {
+        public static id = 3000 /*DEVICE_ID_BUTTON_SLIDE*/;
+        private left: boolean = false;
+
+        setState(left: boolean) {
+            if (this.left === left) {
+                return;
+            }
+            else if (left) {
+                board().bus.queue(SlideSwitchState.id, DAL.DEVICE_BUTTON_EVT_UP);
+            }
+            else {
+                board().bus.queue(SlideSwitchState.id, DAL.DEVICE_BUTTON_EVT_DOWN);
+            }
+            this.left = left;
+        }
+
+        isLeft(): boolean {
+            return this.left;
+        }
+    }
+}
+
+namespace pxsim.input {
+    export function onSwitchMoved(direction: number, body: RefAction) {
+        pxtcore.registerWithDal(SlideSwitchState.id, direction, body);
+
+        const b = board() as SlideSwitchBoard;
+        const sw = b.slideSwitchState;
+        if (sw.isLeft() == (direction == DAL.DEVICE_BUTTON_EVT_UP))
+            b.bus.queue(SlideSwitchState.id, direction);
+    }
+}

--- a/libs/temperature/sim/state.ts
+++ b/libs/temperature/sim/state.ts
@@ -1,0 +1,14 @@
+namespace pxsim {
+    export interface TemperatureBoard extends CommonBoard {
+        thermometerState: AnalogSensorState;
+        thermometerUnitState: ThermometerUnit;
+    }
+
+    export function thermometerState(): AnalogSensorState {
+        return (board() as TemperatureBoard).thermometerState;
+    }
+
+    export function setThermometerUnit(unit: ThermometerUnit) {
+        (board() as TemperatureBoard).thermometerUnitState = unit;
+    }
+}

--- a/libs/temperature/sim/temperature.ts
+++ b/libs/temperature/sim/temperature.ts
@@ -1,0 +1,31 @@
+namespace pxsim {
+    export enum ThermometerUnit {
+        Celsius,
+        Fahrenheit
+    }
+}
+
+namespace pxsim.input {
+
+    export function temperature(unit: number): number {
+        let b = thermometerState();
+        b.setUsed();
+        setThermometerUnit(unit);
+        return b.getLevel();
+    }
+
+    export function onTemperateConditionChanged(condition: number, temperature: number, body: RefAction) {
+        let b = thermometerState();
+        b.setUsed();
+        setThermometerUnit(pxsim.ThermometerUnit.Celsius);
+
+        if (condition === DAL.ANALOG_THRESHOLD_HIGH) {
+            b.setHighThreshold(temperature);
+        }
+        else {
+            b.setLowThreshold(temperature);
+        }
+
+        pxtcore.registerWithDal(b.id, condition, body);
+    }
+}

--- a/libs/touch/sim/touch.ts
+++ b/libs/touch/sim/touch.ts
@@ -1,0 +1,59 @@
+namespace pxsim {
+    export class CapacitiveSensorState {
+        capacity: number[] = [];
+        reading: boolean[] = [];
+        mapping: Map<number>;
+
+        constructor(mapping: Map<number>) {
+            this.mapping = mapping;
+        }
+
+        private getCap(pinId: number): number {
+            return this.mapping[pinId];
+        }
+
+        readCap(pinId: number, samples: number): number {
+            let capId = this.getCap(pinId);
+            return this.capacitiveSensor(capId, samples);
+        }
+
+        isReadingPin(pinId: number, pin: Pin) {
+            let capId = this.getCap(pinId);
+            return this.reading[capId];
+        }
+
+        isReading(capId: number) {
+            return this.reading[capId];
+        }
+
+        startReading(pinId: number, pin: Pin) {
+            let capId = this.getCap(pinId);
+            this.reading[capId] = true;
+            pin.mode = PinFlags.Analog | PinFlags.Input;
+            pin.mode |= PinFlags.Analog;
+        }
+
+        capacitiveSensor(capId: number, samples: number): number {
+            return this.capacity[capId] || 0;
+        }
+
+        reset(capId: number): void {
+            this.capacity[capId] = 0;
+            this.reading[capId] = false;
+        }
+    }
+}
+
+namespace pxsim.pxtcore {
+    export function getTouchButton(buttonId: number): Button {
+        // const state = board().buttonState;
+        // if (buttonId < state.touchButtons.length && buttonId >= 0) {
+        //     const pin = board().edgeConnectorState.getPin(state.touchPins[buttonId]) as pins.CPPin;
+        //     pin.mode |= PinFlags.Analog;
+        //     pins.markUsed(pin);
+        //     return state.touchButtons[buttonId];
+        // }
+        // panic
+        return undefined;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,38 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "out": "built/common-sim.js",
+        "rootDir": ".",
+        "newLine": "LF",
+        "declaration": true,
+        "sourceMap": false
+    },
+    "files": [
+        "libs/accelerometer/sim/accelerometer.ts",
+        "libs/accelerometer/sim/state.ts",
+        "libs/core/sim/analogSensor.ts",
+        "libs/core/dal.d.ts",
+        "libs/core/sim/buttons.ts",
+        "libs/core/sim/control.ts",
+        "libs/core/sim/core.ts",
+        "libs/core/sim/loops.ts",
+        "libs/core/sim/pins.ts",
+        "libs/core/sim/serial.ts",
+        "libs/light/sim/neopixel.ts",
+        "libs/light/sim/state.ts",
+        "libs/lightsensor/sim/lightsensor.ts",
+        "libs/lightsensor/sim/state.ts",
+        "libs/microphone/sim/microphone.ts",
+        "libs/microphone/sim/state.ts",
+        "libs/music/sim/music.ts",
+        "libs/music/sim/state.ts",
+        "libs/switch/sim/state.ts",
+        "libs/switch/sim/switch.ts",
+        "libs/temperature/sim/state.ts",
+        "libs/temperature/sim/temperature.ts",
+        "libs/touch/sim/touch.ts"
+    ]
+}
+


### PR DESCRIPTION
Each package now has a `sims` folder that exports an interface for the simulator to implement. In the root of this repo I've added a `tsconfig.json` that builds all the sim folders together into one file called `common-sim.js`. I'll be opening a PR in pxt-core that builds that file as part of the target build and copies it into the target's `built` directory.