### PR TITLE
do not enforce color on show-animation-frame

### DIFF
--- a/libs/light/docs/reference/light/neopixelstrip/show-animation-frame.md
+++ b/libs/light/docs/reference/light/neopixelstrip/show-animation-frame.md
@@ -8,6 +8,8 @@ light.createStrip().showAnimationFrame(light.animation(LightAnimation.Rainbow))
 You can show the colors from a pixel animation without having to play the whole animation. Just pick
 one of the built-in animations to see its first frame.
 
+If the strip is buffered, renders the color but does not call ``show`` to allow for other animation frames to be rendered.
+
 ## Parameters
 
 * **animation**: a built-in light animation to show a frame from on the pixels.

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -596,11 +596,8 @@ namespace light {
                 this._lastAnimation = animation;
                 renderer = this._lastAnimationRenderer = animation.createRenderer(this);
             }
-            const buf = this.buffered();
-            this.setBuffered(false);
             renderer();
-            this.setBuffered(buf);
-            this.show();
+            this.autoShow();
         }
 
         /**


### PR DESCRIPTION
show animation uses "autoShow" instead of forcing the buffering mode. This allows for calling multiple animation frame on different ranges before showing the entire strip.