### PR TITLE
Set minimum rest time

### DIFF
--- a/libs/music/music.ts
+++ b/libs/music/music.ts
@@ -150,7 +150,7 @@ namespace music {
     //% parts="headphone" trackArgs=0
     //% blockNamespace=music
     export function rest(ms: number) {
-        playTone(0, ms);
+        playTone(0, Math.max(ms, 20));
     }
 
     /**


### PR DESCRIPTION
Fixes the "stop all sounds" API so that it doesn't stop sound forever.