### PR TITLE
Only enable serial on webusb after we got some command

### DIFF
--- a/libs/core/hf2.cpp
+++ b/libs/core/hf2.cpp
@@ -209,6 +209,8 @@ int HF2::endpointRequest()
 
 #define checkDataSize(str, add) usb_assert(sz == 8 + (int)sizeof(cmd->str) + (int)(add))
 
+    gotSomePacket = true;
+
     switch (cmdId) {
     case HF2_CMD_INFO:
         return sendResponseWithData(uf2_info(), strlen(uf2_info()));
@@ -283,7 +285,7 @@ int HF2::endpointRequest()
     return sendResponse(0);
 }
 
-HF2::HF2(HF2_Buffer &p) : USBHID(), pkt(p) {}
+HF2::HF2(HF2_Buffer &p) : USBHID(), pkt(p), gotSomePacket(false) {}
 
 //
 //
@@ -312,6 +314,12 @@ static const InterfaceInfo ifaceInfoWeb = {
 const InterfaceInfo *WebHF2::getInterfaceInfo()
 {
     return &ifaceInfoWeb;
+}
+
+int WebHF2::sendSerial(const void *data, int size, int isError)
+{
+    if (!gotSomePacket) return DEVICE_OK;
+    return HF2::sendSerial(data, size, isError);
 }
 
 //

--- a/libs/core/hf2.h
+++ b/libs/core/hf2.h
@@ -25,6 +25,7 @@ class HF2 : public codal::USBHID
 {
 public:
     HF2_Buffer &pkt;
+    bool gotSomePacket;
 
     int sendResponse(int size);
     int send(const void *data, int size, int flag);
@@ -35,8 +36,7 @@ public:
     virtual int endpointRequest();
     virtual int stdRequest(UsbEndpointIn &ctrl, USBSetup& setup);
     virtual const InterfaceInfo *getInterfaceInfo();
-
-    int sendSerial(const void *data, int size, int isError = 0);
+    virtual int sendSerial(const void *data, int size, int isError = 0);
 };
 
 class WebHF2 : public HF2
@@ -45,6 +45,7 @@ public:
     WebHF2(HF2_Buffer &pkt);
     virtual const InterfaceInfo *getInterfaceInfo();
     virtual bool enableWebUSB() { return true; }
+    virtual int sendSerial(const void *data, int size, int isError = 0);
 };
 
 #endif


### PR DESCRIPTION
This seems to fix issues with WebUSB serial lockups - https://github.com/Microsoft/pxt-adafruit/issues/632
