### PR TITLE
Inverting y axis in accelerometer

### DIFF
--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -116,7 +116,7 @@ public:
 
 int InvertableLIS3DH::getX() {
 #if INVERT_ACC_X_AXIS
-    return LIS3DH::getX() * -1;
+    return -LIS3DH::getX();
 #else
     return LIS3DH::getX();
 #endif
@@ -124,7 +124,7 @@ int InvertableLIS3DH::getX() {
 
 int InvertableLIS3DH::getY() {
 #if INVERT_ACC_Y_AXIS
-    return LIS3DH::getY() * -1;
+    return -LIS3DH::getY();
 #else
     return LIS3DH::getY();
 #endif
@@ -132,7 +132,7 @@ int InvertableLIS3DH::getY() {
 
 int InvertableLIS3DH::getZ() {
 #if INVERT_ACC_Z_AXIS
-    return LIS3DH::getZ() * -1;
+    return -LIS3DH::getZ();
 #else
     return LIS3DH::getZ();
 #endif

--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -1,4 +1,5 @@
 #include "pxt.h"
+#include "axis.h"
 #include "LIS3DH.h"
 
 enum class Dimension {
@@ -165,11 +166,26 @@ int getAccelerationStrength() {
 int acceleration(Dimension dimension) {
     switch (dimension) {
     case Dimension::X:
+#if INVERT_ACC_X_AXIS
+        return getWAccel()->acc.getX() * -1;
+#else
         return getWAccel()->acc.getX();
+#endif
+
     case Dimension::Y:
+#if INVERT_ACC_Y_AXIS
         return getWAccel()->acc.getY() * -1;
+#else
+        return getWAccel()->acc.getY();
+#endif
+
     case Dimension::Z:
+#if INVERT_ACC_Z_AXIS
+        return getWAccel()->acc.getZ() * -1;
+#else
         return getWAccel()->acc.getZ();
+#endif
+
     case Dimension::Strength:
         return getAccelerationStrength();
     }

--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -1,5 +1,8 @@
 #include "pxt.h"
 #include "axis.h"
+#include "Pin.h"
+#include "I2C.h"
+#include "CoordinateSystem.h"
 #include "LIS3DH.h"
 
 enum class Dimension {
@@ -103,13 +106,46 @@ enum class Gesture {
 
 namespace pxt {
 
+class InvertableLIS3DH : public LIS3DH {
+public:
+    InvertableLIS3DH(codal::mbed::I2C &_i2c, Pin &_int1, uint16_t address = LIS3DH_DEFAULT_ADDR, uint16_t id = DEVICE_ID_ACCELEROMETER, CoordinateSystem coordinateSystem = SIMPLE_CARTESIAN) : LIS3DH(_i2c, _int1, address, id, coordinateSystem) {}
+    int getX();
+    int getY();
+    int getZ();
+};
+
+int InvertableLIS3DH::getX() {
+#if INVERT_ACC_X_AXIS
+    return LIS3DH::getX() * -1;
+#else
+    return LIS3DH::getX();
+#endif
+}
+
+int InvertableLIS3DH::getY() {
+#if INVERT_ACC_Y_AXIS
+    return LIS3DH::getY() * -1;
+#else
+    return LIS3DH::getY();
+#endif
+}
+
+int InvertableLIS3DH::getZ() {
+#if INVERT_ACC_Z_AXIS
+    return LIS3DH::getZ() * -1;
+#else
+    return LIS3DH::getZ();
+#endif
+}
+
+
 // Wrapper classes
 
 class WAccel {
   public:
     codal::mbed::I2C i2c; // note that this is different pins than io->i2c
     DevicePin int1;
-    LIS3DH acc;
+    InvertableLIS3DH acc;
     WAccel()
         : i2c((PinName)PIN_ACCELEROMETER_SDA, (PinName)PIN_ACCELEROMETER_SCL),
           INIT_PIN(int1, PIN_ACCELEROMETER_INT), //
@@ -166,26 +202,11 @@ int getAccelerationStrength() {
 int acceleration(Dimension dimension) {
     switch (dimension) {
     case Dimension::X:
-#if INVERT_ACC_X_AXIS
-        return getWAccel()->acc.getX() * -1;
-#else
         return getWAccel()->acc.getX();
-#endif
-
     case Dimension::Y:
-#if INVERT_ACC_Y_AXIS
-        return getWAccel()->acc.getY() * -1;
-#else
         return getWAccel()->acc.getY();
-#endif
-
     case Dimension::Z:
-#if INVERT_ACC_Z_AXIS
-        return getWAccel()->acc.getZ() * -1;
-#else
         return getWAccel()->acc.getZ();
-#endif
-
     case Dimension::Strength:
         return getAccelerationStrength();
     }

--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -167,7 +167,7 @@ int acceleration(Dimension dimension) {
     case Dimension::X:
         return getWAccel()->acc.getX();
     case Dimension::Y:
-        return getWAccel()->acc.getY();
+        return getWAccel()->acc.getY() * -1;
     case Dimension::Z:
         return getWAccel()->acc.getZ();
     case Dimension::Strength:

--- a/libs/accelerometer/axis.h
+++ b/libs/accelerometer/axis.h
@@ -1,0 +1,5 @@
+// Override in target to change inversion of axis
+
+#define INVERT_ACC_X_AXIS 0
+#define INVERT_ACC_Y_AXIS 0
+#define INVERT_ACC_Z_AXIS 0

--- a/libs/accelerometer/pxt.json
+++ b/libs/accelerometer/pxt.json
@@ -4,6 +4,7 @@
     "files": [
         "README.md",
         "accelerometer.cpp",
+        "axis.h",
         "shims.d.ts",
         "enums.d.ts",
         "ns.ts"

--- a/libs/accelerometer/sim/accelerometer.ts
+++ b/libs/accelerometer/sim/accelerometer.ts
@@ -215,10 +215,10 @@ namespace pxsim {
             if (this.getX() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
                 return DAL.ACCELEROMETER_EVT_TILT_RIGHT;
 
-            if (this.getY() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
+            if (this.getY() * -1 < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
                 return DAL.ACCELEROMETER_EVT_TILT_DOWN;
 
-            if (this.getY() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
+            if (this.getY() * -1 > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
                 return DAL.ACCELEROMETER_EVT_TILT_UP;
 
             if (this.getZ() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))

--- a/libs/accelerometer/sim/accelerometer.ts
+++ b/libs/accelerometer/sim/accelerometer.ts
@@ -215,11 +215,11 @@ namespace pxsim {
             if (this.getX() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
                 return DAL.ACCELEROMETER_EVT_TILT_RIGHT;
 
-            if (this.getY() * -1 < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
-                return DAL.ACCELEROMETER_EVT_TILT_DOWN;
-
-            if (this.getY() * -1 > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
+            if (this.getY() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
                 return DAL.ACCELEROMETER_EVT_TILT_UP;
+
+            if (this.getY() > (1000 - DAL.ACCELEROMETER_TILT_TOLERANCE))
+                return DAL.ACCELEROMETER_EVT_TILT_DOWN;
 
             if (this.getZ() < (-1000 + DAL.ACCELEROMETER_TILT_TOLERANCE))
                 return DAL.ACCELEROMETER_EVT_FACE_UP;
@@ -264,16 +264,19 @@ namespace pxsim {
           */
         public getX(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
             this.activate();
+            let val: number;            
             switch (system) {
                 case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
-                    return -this.sample.x;
+                    val = -this.sample.x;
 
                 case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
-                    return this.sample.y;
+                    val = this.sample.y;
                 //case MicroBitCoordinateSystem.SIMPLE_CARTESIAN.RAW:
                 default:
-                    return this.sample.x;
+                    val = this.sample.x;
             }
+
+            return (board() as AccelerometerBoard).invertAccelerometerXAxis ? val * -1 : val;
         }
 
         /**
@@ -289,16 +292,19 @@ namespace pxsim {
           */
         public getY(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
             this.activate();
+            let val: number;
             switch (system) {
                 case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
-                    return -this.sample.y;
+                    val = -this.sample.y;
 
                 case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
-                    return -this.sample.x;
+                    val = -this.sample.x;
                 //case RAW:
                 default:
-                    return this.sample.y;
+                    val = this.sample.y;
             }
+
+            return (board() as AccelerometerBoard).invertAccelerometerYAxis ? val * -1 : val;
         }
 
         /**
@@ -314,14 +320,17 @@ namespace pxsim {
           */
         public getZ(system: MicroBitCoordinateSystem = MicroBitCoordinateSystem.SIMPLE_CARTESIAN): number {
             this.activate();
+            let val: number;            
             switch (system) {
                 case MicroBitCoordinateSystem.NORTH_EAST_DOWN:
-                    return -this.sample.z;
+                    val = -this.sample.z;
                 //case MicroBitCoordinateSystem.SIMPLE_CARTESIAN:
                 //case MicroBitCoordinateSystem.RAW:
                 default:
-                    return this.sample.z;
+                    val = this.sample.z;
             }
+
+            return (board() as AccelerometerBoard).invertAccelerometerZAxis ? val * -1 : val;
         }
 
         /**

--- a/libs/accelerometer/sim/state.ts
+++ b/libs/accelerometer/sim/state.ts
@@ -1,6 +1,9 @@
 namespace pxsim {
     export interface AccelerometerBoard extends CommonBoard {
         accelerometerState: AccelerometerState;
+        invertAccelerometerXAxis?: boolean;
+        invertAccelerometerYAxis?: boolean;
+        invertAccelerometerZAxis?: boolean;
     }
 
     export function accelerometer(): AccelerometerState {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-adafruit/issues/304

The Y axis of the accelerometer doesn't match the markings on the circuit playground or the simulator behavior. This PR inverts that value and also fixes the simulator tilt up and down events so that they match the hardware.