### PR TITLE
Don't vent HID serial packets into space - wait for some HF2 message

### DIFF
--- a/libs/core/hf2.cpp
+++ b/libs/core/hf2.cpp
@@ -86,6 +86,7 @@ const InterfaceInfo *HF2::getInterfaceInfo()
 
 int HF2::sendSerial(const void *data, int size, int isError)
 {
+    if (!gotSomePacket) return DEVICE_OK;
     return send(data, size, isError ? HF2_FLAG_SERIAL_ERR : HF2_FLAG_SERIAL_OUT);
 }
 
@@ -314,12 +315,6 @@ static const InterfaceInfo ifaceInfoWeb = {
 const InterfaceInfo *WebHF2::getInterfaceInfo()
 {
     return &ifaceInfoWeb;
-}
-
-int WebHF2::sendSerial(const void *data, int size, int isError)
-{
-    if (!gotSomePacket) return DEVICE_OK;
-    return HF2::sendSerial(data, size, isError);
 }
 
 //

--- a/libs/core/hf2.h
+++ b/libs/core/hf2.h
@@ -36,7 +36,7 @@ public:
     virtual int endpointRequest();
     virtual int stdRequest(UsbEndpointIn &ctrl, USBSetup& setup);
     virtual const InterfaceInfo *getInterfaceInfo();
-    virtual int sendSerial(const void *data, int size, int isError = 0);
+    int sendSerial(const void *data, int size, int isError = 0);
 };
 
 class WebHF2 : public HF2
@@ -45,7 +45,6 @@ public:
     WebHF2(HF2_Buffer &pkt);
     virtual const InterfaceInfo *getInterfaceInfo();
     virtual bool enableWebUSB() { return true; }
-    virtual int sendSerial(const void *data, int size, int isError = 0);
 };
 
 #endif


### PR DESCRIPTION
  see https://github.com/Microsoft/pxt-adafruit/issues/632

I think this should fix the issue above, but it might need testing if we're still getting serial data in WinRT app.