### PR TITLE
add 500ms sleep on start to allow HID interfaces to "settle"

### DIFF
--- a/libs/base/pxt.cpp
+++ b/libs/base/pxt.cpp
@@ -551,15 +551,16 @@ void exec_binary(unsigned *pc) {
 
     initRuntime();
 
+    // sleep needed for HID interfaces
+    pxt::sleep_ms(500);
+
     ((unsigned (*)())startptr)();
 
 #ifdef PXT_MEMLEAK_DEBUG
     pxt::debugMemLeaks();
 #endif
 
-    while (1) {
-        sleep_ms(10000);
-    }
+    pxt::releaseFiber();
 }
 
 void start() {

--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -91,6 +91,7 @@ extern "C" void target_panic(int error_code);
 extern "C" void target_reset();
 void sleep_ms(unsigned ms);
 void sleep_us(uint64_t us);
+void releaseFiber();
 int current_time_ms();
 void initRuntime();
 void sendSerial(const char *data, int len);

--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -70,6 +70,10 @@ void fiberDone(void *a) {
     release_fiber();
 }
 
+void releaseFiber() {
+    release_fiber();    
+}
+
 void sleep_ms(unsigned ms) {
     fiber_sleep(ms);
 }


### PR DESCRIPTION
- [x] add 50ms wait
- [x] use release_fiber instead of infinite sleep