### PR TITLE
Neopixel colors

### DIFF
--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -17,9 +17,9 @@ enum Colors {
     //% block=violet blockIdentity=light.colors
     Violet = 0x8a2be2,
     //% block=purple blockIdentity=light.colors
-    Purple = 0xFF00FF,
+    Purple = 0xA033E5,
     //% block=pink blockIdentity=light.colors
-    Pink = 0xFFC0CB,
+    Pink = 0xFF007F,
     //% block=white blockIdentity=light.colors
     White = 0xFFFFFF,
     //% block=black  blockIdentity=light.colors

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -19,7 +19,7 @@ enum Colors {
     //% block=purple blockIdentity=light.colors
     Purple = 0xFF00FF,
     //% block=pink blockIdentity=light.colors
-    Pink = 0xE242F4,
+    Pink = 0xFFC0CB,
     //% block=white blockIdentity=light.colors
     White = 0xFFFFFF,
     //% block=black  blockIdentity=light.colors

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -5,7 +5,7 @@ enum Colors {
     //% block=red blockIdentity=light.colors
     Red = 0xFF0000,
     //% block=orange blockIdentity=light.colors
-    Orange = 0xFFA500,
+    Orange = 0xFF7F00,
     //% block=yellow blockIdentity=light.colors
     Yellow = 0xFFFF00,
     //% block=green blockIdentity=light.colors


### PR DESCRIPTION
Adjusting pink, purple, and orange definitions to maximize contrast on the device while retaining color integrity in the browser.

Original: ![original](https://user-images.githubusercontent.com/16658549/28633139-ad01258a-71e7-11e7-8f81-f85c263a7674.PNG)

New: ![new](https://user-images.githubusercontent.com/16658549/28633146-b3bde61a-71e7-11e7-8a6f-32a3a46ec4e5.PNG)

