### PR TITLE
Fix sim shims

### DIFF
--- a/libs/base/sim/control.ts
+++ b/libs/base/sim/control.ts
@@ -1,6 +1,6 @@
 namespace pxsim.control {
-    export var runInBackground = thread.runInBackground;
-    export var delay = thread.pause;
+    export let runInBackground = thread.runInBackground;
+    export let delay = thread.pause;
 
     export function reset() {
         U.userError("reset not implemented in simulator yet")

--- a/libs/base/sim/loops.ts
+++ b/libs/base/sim/loops.ts
@@ -1,4 +1,4 @@
 namespace pxsim.loops {
-    export var pause = thread.pause;
-    export var forever = thread.forever;
+    export let pause = thread.pause;
+    export let forever = thread.forever;
 }

--- a/libs/base/sim/serial.ts
+++ b/libs/base/sim/serial.ts
@@ -17,14 +17,6 @@ namespace pxsim.serial {
     }
 
     export function writeBuffer(buffer: any) {
-        // TODO
-    }
-}
-
-namespace pxsim.BufferMethods {
-
-    export function toHex(buffer: any): string {
-        // TODO
-        return undefined;
+        // NOP, can't simulate
     }
 }

--- a/libs/base/sim/serial.ts
+++ b/libs/base/sim/serial.ts
@@ -20,3 +20,11 @@ namespace pxsim.serial {
         // TODO
     }
 }
+
+namespace pxsim.BufferMethods {
+
+    export function toHex(buffer: any): string {
+        // TODO
+        return undefined;
+    }
+}

--- a/libs/base/sim/serial.ts
+++ b/libs/base/sim/serial.ts
@@ -15,4 +15,8 @@ namespace pxsim.serial {
     export function writeValue(name: string, value: number) {
         writeString(name + ": " + value);
     }
+
+    export function writeBuffer(buffer: any) {
+        // TODO
+    }
 }

--- a/libs/buttons/buttons.cpp
+++ b/libs/buttons/buttons.cpp
@@ -65,7 +65,6 @@ AbstractButton *getButton(int id) {
     }
 }
 
-//%
 MultiButton *getMultiButton(int id, int pinA, int pinB, int flags) {
     auto btn = (MultiButton *)lookupComponent(id);
     if (btn == NULL) {

--- a/libs/buttons/sim/buttons.ts
+++ b/libs/buttons/sim/buttons.ts
@@ -88,6 +88,11 @@ namespace pxsim.pxtcore {
         // panic
         return undefined;
     }
+    
+    export function getMultiButton(buttonId: number, pinA: number, pinB: number): Button {
+        // TODO: this should return a MultiButton
+        return undefined;
+    }
 }
 
 namespace pxsim.ButtonMethods {
@@ -101,5 +106,12 @@ namespace pxsim.ButtonMethods {
 
     export function wasPressed(button: pxsim.Button): boolean {
         return (<CommonButton>button).wasPressed();
+    }
+}
+
+namespace pxsim.DigitalPinMethods {
+
+    export function pushButton(pin: pins.DigitalPin): Button {
+        return pxsim.pxtcore.getButtonByPin(pin.id);
     }
 }

--- a/libs/buttons/sim/buttons.ts
+++ b/libs/buttons/sim/buttons.ts
@@ -88,11 +88,6 @@ namespace pxsim.pxtcore {
         // panic
         return undefined;
     }
-    
-    export function getMultiButton(buttonId: number, pinA: number, pinB: number): Button {
-        // TODO: this should return a MultiButton
-        return undefined;
-    }
 }
 
 namespace pxsim.ButtonMethods {

--- a/libs/core/pins.cpp
+++ b/libs/core/pins.cpp
@@ -39,7 +39,6 @@ DevicePin *lookupPin(int pinName) {
     return getPin(pinName);
 }
 
-//%
 CodalComponent *lookupComponent(int id) {
     for (int i = 0; i < DEVICE_COMPONENT_COUNT; ++i) {
         if (CodalComponent::components[i] && CodalComponent::components[i]->id == id)

--- a/libs/core/sim/pins.ts
+++ b/libs/core/sim/pins.ts
@@ -37,7 +37,7 @@ namespace pxsim.DigitalPinMethods {
     * that this pin was either ``high`` or ``low``.
     */
     export function onPulsed(name: pins.DigitalPin, pulse: number, body: RefAction): void {
-        // TODO
+        // NOP, can't simulate
     }
 
     /**
@@ -46,7 +46,7 @@ namespace pxsim.DigitalPinMethods {
     * @param maximum duration in micro-seconds
     */
     export function pulseIn(name: pins.DigitalPin, pulse: number, maxDuration = 2000000): number {
-        // TODO
+        // Always return default value, can't simulate
         return 500;
     }
 
@@ -158,11 +158,6 @@ namespace pxsim.pins {
 
     export function createBuffer(sz: number) {
         return pxsim.BufferMethods.createBuffer(sz)
-    }
-
-    export function spiWrite(value: number): number {
-        // TODO
-        return 0;
     }
 
     export function i2cReadBuffer(address: number, size: number, repeat?: boolean): RefBuffer {

--- a/libs/music/sim/music.ts
+++ b/libs/music/sim/music.ts
@@ -43,7 +43,7 @@ namespace pxsim.music {
     }
 
     export function setTone(buffer: RefBuffer) {
-        // TODO
+        // TODO: implement set tone in the audio context
     }
 
     export function playTone(frequency: number, ms: number) {

--- a/libs/touch/sim/touch.ts
+++ b/libs/touch/sim/touch.ts
@@ -87,4 +87,10 @@ namespace pxsim.TouchButtonMethods {
         return button.value();
     }
 }
-    
+
+namespace pxsim.AnalogPinMethods {
+
+    export function touchButton(name: pins.AnalogPin): TouchButton {
+        return pxsim.pxtcore.getTouchButton(name.id);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-adafruit/issues/461

```
missing in sim: pxsim.BufferMethods.toHex
missing in sim: pxsim.serial.writeBuffer
missing in sim: pxsim.pxtcore.lookupComponent
missing in sim: pxsim.pxtcore.getMultiButton
missing in sim: pxsim.DigitalPinMethods.pushButton
missing in sim: pxsim.AnalogPinMethods.touchButton
```