### PR TITLE
Better defaults for animation and music methods in JS.

### DIFF
--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -479,7 +479,7 @@ namespace light {
 
         /**
          * Show an animation or queue an animation in the animation queue
-         * @param animation the animation to run
+         * @param animation the animation to run, eg: light.animation(LightAnimation.Rainbow)
          * @param duration the duration to run in milliseconds, eg: 500
          */
         //% blockId=neopixel_show_animation block="%strip|show %animation=light_animation|animation for %duration=timePicker|ms"
@@ -499,7 +499,7 @@ namespace light {
 
         /**
          * Show a single animation frame
-         * @param animation the animation to run
+         * @param animation the animation to run, eg: light.animation(LightAnimation.Rainbow)
          */
         //% blockId=neopixel_show_animation_frame block="%strip|show animation frame %animation=light_animation"
         //% help="light/show-animation-frame"

--- a/libs/music/melodies.ts
+++ b/libs/music/melodies.ts
@@ -88,7 +88,7 @@ namespace music {
     /**
      * Start playing a sound and don't wait for it to finish.
      * Notes are expressed as a string of characters with this format: NOTE[octave][:duration]
-     * @param sound the melody to play, eg: 'g5:1'
+     * @param sound the melody to play, eg: music.sounds(Sounds.PowerUp)
      */
     //% help=music/play-sound
     //% blockId=music_play_sound block="play sound %sound=music_sounds"
@@ -108,7 +108,7 @@ namespace music {
     /**
      * Play a sound and wait until the sound is done.
      * Notes are expressed as a string of characters with this format: NOTE[octave][:duration]
-     * @param sound the melody to play, eg: 'g5:1'
+     * @param sound the melody to play, eg: music.sounds(Sounds.PowerUp)
      */
     //% help=music/play-sound-until-done
     //% blockId=music_play_sound_until_done block="play sound %sound=music_sounds|until done"

--- a/libs/music/music.cpp
+++ b/libs/music/music.cpp
@@ -95,8 +95,8 @@ void setVolume(int volume) {
 
 /**
 * Play a tone through the speaker for some amount of time.
-* @param frequency pitch of the tone to play in Hertz (Hz)
-* @param ms tone duration in milliseconds (ms)
+* @param frequency pitch of the tone to play in Hertz (Hz), eg: Note.C
+* @param ms tone duration in milliseconds (ms), eg: music.beat(BeatFraction.Half)
 */
 //% help=music/play-tone
 //% blockId=music_play_note block="play tone|at %note=device_note|for %duration=device_beat"

--- a/libs/music/music.ts
+++ b/libs/music/music.ts
@@ -131,7 +131,7 @@ namespace music {
 
     /**
     * Play a tone.
-    * @param frequency pitch of the tone to play in Hertz (Hz)
+    * @param frequency pitch of the tone to play in Hertz (Hz), eg: Note.C
     */
     //% help=music/ring-tone
     //% blockId=music_ring block="ring tone|at %note=device_note"
@@ -144,7 +144,7 @@ namespace music {
 
     /**
     * Rest, or play silence, for some time (in milleseconds).
-    * @param ms rest duration in milliseconds (ms)
+    * @param ms rest duration in milliseconds (ms), eg: 100
     */
     //% help=music/rest
     //% blockId=music_rest block="rest|for %duration=device_beat"


### PR DESCRIPTION
Better defaults as you type in JS for showAnimation and music functions (instead of nulls and placeholders)
```
    light.showAnimation(light.animation(LightAnimation.Rainbow), 500)
    light.showAnimationFrame(light.animation(LightAnimation.Rainbow))
    music.playSound(music.sounds(Sounds.PowerUp))
    music.playTone(Note.C, music.beat(BeatFraction.Half))
    music.ringTone(Note.C)
    music.rest(100)
```

In conjunction with https://github.com/Microsoft/pxt-adafruit/pull/381