### PR TITLE
Update IR and cable blocks

### DIFF
--- a/libs/cable/cable.ts
+++ b/libs/cable/cable.ts
@@ -42,18 +42,38 @@ namespace network {
     }
 
     /**
-     * Run some code when the cable receives data.
+     * Run some code when the cable receives a number.
      */
     //% blockId=on_cable_received block="on cable received" blockGap=8
     //% help=network/on-cable-received
     //% parts="cable" group="Cable"
-    //% optionalVariableArgs toolboxVariableArgs="1"
-    export function onCableReceived(handler: (num: number, nums?: number[], buf?: Buffer) => void) {
+    export function onCableReceivedNumber(handler: (num: number) => void) {
         onCablePacket(() => {
             const buf: Buffer = cablePacket();
             const nums: number[] = msgpack.unpackNumberArray(buf) || [];
             const num = nums[0] || 0;
-            handler(num, nums, buf);
+            handler(num);
+        })
+    }
+
+    /**
+     * Run some code when the cable receives a list of numbers.
+     */
+    export function onCableReceivedNumbers(handler: (nums: number[]) => void) {
+        onCablePacket(() => {
+            const buf: Buffer = cablePacket();
+            const nums: number[] = msgpack.unpackNumberArray(buf) || [];
+            handler(nums);
+        })
+    }
+
+    /**
+     * Run some code when the cable receives data a buffer.
+     */
+    export function onCableReceivedBuffer(handler: (buf: Buffer) => void) {
+        onCablePacket(() => {
+            const buf: Buffer = cablePacket();
+            handler(buf);
         })
     }
 

--- a/libs/infrared/docs/reference/network.md
+++ b/libs/infrared/docs/reference/network.md
@@ -6,7 +6,7 @@ Send and receive data between your @boardname@ and another board.
 
 ```cards
 network.infraredSendNumber(0);
-network.onInfraredReceived(function (num) {
+network.onInfraredReceivedNumber(function (num) {
 	
 })
 ```

--- a/libs/infrared/docs/reference/network/on-infrared-received.md
+++ b/libs/infrared/docs/reference/network/on-infrared-received.md
@@ -3,7 +3,7 @@
 Run some code when a data message comes into the infrared receiver.
 
 ```sig
-network.onInfraredReceived(function (num) {
+network.onInfraredReceivedNumber(function (num) {
 	
 })
 ```
@@ -30,7 +30,7 @@ Right now, just use ``num`` as your data part from the packet you receive over i
 Show the value of a number received from an infrared data message. The number is shown by lighting the same number of pixels on the pixel strip.
 
 ```blocks
-network.onInfraredReceived(function (num) {
+network.onInfraredReceivedNumber(function (num) {
     light.pixels.graph(num, 9);
 })
 ```

--- a/libs/infrared/ir.ts
+++ b/libs/infrared/ir.ts
@@ -42,18 +42,38 @@ namespace network {
     }
 
     /**
-     * Run some code when the infrared receiver gets a packet.
+     * Run some code when the infrared receiver gets a number.
      */
     //% blockId=ir_on_infrared_received block="on infrared received" blockGap=8
     //% help=network/on-infrared-received
     //% parts="ir" group="Infrared"
-    //% optionalVariableArgs toolboxVariableArgs="1"
-    export function onInfraredReceived(handler: (num: number, nums?: number[], buf?: Buffer) => void) {
+    export function onInfraredReceivedNumber(handler: (num: number) => void) {
         onInfraredPacket(() => {
             const buf: Buffer = infraredPacket();
             const nums: number[] = msgpack.unpackNumberArray(buf) || [];
             const num = nums[0] || 0;
-            handler(num, nums, buf);
+            handler(num);
+        });
+    }
+
+    /**
+     * Run some code when the infrared receiver gets a list of numbers.
+     */
+    export function onInfraredReceivedNumbers(handler: (nums: number[]) => void) {
+        onInfraredPacket(() => {
+            const buf: Buffer = infraredPacket();
+            const nums: number[] = msgpack.unpackNumberArray(buf) || [];
+            handler(nums);
+        });
+    }
+    
+    /**
+     * Run some code when the infrared receiver gets a buffer.
+     */
+    export function onInfraredReceivedBuffer(handler: (buf: Buffer) => void) {
+        onInfraredPacket(() => {
+            const buf: Buffer = infraredPacket();
+            handler(buf);
         });
     }
     


### PR DESCRIPTION
Split IR handlers into three handlers, only surfacing the one sending a single number. 
Did the same for cable. 
Added JSdoc and updated IR documentation

Tested with two Circuit playgrounds. (IR is very finicky)

<img width="270" alt="screen shot 2017-10-26 at 11 23 21 am" src="https://user-images.githubusercontent.com/16690124/32070117-1bf25cde-ba40-11e7-936e-39d1bc023270.png">


Fixes https://github.com/Microsoft/pxt-adafruit/issues/392