### PR TITLE
light.createStrip

### DIFF
--- a/libs/light/create.ts
+++ b/libs/light/create.ts
@@ -1,15 +1,13 @@
 
 namespace light {
     /**
-     * Create a new NeoPixel driver for `numleds` LEDs.
-     * @param pin the pin where the neopixel is connected.
-     * @param numleds number of leds in the strip, eg: 24,30,60,64
+     * This block is deprecated, use ``light.createStrip`` instead.
      */
     //% blockId="neopixel_create" block="create strip|pin %pin|pixels %numleds|mode %mode"
     //% help="light/create-neo-pixel-strip"
     //% trackArgs=0,2
     //% parts="neopixel"
-    //% weight=100
+    //% weight=100 deprecated=true blockHidden=true
     export function createNeoPixelStrip(
         pin: DigitalPin = null,
         numleds: number = 10,
@@ -28,5 +26,24 @@ namespace light {
         strip._barGraphHighLast = 0;
         strip.setBrightness(20)
         return strip;
+    }
+
+    /**
+     * Create a new programmable light strip.
+     * @param pin the pin where the neopixel is connected.
+     * @param numleds number of leds in the strip, eg: 24,30,60,64
+     * @param mode the light encoding mode for different LED strips, eg: NeoPixelMode.RGB_GRB
+     */
+    //% blockId="neopixel_create_strip" block="create strip|on %pin|with %numleds|pixels"
+    //% help="light/create-strip"
+    //% trackArgs=0,2
+    //% parts="neopixel"
+    //% subcategory="External" weight=100
+    export function createStrip(
+        pin: DigitalPin = null,
+        numleds: number = 10,
+        mode: NeoPixelMode = NeoPixelMode.RGB
+    ): NeoPixelStrip {
+        return light.createNeoPixelStrip(pin, numleds, mode);
     }
 }

--- a/libs/light/create.ts
+++ b/libs/light/create.ts
@@ -10,7 +10,7 @@ namespace light {
     //% help="light/create-strip"
     //% trackArgs=0,2
     //% parts="neopixel"
-    //% subcategory="External" weight=100
+    //% weight=100
     export function createStrip(
         pin: DigitalPin = null,
         numleds: number = 10,

--- a/libs/light/create.ts
+++ b/libs/light/create.ts
@@ -1,34 +1,6 @@
 
 namespace light {
     /**
-     * This block is deprecated, use ``light.createStrip`` instead.
-     */
-    //% blockId="neopixel_create" block="create strip|pin %pin|pixels %numleds|mode %mode"
-    //% help="light/create-neo-pixel-strip"
-    //% trackArgs=0,2
-    //% parts="neopixel"
-    //% weight=100 deprecated=true blockHidden=true
-    export function createNeoPixelStrip(
-        pin: DigitalPin = null,
-        numleds: number = 10,
-        mode?: NeoPixelMode
-    ): NeoPixelStrip {
-        if (!mode)
-            mode = NeoPixelMode.RGB
-
-        const strip = new NeoPixelStrip();
-        strip._mode = mode;
-        strip._length = Math.max(0, numleds);
-        strip._start = 0;
-        strip._pin = pin ? pin : defaultPin();
-        strip._pin.digitalWrite(false);
-        strip._barGraphHigh = 0;
-        strip._barGraphHighLast = 0;
-        strip.setBrightness(20)
-        return strip;
-    }
-
-    /**
      * Create a new programmable light strip.
      * @param pin the pin where the neopixel is connected.
      * @param numleds number of leds in the strip, eg: 24,30,60,64

--- a/libs/light/docs/reference/light.md
+++ b/libs/light/docs/reference/light.md
@@ -19,14 +19,15 @@ light.pixels.clear()
 light.pixels.brightness()
 light.pixels.pixelColor(0)
 ```
-## NeoPixel #neopixel
+## External Strip #neopixel
 
 ```cards
-light.createNeoPixelStrip(null, 0)
+light.createStrip(null, 0)
 light.pixels.setPixelWhiteLED(0, 0)
 light.pixels.range(0, 0)
 light.pixels.length()
 light.pixels.move(0, 0)
+light.pixels.setMode(NeoPixelMode.RGB)
 ```
 ## Photon #photon
 

--- a/libs/light/docs/reference/light/create-strip.md
+++ b/libs/light/docs/reference/light/create-strip.md
@@ -1,15 +1,15 @@
-# create Neo Pixel Strip
+# create Strip
 
-Create a NeoPixel connection between your program and a pixel strip.
+Create a controller for a programmable LED strip.
 
 ```sig
-light.createNeoPixelStrip();
+light.createStrip();
 ```
 When you connect a pixel strip to your @boardname@, you have to give your program a way
 to work with it. You tell your program that there is a pixel strip you want to use with
-``||create neo pixel strip||``.
+``||create strip||``.
 
-To use ``||create neo pixel strip||``, you need to know which pin the strip is attached to and
+To use ``||create strip||``, you need to know which pin the strip is attached to and
 how many pixels (LEDs) are on the strip. Also, some pixel strips have different types LEDs.
 If you know the exact type, you can set it in the pixel mode. 
 
@@ -17,24 +17,20 @@ If you know the exact type, you can set it in the pixel mode.
 
 * **pin**: [DigitalPin](/reference/pins), the pin where the neopixel strip is connected.
 * **numleds**: the [number](/types/number) of LEDs in the strip, such as: 10, 30, 60, or 64.
-* **mode**: the mode to light and flash LEDs. The basic mode is RGB but you can set a different
-mode if your pixels have a different type of LEDs.
 
 ## Example
 
 Connect a pixel strip to the pin `D4`. Make all pixels light up `green`.
 
 ```typescript
-let neostrip = light.createNeoPixelStrip(pins.D4, 10);
-neostrip.setAll(Colors.Green)
+const strip = light.createNeoPixelStrip(pins.D4, 10);
+strip.setAll(Colors.Green)
 ```
 
 ## See Also
 
-[``||range||``](/reference/light/range)
+[``||range||``](/reference/light/range), [``||set mode||``](/reference/light/set-mode)
 
 ```package
 light
 ```
-
-

--- a/libs/light/docs/reference/light/create-strip.md
+++ b/libs/light/docs/reference/light/create-strip.md
@@ -23,7 +23,7 @@ If you know the exact type, you can set it in the pixel mode.
 Connect a pixel strip to the pin `D4`. Make all pixels light up `green`.
 
 ```typescript
-const strip = light.createNeoPixelStrip(pins.D4, 10);
+const strip = light.createStrip(pins.D4, 10);
 strip.setAll(Colors.Green)
 ```
 

--- a/libs/light/docs/reference/light/set-mode.md
+++ b/libs/light/docs/reference/light/set-mode.md
@@ -1,0 +1,20 @@
+# set Mode
+
+Sets the color encoding mode sent to the programmable lights.
+
+```sig
+light.pixels.setMode(NeoPixelMode.RGB)
+```
+
+Most light strips use the Green Red Blue encoding (``NeoPixelMode.RGB``), some use Red Green Blue (``NeoPixelMode.RGB_RGB``).
+Some LED strips also have a white LED (``NeoPixelMode.RGBW``).
+
+## Parameters
+
+* **mode**: the desired mode
+
+```package
+light
+```
+
+

--- a/libs/light/docs/reference/light/set-pixel-white-led.md
+++ b/libs/light/docs/reference/light/set-pixel-white-led.md
@@ -20,7 +20,7 @@ between 0 (totally dark) and 255 (very bright).
 Set the white pixel at position `5` in an RGB+W NeoPixel strip to half brightness.
 
 ```blocks
-let rgbwStrip = light.createNeoPixelStrip(null, 24, NeoPixelMode.RGBW)
+let rgbwStrip = light.createStrip(null, 24, NeoPixelMode.RGBW)
 rgbwStrip.setPixelWhiteLED(5, 128)
 ```
 

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -600,8 +600,8 @@ namespace light {
         //% blockId=neopixel_set_mode block="%strip|set mode %mode"
         //% help="light/set-mode"
         //% parts="neopixel"
-        //% group="More" advanced=true weight=84
-        setMode(mode: NeoPixelMode) {
+        //% group="More" weight=1
+        setMode(mode: NeoPixelMode): void {
             this._mode = mode;
             this.reallocateBuffer();
         }

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -587,8 +587,21 @@ namespace light {
         /**
          * Gets a value indicated if the changes are buffered
          */
+        //% weight=85
         buffered(): boolean {
             return this._parent ? this._parent.buffered() : this._buffered;
+        }
+
+        /**
+         * Sets the color mode and clears the colors.
+         * @param mode the kind of color encoding required by the programmable lights
+         */
+        //% blockId=neopixel_set_mode block="%strip|set mode %mode"
+        //% help="light/set-mode"
+        //% advanced=true weight=84
+        setMode(mode: NeoPixelMode) {
+            this._mode = mode;
+            this.reallocateBuffer();
         }
 
         private autoShow() {

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -298,7 +298,8 @@ namespace light {
         //% parts="neopixel"
         //% group="More" weight=86 blockGap=8
         show(): void {
-            sendBuffer(this._pin, this.buf);
+            if (this._pin)
+                sendBuffer(this._pin, this.buf);
         }
 
         /**
@@ -626,6 +627,35 @@ namespace light {
         }
     }
 
+    /**
+     * This block is deprecated, use ``light.createStrip`` instead.
+     */
+    //% blockId="neopixel_create" block="create strip|pin %pin|pixels %numleds|mode %mode"
+    //% help="light/create-neo-pixel-strip"
+    //% trackArgs=0,2
+    //% parts="neopixel"
+    //% weight=100 deprecated=true blockHidden=true
+    export function createNeoPixelStrip(
+        pin: DigitalPin = null,
+        numleds: number = 10,
+        mode?: NeoPixelMode
+    ): NeoPixelStrip {
+        if (!mode)
+            mode = NeoPixelMode.RGB
+
+        const strip = new NeoPixelStrip();
+        strip._mode = mode;
+        strip._length = Math.max(0, numleds);
+        strip._start = 0;
+        strip._pin = pin ? pin : defaultPin();
+        if (strip._pin) // board with no-board LEDs won't have a default pin
+            strip._pin.digitalWrite(false);
+        strip._barGraphHigh = 0;
+        strip._barGraphHighLast = 0;
+        strip.setBrightness(20)
+        return strip;
+    }
+    
     /**
      * Converts red, green, blue channels into a RGB color
      * @param red value of the red channel between 0 and 255. eg: 255

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -588,7 +588,7 @@ namespace light {
         /**
          * Gets a value indicated if the changes are buffered
          */
-        //% weight=85
+        //% weight=85 group="More"
         buffered(): boolean {
             return this._parent ? this._parent.buffered() : this._buffered;
         }
@@ -599,7 +599,8 @@ namespace light {
          */
         //% blockId=neopixel_set_mode block="%strip|set mode %mode"
         //% help="light/set-mode"
-        //% advanced=true weight=84
+        //% parts="neopixel"
+        //% group="More" advanced=true weight=84
         setMode(mode: NeoPixelMode) {
             this._mode = mode;
             this.reallocateBuffer();

--- a/libs/light/test.ts
+++ b/libs/light/test.ts
@@ -1,5 +1,5 @@
 
-let strip = light.createNeoPixelStrip()
+let strip = light.createStrip()
 strip.setBrightness(20)
 
 function flash(n: number) {


### PR DESCRIPTION
- [x] create wrapper light.createStrip that deprecates light.createNeoPixelStrip (still there, hidden). Mode not available in blocks.
- [x] add light.setMode to override default mode