### PR TITLE
adding a fork block

### DIFF
--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -163,6 +163,7 @@ namespace control {
  * @param condition condition to test for
  * @param timeOut if positive, maximum duration to wait for in milliseconds
  */
+//% weight=98
 //% blockId="pxt_pause_until"
 function pauseUntil(condition: () => boolean, timeOut?: number): void {
     if (!condition || condition()) return; // optimistic path
@@ -175,3 +176,18 @@ function pauseUntil(condition: () => boolean, timeOut?: number): void {
  */
 //% shim=@hex
 function hex(lits: any, ...args: any[]): Buffer { return null }
+
+namespace loops {
+    /**
+     * Starts executing the code in parralel
+     * @param a 
+     */
+    //% weight=19
+    //% blockId=pxt_fork block="fork"
+    //% handlerStatement=1
+    //% help=loops/fork
+    export function fork(a: () => void) {
+        control.runInBackground(a);
+    }
+
+}

--- a/libs/base/docs/reference/loops/fork.md
+++ b/libs/base/docs/reference/loops/fork.md
@@ -1,0 +1,14 @@
+# fork
+
+Schedules other code to run and continues the execution.
+
+```sig
+loops.fork(() => {})
+```
+
+## Parameters
+
+* **a**: the code to run in the background.
+
+## Example #exsection
+


### PR DESCRIPTION
Allows to fork execution from within a code block -- rather than a top level block like control.runInBackground.