### PR TITLE
add plumbing for event flags

### DIFF
--- a/libs/base/control.cpp
+++ b/libs/base/control.cpp
@@ -1,5 +1,6 @@
 #include "pxtbase.h"
 
+
 namespace control {
     /**
     * Gets the number of milliseconds elapsed since power on.
@@ -17,9 +18,9 @@ namespace control {
      */
     //% weight=20 blockGap=8 blockId="control_on_event" block="on event|from %src|with value %value"
     //% blockExternalInputs=1
-    //% help="control/on-event"
-    void onEvent(int src, int value, Action handler) {
-        registerWithDal(src, value, handler);
+    //% help="control/on-event"          
+    void onEvent(int src, int value, Action handler, int flags = 16) { // EVENT_LISTENER_DEFAULT_FLAGS
+        registerWithDal(src, value, handler, flags);
     }
 
     /**

--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -80,7 +80,7 @@ int current_time_ms();
 void initRuntime();
 void sendSerial(const char *data, int len);
 int getSerialNumber();
-void registerWithDal(int id, int event, Action a);
+void registerWithDal(int id, int event, Action a, int flags = 16); // EVENT_LISTENER_DEFAULT_FLAGS
 void runInBackground(Action a);
 void runForever(Action a);
 void waitForEvent(int id, int event);

--- a/libs/base/sim/core.ts
+++ b/libs/base/sim/core.ts
@@ -14,7 +14,8 @@ namespace pxsim {
 
 
 namespace pxsim.pxtcore {
-    export function registerWithDal(id: number, evid: number, handler: RefAction) {
+    // TODO: add in support for mode, as in CODAL
+    export function registerWithDal(id: number, evid: number, handler: RefAction, mode: number = 0) {
         board().bus.listen(id, evid, handler);
     }
     export function getPin(id: number) : pxsim.Pin {

--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -66,10 +66,10 @@ void dispatchEvent(Event e) {
         runAction1(curr->action, fromInt(e.value));
 }
 
-void registerWithDal(int id, int event, Action a) {
+void registerWithDal(int id, int event, Action a, int flags) {
     // first time?
     if (!findBinding(id, event))
-        devMessageBus.listen(id, event, dispatchEvent);
+        devMessageBus.listen(id, event, dispatchEvent, flags);
     setBinding(id, event, a);
 }
 


### PR DESCRIPTION
CODAL supports executing an event under different concurrency/queueing models.  This change exposes the CODAL events flags as a default parameter.  No change of behavior for existing targets.  For example of use, see 

https://makecode.com/_1xWL07DrvM23