### PR TITLE
Enable help for base lib APIs.

### DIFF
--- a/libs/base/control.cpp
+++ b/libs/base/control.cpp
@@ -63,6 +63,7 @@ namespace control {
     * Derive a unique, consistent serial number of this device from internal data.
     */
     //% blockId="control_device_serial_number" block="device serial number" weight=9
+    //% help=control/device-serial-number
     int deviceSerialNumber() {
         return pxt::getSerialNumber();
     }

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -16,6 +16,9 @@ namespace control {
     /**
      * Display specified error code and stop the program.
      */
+    //% help=control/assert weight=30
+    //% blockId="control_assert" block="assert %cond| with value %code"
+    //% shim=pxtrt::panic
     export function assert(cond: boolean, code: number) {
         if (!cond) {
             fail("Assertion failed, code=" + code)

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -14,11 +14,10 @@ namespace control {
     export function panic(code: number) { }
 
     /**
-     * Display specified error code and stop the program.
+     * Display an error code and stop the program when the assertion is `false`.
      */
     //% help=control/assert weight=30
-    //% blockId="control_assert" block="assert %cond| with value %code"
-    //% shim=pxtrt::panic
+    //% blockId="control_assert" block="assert %cond|with value %code"
     export function assert(cond: boolean, code: number) {
         if (!cond) {
             fail("Assertion failed, code=" + code)

--- a/libs/base/docs/reference/control.md
+++ b/libs/base/docs/reference/control.md
@@ -9,15 +9,16 @@ control.runInBackground(() => {
 });
 control.reset();
 control.waitMicros(4);
+control.deviceSerialNumber();
+```
+
+## Advanced #advanced
+
+```cards
 control.raiseEvent(0, 0);
 control.onEvent(0, 0, () => {
     
 });
-```
-## Advanced #advanced
-
-```cards
-control.deviceSerialNumber();
 control.assert(false, 0);
 control.deviceDalVersion();
 control.panic(0);

--- a/libs/base/ns.ts
+++ b/libs/base/ns.ts
@@ -1,4 +1,7 @@
 
+/**
+ * Respond to and read data from buttons and sensors.
+ */
 //% color="#B4009E" weight=98 icon="\uf192"
 namespace input {
 }

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -24,7 +24,8 @@ namespace control {
  * @param mode optional definition of how the event should be processed after construction.
  */
 //% weight=21 blockGap=12 blockId="control_raise_event"
-//% block="raise event|from %src|with value value" blockExternalInputs=1
+//% help=control/raise-event
+//% block="raise event|from %src|with value %value" blockExternalInputs=1
 //% mode.defl=CREATE_AND_FIRE
 void raiseEvent(int src, int value, EventCreationMode mode) {
     Event evt(src, value, (EventLaunchMode)mode);
@@ -33,7 +34,8 @@ void raiseEvent(int src, int value, EventCreationMode mode) {
 /**
 * Determine the version of system software currently running.
 */
-//%
+//% blockId="control_device_dal_version" block="device dal version"
+//% help=control/device-dal-version
 String deviceDalVersion() {
     return mkString(device.getVersion());
 }


### PR DESCRIPTION
- [x] Add block and help jsDoc meta.
- [x] Include jsDoc description for _input_ namespace.