### PR TITLE
Fixup the 'network' docs a bit

### DIFF
--- a/libs/cable/cable.ts
+++ b/libs/cable/cable.ts
@@ -26,7 +26,7 @@ namespace network {
     }
 
     /**
-     * Send an array of numbers over infrared. The array size has to be 32 bytes or less.
+     * Send an array of numbers over the cable. The array size has to be 32 bytes or less.
      * @param values 
      */
     //% parts="cable" group="Cable"
@@ -42,10 +42,10 @@ namespace network {
     }
 
     /**
-     * Run some code when the cable receives a number.
+     * Run some code when a number value comes across the cable.
      */
     //% blockId=on_cable_received block="on cable received" blockGap=8
-    //% help=network/on-cable-received
+    //% help=network/on-cable-received-number
     //% parts="cable" group="Cable"
     export function onCableReceivedNumber(handler: (num: number) => void) {
         onCablePacket(() => {

--- a/libs/cable/docs/reference/network/cable-send-number.md
+++ b/libs/cable/docs/reference/network/cable-send-number.md
@@ -6,11 +6,11 @@ Send a number value to another @boardname@ using a cable.
 network.cableSendNumber(0);
 ```
 
-The infrared transmitter on your board will send a number as part of a data message signaled by infrared light pulses. If another @boardname@ is waiting to receive an infrared signal, it will get this number in the data message it receives.
+The cable transmitter on your board will send a number as part of a data message signaled by pulses. If another @boardname@ is waiting to receive an cable message, it will get this number in the data message it receives.
 
 ## Parameters
 
-* **value**: the [number](types/number) to send to another @boardname@ using infrared.
+* **value**: the [number](types/number) to send to another @boardname@ using a cable.
 
 ## Example #ex1
 
@@ -26,7 +26,7 @@ for (let i = 0; i <= 9; i++) {
 
 ## See also
 
-[``||network:on cable received||``](/reference/network/on-cable-received)
+[``||network:on cable received number||``](/reference/network/on-cable-received-number)
 
 ```package
 cable

--- a/libs/cable/docs/reference/network/on-cable-packet-received.md
+++ b/libs/cable/docs/reference/network/on-cable-packet-received.md
@@ -1,37 +1,39 @@
 # on Cable Received
 
-Run some code when a data message comes into the cable.
+Run some code when a data message comes across the cable.
 
 ```sig
-network.onCableReceived(function (num: number) {
+network.onCablePacketReceived(function ({ receivedNumber }) { 
 	
 })
 ```
 
-The infrared receiver gets a data message sent from another board. The message is called a
+The cable receiver gets a data message sent from another board. The message is called a
 _packet_. The packet has both the data from the sender and some other information used to help
 transmit the data correctly between the boards. You only need to know what the program on the other
 board wants to send you so your program just receives the _data_ part of the packet.
 
 ## Parameters
 
-* **handler**: the [function](/types/function) that has the code to run when the infrared data message is received.
+* **handler**: the [function](/types/function) that has the code to run when the cable data message is received.
 This function takes 3 optional arguments:
 * ``num``: a single [number](/types/number) value from the sender.
 * ``nums``: an array of [numbers](/types/number) from the sender.
 * ``buffer``: a group of data values with no specific [type](/types). Both the sender and receiver agree about what kind information is in this buffer.
 
 ### ~hint
-Right now, just use ``num`` as your data part from the packet you receive over infrared.
+Right now, just use ``num`` as your data part from the packet you receive over the cable.
 ### ~
 
 ## Example #ex1
 
-Show the value of a number received from an infrared data message. The number is shown by lighting the same number of pixels on the pixel strip.
+Show the value of a number received from an cable data message. The number is shown by lighting the same number of pixels on the pixel strip.
 
 ```blocks
-network.onCableReceived(function (num) {
-    light.pixels.graph(num, 9);
+let strip = light.createStrip();
+
+network.onCableReceivedNumber(function (num) {
+    strip.graph(num, 9);
 })
 ```
 

--- a/libs/cable/docs/reference/network/on-cable-received-number.md
+++ b/libs/cable/docs/reference/network/on-cable-received-number.md
@@ -1,0 +1,40 @@
+# on Cable Received Number
+
+Run some code when a data message comes across the cable.
+
+```sig
+network.onCableReceivedNumber(function (num: number) {
+	
+})
+```
+
+The cable receiver gets a data message sent from another board. The message is called a
+_packet_. The packet has both the data from the sender and some other information used to help
+transmit the data correctly between the boards. You only need to know what the program on the other
+board wants to send you so your program just receives the _data_ part of the packet.
+
+## Parameters
+
+* **handler**: the [function](/types/function) that has the code to run when the cable data message is received.
+This function takes 1 argument:
+* ``num``: a single [number](/types/number) value from the sender.
+
+## Example #ex1
+
+Show the value of a number received from an cable data message. The number is shown by lighting the same number of pixels on the pixel strip.
+
+```blocks
+let strip = light.createStrip();
+
+network.onCableReceivedNumber(function (num) {
+    strip.graph(num, 9);
+})
+```
+
+## See also
+
+[``||network:cable send number||``](/reference/network/cable-send-number)
+
+```package
+cable
+```

--- a/libs/infrared/docs/reference/network/on-infrared-packet-received.md
+++ b/libs/infrared/docs/reference/network/on-infrared-packet-received.md
@@ -1,0 +1,48 @@
+# on Infrared Packet Received
+
+Run some code when a data message comes into the infrared receiver.
+
+```sig
+network.onInfraredPacketReceived(function ({ receivedNumber }) { 
+	
+})
+```
+
+The infrared receiver gets a data message sent from another board. The message is called a
+_packet_. The packet has both the data from the sender and some other information used to help
+transmit the data correctly between the boards. You only need to know what the program on the other
+board wants to send you so your program just receives the _data_ part of the packet.
+
+## Parameters
+
+* **handler**: the [function](/types/function) that has the code to run when the infrared data message is received.
+This function takes 3 optional arguments:
+* ``num``: a single [number](/types/number) value from the sender.
+* ``nums``: an array of [numbers](/types/number) from the sender.
+* ``buffer``: a group of data values with no specific [type](/types). Both the sender and receiver agree about what kind information is in this buffer.
+
+### ~hint
+Right now, just use ``num`` as your data part from the packet you receive over infrared.
+### ~
+
+## Example #ex1
+
+Show the value of a number received from an infrared data message. The number is shown by lighting the same number of pixels on the pixel strip.
+
+```blocks
+let strip = light.createStrip();
+
+network.onInfraredPacketReceived(function ({ receivedNumber }) { 
+    if (receivedNumber > 0) { 
+        strip.graph(num, 9);
+    } 
+})
+```
+
+## See also
+
+[``||network:infrared send number||``](/reference/network/infrared-send-number)
+
+```package
+infrared
+```

--- a/libs/infrared/docs/reference/network/on-infrared-received-number.md
+++ b/libs/infrared/docs/reference/network/on-infrared-received-number.md
@@ -1,6 +1,6 @@
-# on Infrared Packet Received
+# on Infrared Received Number
 
-Run some code when a data message comes into the infrared receiver.
+Run some code when a number from a data message comes into the infrared receiver.
 
 ```sig
 network.onInfraredReceivedNumber(function (num) {
@@ -16,22 +16,20 @@ board wants to send you so your program just receives the _data_ part of the pac
 ## Parameters
 
 * **handler**: the [function](/types/function) that has the code to run when the infrared data message is received.
-This function takes 3 optional arguments:
-* ``num``: a single [number](/types/number) value from the sender.
-* ``nums``: an array of [numbers](/types/number) from the sender.
-* ``buffer``: a group of data values with no specific [type](/types). Both the sender and receiver agree about what kind information is in this buffer.
-
-### ~hint
-Right now, just use ``num`` as your data part from the packet you receive over infrared.
-### ~
+This function has one argument:
+* ``num``: a single [number](/types/number) value received from the sender.
 
 ## Example #ex1
 
 Show the value of a number received from an infrared data message. The number is shown by lighting the same number of pixels on the pixel strip.
 
 ```blocks
+let strip = light.createStrip();
+
 network.onInfraredReceivedNumber(function (num) {
-    light.pixels.graph(num, 9);
+    if (num > 0) { 
+        strip.graph(num, 9);
+    } 
 })
 ```
 

--- a/libs/infrared/ir.ts
+++ b/libs/infrared/ir.ts
@@ -45,7 +45,7 @@ namespace network {
      * Run some code when the infrared receiver gets a number.
      */
     //% blockId=ir_on_infrared_received block="on infrared received" blockGap=8
-    //% help=network/on-infrared-received
+    //% help=network/on-infrared-received-number
     //% parts="ir" group="Infrared"
     export function onInfraredReceivedNumber(handler: (num: number) => void) {
         onInfraredPacket(() => {


### PR DESCRIPTION
- [x] Make _onInfraredReceivedNumber.md_ and _onCableReceivedNumber.md_ for the actual API.
- [x] Bring back _onXxxPacketReceived_ as a stub for the 'deprecated' functions.
- [x] Fix examples and references to 'cable'.
- [x] Set help paths.