### PR TITLE
Update the serial docs.

### DIFF
--- a/libs/core/docs/reference/serial.md
+++ b/libs/core/docs/reference/serial.md
@@ -9,16 +9,16 @@ serial.writeValue("x", 0);
 serial.writeString("");
 ```
 
-### Advanced
+## Advanced
 
 ```cards
-serial.writeBuffer(pins.createBuffer(0));
+serial.writeBuffer(null);
 ```
 
-### See Also
+## See Also
 
-[serial write line](/reference/serial/write-line)
-,[serial write string](/reference/serial/write-string)
-,[serial write number](/reference/serial/write-number)
-,[serial write value](/reference/serial/write-value)
-,[serial write buffer](/reference/serial/write-buffer)
+[``||write line||``](/reference/serial/write-line),
+[``||write string||``](/reference/serial/write-string),
+[``||write number||``](/reference/serial/write-number),
+[``||write value||``](/reference/serial/write-value),
+[``||write buffer||``](/reference/serial/write-buffer)

--- a/libs/core/docs/reference/serial/write-buffer.md
+++ b/libs/core/docs/reference/serial/write-buffer.md
@@ -1,18 +1,31 @@
-# Serial Write Buffer
+# write Buffer
 
-Write a buffer to the Serial communication port.
+Write a buffer to the serial communication port.
 
 ```sig
 serial.writeBuffer(pins.createBuffer(0));
 ```
+Information in a buffer is sent out the serial port with ``||write buffer||``. This is used
+when you want to send information that is more complex and not just simple text or a number.
 
-### Parameters
+## Parameters
 
-* `buffer` is the buffer to write to the serial port
+* **buffer**: the buffer to write to the serial port
 
-### #examples
+## Example
 
-### See also
+Set some special data values in a buffer and send the buffer across the serial connection.
 
-[serial write line](/reference/serial/write-line),
-[serial write number](/reference/serial/write-number)
+```blocks
+let sdv = pins.createBuffer(4)
+sdv.setNumber(NumberFormat.Int8LE, 0, 53)
+sdv.setNumber(NumberFormat.Int8LE, 1, 141)
+sdv.setNumber(NumberFormat.Int8LE, 2, 9)
+sdv.setNumber(NumberFormat.Int8LE, 3, 87)
+serial.writeBuffer(sdv);
+```
+
+## See also
+
+[``||write line||``](/reference/serial/write-line),
+[``||write number||``](/reference/serial/write-number)

--- a/libs/core/docs/reference/serial/write-line.md
+++ b/libs/core/docs/reference/serial/write-line.md
@@ -1,31 +1,36 @@
-# Serial Write Line
+# write Line
 
-Write a string to the Serial port and start a new line of text
-by writing `\r\n`.
+Write a line of text to the serial port.
 
 ```sig
 serial.writeLine("");
 ```
 
-### Parameters
+A line is a text string that has two special characters added at the end: _carriage return_
+and _line feed_. These characters are really just codes that mean start a new line.
+Sometimes they appear in code as ``"\r\n"``. 
 
-* `text` is the [string](/types/string) to write to the serial port
+After using a ``||write line||``, any new text written to the serial port will begin on a new line.
 
-### Example: simple serial
+With ``||write line||``, the new line characters are automatically added for you. You only need to 
+give the text you want to write.
 
-This program writes the word `BOFFO` to the serial port repeatedly.
+## Parameters
+
+* **text**: the [string](/types/string) to write to the serial port
+
+## Example
+
+Write two greeting messages to the serial port.
 
 ```blocks
