### PR TITLE
support for hue in photon

### DIFF
--- a/libs/light/docs/examples/photon-bounce.md
+++ b/libs/light/docs/examples/photon-bounce.md
@@ -9,7 +9,7 @@ let n = p.length()
 p.setBrightness(100)
 loops.forever(() => {
     p.setPhotonMode(PhotonMode.PenUp);
-    p.setPhotonColor(Math.randomRange(0, 255));
+    p.setPhotonPenColor(Math.randomRange(0, 255));
     distance = n - 1;
     for (let i = 0; i < n; ++i) {
         for (let i = 0; i < distance; ++i) {

--- a/libs/light/docs/examples/photon-color-wipe.md
+++ b/libs/light/docs/examples/photon-color-wipe.md
@@ -2,7 +2,7 @@
 
 ```blocks
 loops.forever(() => {
-    light.pixels.setPhotonColor(Math.randomRange(0, 256))
+    light.pixels.setPhotonPenHue(Math.randomRange(0, 256))
     light.pixels.setPhotonMode(PhotonMode.PenDown)
     for (let i = 0; i < 9; i++) {
         light.pixels.photonForward(1)

--- a/libs/light/docs/examples/photon-raibow.md
+++ b/libs/light/docs/examples/photon-raibow.md
@@ -3,7 +3,7 @@
 ```blocks
 let c = 0;
 loops.forever(() => {
-    light.pixels.setPhotonColor(c)
+    light.pixels.setPhotonPenHue(c)
     light.pixels.photonForward(1)
     c += 16;
 })

--- a/libs/light/docs/examples/photon-roundtrip.md
+++ b/libs/light/docs/examples/photon-roundtrip.md
@@ -3,7 +3,7 @@
 ```blocks
 input.buttonA.onEvent(ButtonEvent.Click, () => {
     light.pixels.setPhotonMode(PhotonMode.PenDown)
-    light.pixels.setPhotonColor(Math.randomRange(0, 256))
+    light.pixels.setPhotonPenHue(Math.randomRange(0, 256))
     for (let i = 0; i < 10; i++) {
         light.pixels.photonForward(1)
         loops.pause(50)

--- a/libs/light/docs/examples/photon-wand.md
+++ b/libs/light/docs/examples/photon-wand.md
@@ -14,7 +14,7 @@ input.onGesture(Gesture.Shake, () => {
 })
 loops.forever(() => {
     light.pixels.photonForward(1)
-    light.pixels.setPhotonColor(c)
+    light.pixels.setPhotonPenHue(c)
     c += 16
 })
 ```

--- a/libs/light/docs/reference/light.md
+++ b/libs/light/docs/reference/light.md
@@ -34,6 +34,7 @@ light.pixels.setMode(NeoPixelMode.RGB)
 ```cards
 light.pixels.photonForward(0)
 light.pixels.photonFlip()
+light.pixels.setPhotonPenHue(0)
 light.pixels.setPhotonPenColor(0)
 light.pixels.setPhotonMode(PhotonMode.PenUp)
 ```
@@ -58,6 +59,7 @@ light.fade(0, 0)
 [range](/reference/light/range), [length](/reference/light/length),
 [move](/reference/light/move), [photonForward](/reference/light/photon-forward),
 [photonFlip](/reference/light/photon-flip), [setPhotonPenColor](/reference/light/set-photon-pen-color),
+[setPhotonPenHue](/reference/light/set-photon-pen-hue),
 [setPhotonMode](/reference/light/set-photon-mode), [rgb](/reference/light/rgb),
 [hsv](/reference/light/hsv), [colors](/reference/light/colors),
 [fade](/reference/light/fade)

--- a/libs/light/docs/reference/light/set-photon-mode.md
+++ b/libs/light/docs/reference/light/set-photon-mode.md
@@ -26,7 +26,7 @@ so it erases when it moves backward.
 
 ```blocks
 let forward = true
-light.pixels.setPhotonColor(191)
+light.pixels.setPhotonPenHue(191)
 loops.forever(() => {
     if (forward) {
         light.pixels.setPhotonMode(PhotonMode.PenDown)
@@ -49,14 +49,14 @@ Flash a purple photon across the pixel strip using `pen down` mode. Switch the m
 color stays purple.
 
 ```blocks
-light.pixels.setPhotonColor(191)
+light.pixels.setPhotonPenHue(191)
 light.pixels.setPhotonMode(PhotonMode.PenDown)
 for (let i = 1; i < light.pixels.length(); i++) {
     light.pixels.photonForward(1)
     loops.pause(500)
 }
 
-light.pixels.setPhotonColor(86)
+light.pixels.setPhotonPenHue(86)
 light.pixels.setPhotonMode(PhotonMode.PenUp)
 for (let i = 1; i < light.pixels.length(); i++) {
     light.pixels.photonForward(1)

--- a/libs/light/docs/reference/light/set-photon-pen-color.md
+++ b/libs/light/docs/reference/light/set-photon-pen-color.md
@@ -3,7 +3,7 @@
 Change the color of the photon pixels on the pixel strip.
 
 ```sig
-light.pixels.setPhotonColor(0)
+light.pixels.setPhotonPenColor(0)
 ```
 
 The photon effect is a pulse of bright light moving through a strip of colored pixels.
@@ -18,7 +18,7 @@ You can change the color of the photon to whatever you want.
 Pulse an blue photon forward and backward across the pixel strip.
 
 ```blocks
-light.pixels.setPhotonColor(Colors.Blue)
+light.pixels.setPhotonPenColor(Colors.Blue)
 loops.forever(() => {
     for (let i = 0; i < light.pixels.length(); i++) {
         light.pixels.photonForward(1)

--- a/libs/light/docs/reference/light/set-photon-pen-hue.md
+++ b/libs/light/docs/reference/light/set-photon-pen-hue.md
@@ -1,0 +1,57 @@
+# set Photon Color
+
+Change the color **hue** of the photon on the pixel strip.
+
+```sig
+light.pixels.setPhotonPenHue(0)
+```
+
+The photon effect is a pulse of bright light moving through a strip of colored pixels.
+You can change the color of the photon to whatever you want.
+
+The color is a **hue** and not an _RGB_ number. This means that red light is `0` and red light is also `255`. All the other colors are between `0` and `255`. Color begins at red and ends up back at red.
+
+## Parameters
+
+* **hue**: a [number](/types/number) from 0 (red light) to 255 (red light again) for
+the _hue_ of the color you want.
+> Some standard numbers for hue are:
+> * red - `0`
+> * orange - `29`
+> * yellow - `43`
+> * green - `86`
+> * aqua - `125`
+> * blue - `170`
+> * purple - `191`
+> * magenta - `213`
+> * pink - `234`
+> * red - `255`
+
+
+## Example
+
+Pulse an rainbow photon forward and backward across the pixel strip.
+
+```blocks
+let hue = 0;
+light.pixels.setPhotonPenHue(hue)
+loops.forever(() => {
+    for (let i = 0; i < light.pixels.length(); i++) {
+        light.pixels.photonForward(1)
+        loops.pause(100)
+        hue = hue + 1;
+    }
+    light.pixels.photonFlip()
+})
+```
+## See also
+
+[``||photon forward||``](/reference/light/photon-forward),
+[``||photon flip||``](/reference/light/photon-flip),
+[``||set photon pen color||``](/reference/light/set-photon-pen-color),
+[``||photon mode||``](/reference/light/set-photon-mode)
+
+```package
+light
+```
+

--- a/libs/light/docs/reference/light/set-photon-pen-hue.md
+++ b/libs/light/docs/reference/light/set-photon-pen-hue.md
@@ -1,4 +1,4 @@
-# set Photon Color
+# set Photon Hue
 
 Change the color **hue** of the photon on the pixel strip.
 
@@ -34,14 +34,14 @@ Pulse an rainbow photon forward and backward across the pixel strip.
 
 ```blocks
 let hue = 0;
-light.pixels.setPhotonPenHue(hue)
 loops.forever(() => {
+    light.pixels.setPhotonPenHue(hue)
     for (let i = 0; i < light.pixels.length(); i++) {
         light.pixels.photonForward(1)
         loops.pause(100)
-        hue = hue + 1;
     }
     light.pixels.photonFlip()
+    hue = hue + 1;
 })
 ```
 ## See also

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -506,7 +506,6 @@ namespace light {
         //% parts="neopixel" deprecated=1 blockHidden=true
         //% group="Photon" weight=39 blockGap=8
         setPhotonPenHue(hue: number) {
-            hue = (hue >> 0) % 0xff; // cycle through colors
             this.setPhotonPenColor(hsv(hue, 0xff, 0xff));            
         }
 

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -1,5 +1,5 @@
 /**
- * Well known colors for a NeoPixel strip
+ * Well known colors
  */
 enum Colors {
     //% block=red blockIdentity=light.colors
@@ -24,6 +24,30 @@ enum Colors {
     White = 0xFFFFFF,
     //% block=black  blockIdentity=light.colors
     Black = 0x000000
+}
+
+/**
+ * Well known color hues 
+ */
+enum ColorHues {
+    //% block=red
+    Red = 0,
+    //% block=orange
+    Orange = 29,
+    //% block=yellow
+    Yellow = 43,
+    //% block=green
+    Green = 86,
+    //% block=aqua
+    Aqua = 125,
+    //% block=blue
+    Blue = 170,
+    //% block=purple
+    Purple = 191,
+    //% block=magenta
+    Magenta = 213,
+    //% block=pink
+    Pink = 234
 }
 
 /**
@@ -477,11 +501,18 @@ namespace light {
         /**
          * This function is deprecated.
          */
-        //% blockId=neophoton_set_color block="%strip=variables_get|photon set pen color %color=colorWheelPicker"
+        //% blockId=neophoton_set_color block="%strip=variables_get|photon set pen hue %hue=colorWheelPicker"
+        //% help="light/set-photon-pen-hue"
         //% parts="neopixel" deprecated=1 blockHidden=true
         //% group="Photon" weight=39 blockGap=8
-        setPhotonColor(color: number) {
-            this.setPhotonPenColor(hsv(color, 0xff, 0xff));
+        setPhotonPenHue(hue: number) {
+            hue = (hue >> 0) % 0xff; // cycle through colors
+            this.setPhotonPenColor(hsv(hue, 0xff, 0xff));            
+        }
+
+        //% deprecated=1 blockHidden=1
+        setPhotonColor(hue: number) {
+            this.setPhotonPenHue(hue);
         }
             
         /**
@@ -737,7 +768,7 @@ namespace light {
     //% hue.min=0 hue.max=255 sat.min=0 sat.max=255 val.min=0 val.max=255
     //% help="light/hsv"
     //% group="Color" weight=17
-    export function hsv(hue: number, sat: number, val: number): number {
+    export function hsv(hue: number, sat: number = 255, val: number = 255): number {
         let h = (hue % 255) >> 0;
         if (h < 0) h += 255;
         // scale down to 0..192


### PR DESCRIPTION
Add a photon API that uses a color hue instead of RGB. Hue is needed to do cool math on colors. RGB does not cut it. The wording is changed so that there is no more confusion about this.

![image](https://user-images.githubusercontent.com/4175913/31788648-3a2468ae-b4c4-11e7-8334-1cd611393e24.png)
