### PR TITLE
Fix serial default value

### DIFF
--- a/libs/base/serial.ts
+++ b/libs/base/serial.ts
@@ -27,7 +27,7 @@ namespace serial {
 
     /**
      * Write a name:value pair as a line of text to the serial port.
-     * @param name name of the value stream, eg: x
+     * @param name name of the value stream, eg: "x"
      * @param value to write
      */
     //% weight=88 blockGap=8


### PR DESCRIPTION
Change to "x" instead of x. Need to add quotes in the eg parameter.

Fix https://github.com/Microsoft/pxt-adafruit/issues/432