### PR TITLE
Fix type of control.deviceDalVersion in docs.

### DIFF
--- a/libs/base/docs/reference/control/device-dal-version.md
+++ b/libs/base/docs/reference/control/device-dal-version.md
@@ -8,7 +8,7 @@ control.deviceDalVersion()
 
 ## Returns
 
-* a [number](/types/number) that is the version of the system software (DAL) on the board.
+* a [string](/types/string) that represents the version of the system software (DAL) on the board.
 
 ## Example
 


### PR DESCRIPTION
A minor fix to the docs:
As implied by the original example, the return type is string, not number.