### PR TITLE
Bootloader v1.23 compat

### DIFF
--- a/libs/core/hf2.cpp
+++ b/libs/core/hf2.cpp
@@ -8,6 +8,74 @@
 
 #if CONFIG_ENABLED(DEVICE_USB)
 
+static const char hidDescriptor[] = {
+    0x06, 0x97, 0xFF, // usage page vendor 0x97 (usage 0xff97 0x0001)
+    0x09, 0x01,       // usage 1
+    0xA1, 0x01,       // collection - application
+    0x15, 0x00,       // logical min 0
+    0x26, 0xFF, 0x00, // logical max 255
+    0x75, 8,          // report size 8
+    0x95, 64,         // report count 64
+    0x09, 0x01,       // usage 1
+    0x81, 0x02,       // input: data, variable, absolute
+    0x95, 64,         // report count 64
+    0x09, 0x01,       // usage 1
+    0x91, 0x02,       // output: data, variable, absolute
+    0x95, 1,          // report count 1
+    0x09, 0x01,       // usage 1
+    0xB1, 0x02,       // feature: data, variable, absolute
+    0xC0,             // end
+};
+
+static const HIDReportDescriptor reportDesc = {
+    9,
+    0x21,                  // HID
+    0x100,                 // hidbcd 1.00
+    0x00,                  // country code
+    0x01,                  // num desc
+    0x22,                  // report desc type
+    sizeof(hidDescriptor), // size of 0x22
+};
+
+static const InterfaceInfo ifaceInfo = {
+    &reportDesc,
+    sizeof(reportDesc),
+    1,
+    {
+        2,    // numEndpoints
+        0x03, /// class code - HID
+        0x00, // subclass
+        0x00, // protocol
+        0x00, //
+        0x00, //
+    },
+    {USB_EP_TYPE_INTERRUPT, 1},
+    {USB_EP_TYPE_INTERRUPT, 1},
+};
+
+int HF2::stdRequest(UsbEndpointIn &ctrl, USBSetup &setup)
+{
+    if (setup.bRequest == GET_DESCRIPTOR)
+    {
+        if (setup.wValueH == 0x21)
+        {
+            InterfaceDescriptor tmp;
+            fillInterfaceInfo(&tmp);
+            return ctrl.write(&tmp, sizeof(tmp));
+        }
+        else if (setup.wValueH == 0x22)
+        {
+            return ctrl.write(hidDescriptor, sizeof(hidDescriptor));
+        }
+    }
+    return DEVICE_NOT_SUPPORTED;
+}
+
+const InterfaceInfo *HF2::getInterfaceInfo()
+{
+    return &ifaceInfo;
+}
+
 int HF2::sendSerial(const void *data, int size, int isError)
 {
     return send(data, size, isError ? HF2_FLAG_SERIAL_ERR : HF2_FLAG_SERIAL_OUT);

--- a/libs/core/hf2.h
+++ b/libs/core/hf2.h
@@ -30,6 +30,9 @@ class HF2 : public USBHID
 public:
     HF2();
     virtual int endpointRequest();
+    virtual int stdRequest(UsbEndpointIn &ctrl, USBSetup& setup);
+    virtual const InterfaceInfo *getInterfaceInfo();
+
     int sendSerial(const void *data, int size, int isError = 0);
 };
 

--- a/libs/core/pxt.cpp
+++ b/libs/core/pxt.cpp
@@ -6,12 +6,13 @@ CodalDevice device;
 
 namespace pxt {
 
-// The first word is used to tell the bootloader that a single reset should start the
+// The first two word are used to tell the bootloader that a single reset should start the
 // bootloader and the MSD device, not us.
 // The rest is reserved for partial flashing checksums.
 __attribute__((section(".binmeta"))) __attribute__((used)) const uint32_t pxt_binmeta[] = {
-    0x87eeb07c, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff,
+    0x87eeb07c, 0x87eeb07c, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff,
     0x00ff00ff, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff, 0x00ff00ff,
+    0x00ff00ff, 0x00ff00ff,
 };
 
 TValue incr(TValue e) {


### PR DESCRIPTION
See https://github.com/Microsoft/pxt-adafruit/issues/171

This will be compatible with bootloader 1.23, but also the earlier versions.

Also, it changes HID usage ID to 0xff97 0x0001 for easier identification in winrt (in line with bootloader 1.23).

Some testing would be in order.