### PR TITLE
Remove reference to micro:bit in usb.md

### DIFF
--- a/libs/core/docs/device/usb.md
+++ b/libs/core/docs/device/usb.md
@@ -2,7 +2,7 @@
 
 While you're writing and testing your programs, you'll mostly be [running them
 in the simulator](/device/simulator), but once you've finished your program you
-can **compile** it and run it on your micro:bit.
+can **compile** it and run it on your @boardname@.
 
 The basic steps are:
 


### PR DESCRIPTION
Intro paragraph referred to uploading code on a micro:bit. I replaced that with @boardname@ to eliminate possible confusion