-loops.forever(() => {
-    serial.writeLine("BOFFO");
-    control.pause(5000);
-});
+serial.writeLine("How are you today?");
+loops.pause(5000);
+serial.writeLine("Well that's great! I'm doing well too.");
 ```
 
-### #examples
+## See also
 
-### See also
-
-[serial write number](/reference/serial/write-number),
-[serial write string](/reference/serial/write-string),
-[serial write value](/reference/serial/write-value)
+[``||write number||``](/reference/serial/write-number),
+[``||write string||``](/reference/serial/write-string),
+[``||write value||``](/reference/serial/write-value)

--- a/libs/core/docs/reference/serial/write-number.md
+++ b/libs/core/docs/reference/serial/write-number.md
@@ -1,30 +1,32 @@
-# Serial Write Number
+# write Number
 
-Write a number to the Serial port.
+Write a number to the serial port.
 
 ```sig
 serial.writeNumber(0);
 ```
+The number you send is turned into a string before it's sent. So, a value like ``1023``
+is a the four character string of ``"1023"`` when it's sent across the serial
+connection. The number is written as part of the current line and a new line isn't
+started when it's finished.
 
-### Parameters
+## Parameters
 
-* `value` is the [number](/types/number) to write to the serial port
+* **value**: the [number](/types/number) to write to the serial port
 
-### Example: one through ten
+## Example
 
-This program repeatedly writes a 10-digit number to the serial port.
+Write a 10-digit number to the serial port many, many times.
 
 ```blocks
 loops.forever(() => {
     serial.writeNumber(1234567890);
-    control.pause(5000);
+    loops.pause(5000);
 });
 ```
 
-### #examples
+## See also
 
-### See also
-
-[serial write line](/reference/serial/write-line),
-[serial write value](/reference/serial/write-value)
+[``||write line||``](/reference/serial/write-line),
+[``||write value||``](/reference/serial/write-value)
 

--- a/libs/core/docs/reference/serial/write-string.md
+++ b/libs/core/docs/reference/serial/write-string.md
@@ -1,29 +1,31 @@
-# Serial Write String
+# write String
 
-Write a string to the Serial port, without starting a new line afterward.
+Write a string to the serial port but don't start a new line.
 
 ```sig
 serial.writeString("");
 ```
+Just the text of the string is written to the serial port. The next time text is written,
+it will be on the same line that this text is on. The text is written without making
+a new line.
 
-### Parameters
+## Parameters
 
-* `text` is the [string](/types/string) to write to the serial port
+* **text**: the [string](/types/string) to write to the serial port
 
-### Example: simple serial
+## Example
 
-This program writes the word `JUMBO` to the serial port repeatedly,
-without any new lines.
+Writes the word `JUMBO` to the serial port a bunch of times, without any new lines.
 
 ```blocks
 loops.forever(() => {
     serial.writeString("JUMBO");
-    control.pause(1000);
+    loops.pause(1000);
 });
 ```
 
-### See also
+## See also
 
-[serial write line](/reference/serial/write-line),
-[serial write number](/reference/serial/write-number),
-[serial write value](/reference/serial/write-value)
+[``||write line||``](/reference/serial/write-line),
+[``||write number||``](/reference/serial/write-number),
+[``||write value||``](/reference/serial/write-value)

--- a/libs/core/docs/reference/serial/write-value.md
+++ b/libs/core/docs/reference/serial/write-value.md
@@ -1,20 +1,40 @@
-# Write Value
+# write Value
 
-Write a name/value pair and a newline character (`\r\n`) to the Serial port.
+Write a **name:value** pair as a line of text to the serial port.
 
 ```sig
 serial.writeValue("x", 0);
 ```
 
-### Parameters
+A **name:value** pair is a string that has both a name for a value and the value
+itself. If you want to send a temperature value of 32 degrees as a _name:value_ pair,
+it would go to the serial port as this: "temperature:32". This is a good way to
+connect a number value to it's meaning.
 
-* `name` is the [string](/types/string) to write to the serial port
-* `value` is the [number](/types/number) to write to the serial port
+So, ``||write value||`` does this but you give the name and the value as two parts and it
+sends it as a pair.
 
-### #examples
+## Parameters
 
-### See also
+* **name**: a [string](/types/string) that is the name part of the _name:value_ pair
+* **value**: a [number](/types/number) that is the value part of the _name:value_ pair 
 
-[serial write line](/reference/serial/write-line),
-[serial write number](/reference/serial/write-number)
+## Example
+
+Send _name:value_ pairs for odd and even numbers to the serial port.
+
+```blocks
+for (let i = 0; i < 10; i++) {
+    if (i % 2 > 0) {
+        serial.writeValue("odd", i)
+    } else {
+        serial.writeValue("even", i)
+    }
+}
+```
+
+## See also
+
+[``||write line||``](/reference/serial/write-line),
+[``||write number||``](/reference/serial/write-number)
 

--- a/libs/core/serial.cpp
+++ b/libs/core/serial.cpp
@@ -6,7 +6,7 @@ namespace serial {
     // note that at least one // followed by % is needed per declaration!
 
     /**
-     * Sends a piece of text through Serial connection.
+     * Write some text to the serial port.
      */
     //% help=serial/write-string
     //% weight=87
@@ -16,9 +16,10 @@ namespace serial {
     }
 
     /**
-    * Sends a buffer through Serial connection
+    * Send a buffer across the serial connection.
     */
     //% help=serial/write-buffer advanced=true weight=6
+    //% blockId=serial_writebuffer block="serial|write buffer %buffer"
     void writeBuffer(Buffer buffer) {
       if (!buffer) return;
 

--- a/libs/core/serial.ts
+++ b/libs/core/serial.ts
@@ -5,7 +5,7 @@
 //% advanced=true
 namespace serial {
     /**
-     * Prints a line of text to the serial
+     * Write a line of text to the serial port.
      * @param value to send over serial
      */
     //% weight=90
@@ -16,7 +16,7 @@ namespace serial {
     }
 
     /**
-     * Prints a numeric value to the serial
+     * Write a number to the serial port.
      */
     //% help=serial/write-number
     //% weight=89 blockGap=8
@@ -26,7 +26,7 @@ namespace serial {
     }
 
     /**
-     * Writes a ``name: value`` pair line to the serial.
+     * Write a name:value pair as a line of text to the serial port.
      * @param name name of the value stream, eg: x
      * @param value to write
      */


### PR DESCRIPTION
These are fairly simple. I suppose we could add a description of serial communications and terminals and such but do we want to go there?

Also, **writeBuffer** is and was in _advanced_. It uses Buffer which is not documented yet. We can keep it in advanced or select it out in and entends doc.