### PR TITLE
Make forever and pause be top level

### DIFF
--- a/libs/accelerometer/docs/reference/input/acceleration.md
+++ b/libs/accelerometer/docs/reference/input/acceleration.md
@@ -32,7 +32,7 @@ Show the acceleration of the @boardname@ with a bar graph.
 
 ```blocks
 let pixels = light.createStrip();
-loops.forever(() => {
+forever(() => {
     pixels.graph(input.acceleration(Dimension.X), 1023)
 })
 ```

--- a/libs/accelerometer/docs/reference/input/rotation.md
+++ b/libs/accelerometer/docs/reference/input/rotation.md
@@ -32,7 +32,7 @@ it is levelled, the @boardname@ shows turns blue.
 let roll = 0
 let pitch = 0
 let pixels = light.createStrip();
-loops.forever(() => {
+forever(() => {
     pitch = input.rotation(Rotation.Pitch)
     roll = input.rotation(Rotation.Roll)
     if (Math.abs(pitch) < 10 && Math.abs(roll) < 10) {

--- a/libs/accelerometer/docs/reference/input/set-accelerometer-range.md
+++ b/libs/accelerometer/docs/reference/input/set-accelerometer-range.md
@@ -22,7 +22,7 @@ will measure up to 4 g. Then, write to **serial** the acceleration measured when
 
 ```blocks
 input.setAccelerometerRange(AcceleratorRange.FourG)
-loops.forever(() => {
+forever(() => {
     serial.writeNumber(input.acceleration(Dimension.X))
 })
 ```

--- a/libs/automation/behaviors.ts
+++ b/libs/automation/behaviors.ts
@@ -81,7 +81,7 @@ namespace automation {
             this._state = BehaviorManagerState.StopPending;
             pauseUntil(() => this._state == BehaviorManagerState.Stopped);
         }
-        
+
         private run() {
             let elapsed = 0;
             // this is the main control loop
@@ -91,7 +91,7 @@ namespace automation {
 
                 // update all behaviors, even supprsed
                 for (let i = 0; i < n; ++i)
-                    bvs[i].update(elapsed);                
+                    bvs[i].update(elapsed);
 
                 // poll non-suppressed behaviors
                 for (let i = 0; i < n; ++i) {
@@ -122,7 +122,7 @@ namespace automation {
                 this._behaviors[j].active = false;
             }
             // allow events to percolate
-            loops.pause(1);
+            pause(1);
 
             // activate current behavior
             this._behaviors[i].active = true;

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -69,7 +69,7 @@ namespace control {
             while (this.running
                 && !this.isCancelled(evid)
                 && render()) {
-                loops.pause(this.interval);
+                pause(this.interval);
             }
 
             // check if the animation hasn't been cancelled since we've been waiting
@@ -132,7 +132,7 @@ namespace control {
                     }
                 }
             }
-            loops.pause(50);
+            pause(50);
         }
         // release fiber
         _pollEventQueue = undefined;

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -11,7 +11,7 @@ namespace control {
     export function runInBackground(a: () => void) {
         control.runInParallel(a);
     }
-    
+
     /**
      * Display an error code and stop the program.
      * @param code an error number to display. eg: 5
@@ -176,6 +176,27 @@ function pauseUntil(condition: () => boolean, timeOut?: number): void {
     if (!condition || condition()) return; // optimistic path
     if (!timeOut) timeOut = 0;
     control.__queuePollEvent(timeOut, condition, undefined);
+}
+
+/**
+ * Repeats the code forever in the background. On each iteration, allows other codes to run.
+ * @param body code to execute
+ */
+//% help=loops/forever weight=100 afterOnStart=true blockNamespace="loops"
+//% blockId=forever block="forever" blockAllowMultiple=1
+function forever(a: () => void): void {
+    loops.forever(a);
+}
+
+/**
+ * Pause for the specified time in milliseconds
+ * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
+ */
+//% help=loops/pause weight=99
+//% async block="pause %pause=timePicker|ms"
+//% blockId=device_pause blockNamespace="loops"
+function pause(ms: number): void {
+    loops.pause(ms);
 }
 
 /**

--- a/libs/base/docs/reference/console/log.md
+++ b/libs/base/docs/reference/console/log.md
@@ -8,7 +8,7 @@ console.log("");
 
 A line of text is a string that has two special characters added at the end: _carriage return_
 and _line feed_. These characters are really just codes that mean start a new line.
-Sometimes they appear in code as ``"\r\n"``. 
+Sometimes they appear in code as ``"\r\n"``.
 
 After using ``||console:log||``, any new text written to the console output will begin on a new line.
 
@@ -24,7 +24,7 @@ Write two greeting messages to the console output.
 
 ```blocks
 console.log("How are you today?");
-loops.pause(5000);
+pause(5000);
 console.log("Well that's great! I'm doing well too.");
 ```
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -18,9 +18,9 @@ You can insist that your program will stop at an assert block if a certain condi
 Stop the program if a sensor connected to pin `A0` sends a low (`0`) signal.
 
 ```blocks
-loops.forever(function () {
+forever(function () {
     control.assert((pins.A0.digitalRead() == 1), 15)
-    loops.pause(1000)
+    pause(1000)
 })
 ```
 

--- a/libs/base/docs/reference/control/on-event.md
+++ b/libs/base/docs/reference/control/on-event.md
@@ -75,7 +75,7 @@ let pixels = light.createStrip()
 
 control.runInParallel(() => {
     for (let i = 0; i < 2; i++) {
-        loops.pause(1000)
+        pause(1000)
     control.raiseEvent(pixelLighter, i)
     }
 })

--- a/libs/base/docs/reference/control/raise-event.md
+++ b/libs/base/docs/reference/control/raise-event.md
@@ -43,7 +43,7 @@ let pixels = light.createStrip();
 
 control.runInParallel(() => {
     for (let i = 0; i < 2; i++) {
-        loops.pause(1000);
+        pause(1000);
         control.raiseEvent(pixelLighter, i);
     }
 })

--- a/libs/base/docs/reference/control/run-in-parallel.md
+++ b/libs/base/docs/reference/control/run-in-parallel.md
@@ -21,7 +21,7 @@ let pixels = light.createStrip();
 control.runInParallel(() => {
     while (spinit) {
         pixels.move(LightMove.Rotate, 1);
-        loops.pause(200);
+        pause(200);
     }
 })
 ```
@@ -34,9 +34,9 @@ let spinit = true;
 let pixels = light.createStrip();
 
 pixels.setPixelColor(0, Colors.Blue);
-loops.pause(5000);
+pause(5000);
 pixels.setPixelColor(0, Colors.Blue);
-loops.pause(5000);
+pause(5000);
 spinit = false;
 pixels.clear();
 ```
@@ -68,13 +68,13 @@ input.buttonA.onEvent(ButtonEvent.Click, () => {
         pixels.setPixelColor(0, Colors.Blue);
         while (spinit) {
             pixels.move(LightMove.Rotate, 1);
-            loops.pause(250);
+            pause(250);
         }
     })
 })
 spinit = true;
 for (let i = 0; i < 5; i++) {
-    loops.pause(1000);
+    pause(1000);
     pixels.setPixelColor(0, Colors.Blue);
 }
 ```

--- a/libs/base/docs/reference/control/wait-for-event.md
+++ b/libs/base/docs/reference/control/wait-for-event.md
@@ -47,7 +47,7 @@ let pixels = light.createStrip();
 
 control.runInParallel(() => {
     while (true) {
-        loops.pause(2000);
+        pause(2000);
         control.raiseEvent(myTimer, timerTimeout);
     }
 })

--- a/libs/base/docs/reference/loops/forever.md
+++ b/libs/base/docs/reference/loops/forever.md
@@ -3,7 +3,7 @@
 Run a part of the program in the background and keep running it over again.
 
 ```sig
-loops.forever(() => {
+forever(() => {
 })
 ```
 
@@ -22,12 +22,12 @@ Rotate a blue pixel along the pixel strip (one pixel at a time) and keep it rota
 ```blocks
 let lightSpot = 0;
 let pixels = light.createStrip();
-loops.forever(() => {
+forever(() => {
     if (lightSpot == light.pixels.length()) {
         lightSpot = 0;
     }
     pixels.setPixelColor(lightSpot, Colors.Blue);
-    loops.pause(500);
+    pause(500);
     pixels.setPixelColor(lightSpot, Colors.Black);
     lightSpot++;
 })

--- a/libs/base/docs/reference/loops/pause.md
+++ b/libs/base/docs/reference/loops/pause.md
@@ -3,7 +3,7 @@
 Pause a part of the program for some number of milliseconds.
 
 ```sig
-loops.pause(400)
+pause(400)
 ```
 
 When code in a block comes to a ``||control:pause||``, it will wait the amount of time you tell it to. Code
@@ -22,7 +22,7 @@ Light up to `5` pixels but wait one-half second before lighting each pixel.
 let pixels = light.createStrip();
 for (let i = 0; i < 5; i++) {
     pixels.setPixelColor(i, Colors.Green)
-    loops.pause(500)
+    pause(500)
 }
 ```
 

--- a/libs/base/docs/reference/serial/write-line.md
+++ b/libs/base/docs/reference/serial/write-line.md
@@ -8,11 +8,11 @@ serial.writeLine("");
 
 A line of text is string that has two special characters added at the end: _carriage return_
 and _line feed_. These characters are really just codes that mean start a new line.
-Sometimes they appear in code as ``"\r\n"``. 
+Sometimes they appear in code as ``"\r\n"``.
 
 After using a ``||write line||``, any new text written to the serial port will begin on a new line.
 
-With ``||write line||``, the new line characters are automatically added for you. You only need to 
+With ``||write line||``, the new line characters are automatically added for you. You only need to
 give the text you want to write.
 
 ## Parameters
@@ -25,7 +25,7 @@ Write two greeting messages to the serial port.
 
 ```blocks
 serial.writeLine("How are you today?");
-loops.pause(5000);
+pause(5000);
 serial.writeLine("Well that's great! I'm doing well too.");
 ```
 

--- a/libs/base/docs/reference/serial/write-number.md
+++ b/libs/base/docs/reference/serial/write-number.md
@@ -19,9 +19,9 @@ started when it's finished.
 Write a 10-digit number to the serial port many, many times.
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     serial.writeNumber(1234567890);
-    loops.pause(5000);
+    pause(5000);
 });
 ```
 

--- a/libs/base/docs/reference/serial/write-string.md
+++ b/libs/base/docs/reference/serial/write-string.md
@@ -18,9 +18,9 @@ a new line.
 Writes the word `JUMBO` to the serial port a bunch of times, without any new lines.
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     serial.writeString("JUMBO");
-    loops.pause(1000);
+    pause(1000);
 });
 ```
 

--- a/libs/base/loops.cpp
+++ b/libs/base/loops.cpp
@@ -6,8 +6,8 @@ namespace loops {
  * Repeats the code forever in the background. On each iteration, allows other codes to run.
  * @param body code to execute
  */
-//% help=loops/forever weight=100 afterOnStart=true
-//% blockId=forever block="forever" blockAllowMultiple=1
+//% help=loops/forever weight=100 afterOnStart=true deprecated=true
+//% blockId=forever_deprecated block="forever" blockAllowMultiple=1
 void forever(Action a) {
     runForever(a);
 }
@@ -16,9 +16,9 @@ void forever(Action a) {
  * Pause for the specified time in milliseconds
  * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
  */
-//% help=loops/pause weight=99
+//% help=loops/pause weight=99 deprecated=true
 //% async block="pause %pause=timePicker|ms"
-//% blockId=device_pause
+//% blockId=device_pause_deprecated
 void pause(int ms) {
     if (ms < 0) return;
     sleep_ms(ms);

--- a/libs/base/test.ts
+++ b/libs/base/test.ts
@@ -6,6 +6,6 @@ let minus = i - f
 let r = Math.random()
 let ri = Math.randomRange(5, 10)
 
-loops.forever(() => {
-    loops.pause(100)
+forever(() => {
+    pause(100)
 })

--- a/libs/buttons/docs/reference/input/button/is-pressed.md
+++ b/libs/buttons/docs/reference/input/button/is-pressed.md
@@ -31,7 +31,7 @@ Set all the pixels to green when button `A` is pressed. When the button is not p
 ```blocks
 let pixels = light.createStrip();
 
-loops.forever(function() {
+forever(function() {
     if (input.buttonA.isPressed()) {
         pixels.setAll(Colors.Green);
     } else {

--- a/libs/cable/docs/reference/network/cable-send-number.md
+++ b/libs/cable/docs/reference/network/cable-send-number.md
@@ -20,7 +20,7 @@ receiving board think about the number it just got.
 ```blocks
 for (let i = 0; i <= 9; i++) {
     network.cableSendNumber(i);
-    loops.pause(500);
+    pause(500);
 }
 ```
 

--- a/libs/core/docs/reference/pins/analog-read.md
+++ b/libs/core/docs/reference/pins/analog-read.md
@@ -7,7 +7,7 @@ pins.A0.analogRead()
 ```
 
 Your board can read a number value for a _signal_ on an analog pin. A signal is some amount of voltage
-measured by a circuit on your board. The value for that signal doesn't actually match its 
+measured by a circuit on your board. The value for that signal doesn't actually match its
 voltage, but it's a number that means how much signal is there. The number you read for the signal
 is something between `0` and `1023`.  A `0` is no signal and `1023` is a full signal.
 
@@ -23,12 +23,12 @@ strip. Also, output the value to the serial port.
 ```blocks
 let pixels = light.createStrip();
 
-loops.forever(function() {
+forever(function() {
     let signal = pins.A2.analogRead()
     pixels.graph(signal, 1023)
     serial.writeValue("signal", signal)
-    loops.pause(1000)
-}) 
+    pause(1000)
+})
 ```
 
 ## See also

--- a/libs/core/docs/reference/pins/analog-write.md
+++ b/libs/core/docs/reference/pins/analog-write.md
@@ -23,11 +23,11 @@ Create a sawtooth wave signal on pin `A0`.
 
 ```blocks
 let i = 0
-loops.forever(() => {
+forever(() => {
     i = 0
     while (i <= 1023) {
         pins.A0.analogWrite(i)
-        loops.pause(100)
+        pause(100)
         if (i > 0) {
             i += 128
         } else {

--- a/libs/core/docs/reference/pins/i2c-read-number.md
+++ b/libs/core/docs/reference/pins/i2c-read-number.md
@@ -6,7 +6,7 @@ Read a number from an address on the I2C bus.
 pins.i2cReadNumber(0, NumberFormat.Int8LE, false)
 ```
 
-If your board has pins that say **SDA** and **SCL**, then you can read numbers from 
+If your board has pins that say **SDA** and **SCL**, then you can read numbers from
 other chips that are not on your board. The **SDA** and **SCL** pins connect to other chips
 ([ICs](https://wikipedia.org/wiki/Integrated_circuit)) that also have these same pins. This connection
 is called [**I2C**](https://wikipedia.org/wiki/I2C). It only needs two wires to read or write
@@ -50,16 +50,16 @@ bytes in size depending on what type you asked for in **format**.
 ## Example #ex1
 
 Connect a temperature sensor on a breadboard to the **SDA** and **SCL** pins on your board. Set your sensor
-to respond to address `24`. Every 30 seconds, read the temperature from the sensor and write it as Fahrenheit 
+to respond to address `24`. Every 30 seconds, read the temperature from the sensor and write it as Fahrenheit
 to the serial port.
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     let celcius = pins.i2cReadNumber(24, NumberFormat.Int8LE, false)
     let fahr = Math.map(celcius, 0, 100, 32, 212)
     serial.writeValue("Degrees F", fahr)
-    loops.pause(30000)
-}) 
+    pause(30000)
+})
 ```
 
 ## See Also

--- a/libs/core/docs/reference/pins/i2c-write-number.md
+++ b/libs/core/docs/reference/pins/i2c-write-number.md
@@ -6,7 +6,7 @@ Write a number to an address on the I2C bus.
 pins.i2cWriteNumber(0, NumberFormat.Int8LE, false)
 ```
 
-If your board has pins that say **SDA** and **SCL**, then you can write numbers to 
+If your board has pins that say **SDA** and **SCL**, then you can write numbers to
 other chips that are not on your board. The **SDA** and **SCL** pins connect to other chips
 ([ICs](https://wikipedia.org/wiki/Integrated_circuit)) that also have these same pins. This connection
 is called [**I2C**](https://wikipedia.org/wiki/I2C). It only needs two wires to read or write
@@ -36,8 +36,8 @@ sure that all of the chips are using a different number so they respond to their
 ## Parameters
 
 * **address**: a [number](types/number) between `8` and `123` that is the address of a chip on the I2C bus.
-* **value**: a [number](types/number) a number to write to the I2C bus. It's size (number of bytes) depends 
-on what you say in **format**. 
+* **value**: a [number](types/number) a number to write to the I2C bus. It's size (number of bytes) depends
+on what you say in **format**.
 * **format**: the type of number you will write to the bus, like: `Int8LE`.
 * **repeated**: a [boolean](/types/boolean) value, `true` or `false`, to say if you want to read
 again right away.
@@ -52,11 +52,11 @@ about every second.
 
 ```blocks
 let i = 0
-loops.forever(() => {
+forever(() => {
     i = 0
     while (i <= 4095) {
         pins.i2cWriteNumber(98, i, NumberFormat.UInt16LE, false)
-        loops.pause(6)
+        pause(6)
         if (i > 0) {
             i += 256
         } else {

--- a/libs/core/docs/reference/pins/on-pulsed.md
+++ b/libs/core/docs/reference/pins/on-pulsed.md
@@ -32,7 +32,7 @@ pins.D4.setPull(PinPullMode.PullUp)
 
 pins.D4.onPulsed(PulseValue.Low, () => {
     pins.D13.digitalWrite(true)
-    loops.pause(250)
+    pause(250)
     pins.D13.digitalWrite(false)
 })
 ```

--- a/libs/core/docs/reference/pins/pulse-in.md
+++ b/libs/core/docs/reference/pins/pulse-in.md
@@ -14,7 +14,7 @@ input value to keep the pin at is when it's not pulsed. You do this by giving it
 with [``||pins:set pull||``](/reference/pins/set-pull).
 
 You wait for a pulse on a pin, going from either `high` to `low`, or `low` to `high`. A pulse **value** of `high` is
-used when you are waiting for an input change from `low` to `high`. A pulse **value** of `low` is used to wait for 
+used when you are waiting for an input change from `low` to `high`. A pulse **value** of `low` is used to wait for
 a change of input going from `high` to `low`.
 
 When it notices a pulse in the direction it's waiting for, ``||pins:pulse in||`` stops waiting and tells you
@@ -36,21 +36,21 @@ is in microseconds (1 second = 1000000 microseconds).
 ## Example #ex1
 
 Check for a `low` pulse on pin `D5` every one-half of a second. Make the first pixel on the pixel strip `red`
-if there was a pulse. 
+if there was a pulse.
 
 ```blocks
 let pulseTime = 0;
 let pixels = light.createStrip();
 pins.D5.setPull(PinPullMode.PullUp)
 
-loops.forever(function() {
+forever(function() {
     pulseTime = pins.D5.pulseIn(PulseValue.Low)
     if (pulseTime > 0) {
         pixels.setPixelColor(0, Colors.Red)
     } else {
-        pixels.setPixelColor(0, Colors.Black)        
+        pixels.setPixelColor(0, Colors.Black)
     }
-    loops.pause(500)
+    pause(500)
 })
 ```
 

--- a/libs/core/docs/reference/pins/servo-set-pulse.md
+++ b/libs/core/docs/reference/pins/servo-set-pulse.md
@@ -44,7 +44,7 @@ of those types of servos, find out what pulse times move the shaft where you wan
 ### PWM
 
 The ``||set servo pulse||`` block is useful for sending other [PWM](/reference/pins/what-is-pwm) signals as
-long as you use a 20 millisecond signalling period. 
+long as you use a 20 millisecond signalling period.
 
 ## Parameters
 
@@ -60,7 +60,7 @@ Turn a standard serve to 135 degrees connected to pin `A1`. Wait for 3 seconds a
 
 ```blocks
 pins.A1.servoSetPulse(1750)
-loops.pause(3000)
+pause(3000)
 pins.A1.servoWrite(1500)
 ```
 

--- a/libs/core/docs/reference/pins/servo-write.md
+++ b/libs/core/docs/reference/pins/servo-write.md
@@ -7,7 +7,7 @@ pins.A1.servoWrite(90)
 ```
 
 Servos turn a shaft in one of two of directions by an amount of angle in degrees. With a servo,
-you are using just 180 degrees to position an arm, gear, or wheel that is connected to the shaft. The position 
+you are using just 180 degrees to position an arm, gear, or wheel that is connected to the shaft. The position
 at 90 degrees is the base, or neutral position. To turn the servo shaft left (counter-clockwise) you
 write to it a number of degrees to the between 0 and 90. The `0` degree spot is all the way left and
 any other number up to `90` is somewhere between left and the neutral position. The same thing works
@@ -48,9 +48,9 @@ direction for 5 times.
 ```blocks
 for (let i = 1; i <= 5; i++) {
     pins.A1.servoWrite(135)
-    loops.pause(500)
+    pause(500)
     pins.A1.servoWrite(45)
-    loops.pause(500)
+    pause(500)
 }
 ```
 

--- a/libs/core/docs/reference/pins/set-pull.md
+++ b/libs/core/docs/reference/pins/set-pull.md
@@ -44,7 +44,7 @@ pins.D4.setPull(PinPullMode.PullUp)
 
 pins.D4.onPulsed(PulseValue.Low, () => {
     pins.D13.digitalWrite(true)
-    loops.pause(250)
+    pause(250)
     pins.D13.digitalWrite(false)
 })
 ```

--- a/libs/core/test.ts
+++ b/libs/core/test.ts
@@ -6,6 +6,6 @@ let minus = i - f
 let r = Math.random()
 let ri = Math.randomRange(5, 10)
 
-loops.forever(() => {
-    loops.pause(100)
+forever(() => {
+    pause(100)
 })

--- a/libs/core/timer.ts
+++ b/libs/core/timer.ts
@@ -17,7 +17,7 @@ namespace control {
         millis(): number {
             return control.millis() - this.start;
         }
-        
+
         /**
          * Gets the elapsed time in seconds since the last reset
          */
@@ -41,7 +41,7 @@ namespace control {
         //% blockId=timerPauseUntil block="%timer|pause until (ms) %ms"
         pauseUntil(ms: number) {
             const remaining = this.millis() - ms;
-            loops.pause(Math.max(0, remaining));
+            pause(Math.max(0, remaining));
         }
     }
 

--- a/libs/datalog/test.ts
+++ b/libs/datalog/test.ts
@@ -1,5 +1,5 @@
 let k = 0;
-loops.forever(function () {
+forever(function () {
     datalog.addRow()
     datalog.addValue("x", k)
     datalog.addValue("y", 1 / k)

--- a/libs/gamepad/test.ts
+++ b/libs/gamepad/test.ts
@@ -5,12 +5,12 @@ function throttle() {
         //increase throttle
         for (let j = 0; j <= 31; j++) {
             gamepad.setThrottle(i, j);
-            loops.pause(100);
+            pause(100);
         }
         //move throttle back down
         for (let j = 31; j >= 0; j--) {
             gamepad.setThrottle(i, j);
-            loops.pause(100);
+            pause(100);
         }
     }
 }
@@ -19,19 +19,19 @@ function buttons() {
     //set buttons
     for (let i = 0; i < 16; i++) {
         gamepad.setButton(i, false);
-        loops.pause(100);
+        pause(100);
     }
 
     //clear buttons
     for (let i = 0; i < 16; i++) {
         gamepad.setButton(i, true);
-        loops.pause(100);
+        pause(100);
     }
 
     //set buttons
     for (let i = 0; i < 16; i++) {
         gamepad.setButton(i, false);
-        loops.pause(100);
+        pause(100);
     }
 }
 
@@ -42,30 +42,30 @@ function sticks() {
         //move x axis up
         for (let j = 0; j < 127; j += 8) {
             gamepad.move(i, j, 0);
-            loops.pause(50);
+            pause(50);
         }
 
         //move x axis back down
         for (let j = 127; j >= 0; j -= 8) {
             gamepad.move(i, j, 0);
-            loops.pause(50);
+            pause(50);
         }
 
         //move y axis up
         for (let j = 0; j < 127; j += 8) {
             gamepad.move(i, 0, j);
-            loops.pause(50);
+            pause(50);
         }
 
         //move y axis back down
         for (let j = 127; j >= 0; j -= 8) {
             gamepad.move(i, 0, j);
-            loops.pause(50);
+            pause(50);
         }
     }
 }
 
-loops.forever(function () {
+forever(function () {
     buttons()
     // sticks()
     throttle()

--- a/libs/infrared/docs/reference/network/infrared-send-number.md
+++ b/libs/infrared/docs/reference/network/infrared-send-number.md
@@ -20,7 +20,7 @@ receiving board think about the number it just got.
 ```blocks
 for (let irDataNumber = 0; irDataNumber <= 9; irDataNumber++) {
     network.infraredSendNumber(irDataNumber);
-    loops.pause(500);
+    pause(500);
 }
 ```
 

--- a/libs/light/docs/examples/photon-bounce.md
+++ b/libs/light/docs/examples/photon-bounce.md
@@ -7,34 +7,34 @@ let ms = 30;
 let p = light.createStrip();
 let n = p.length()
 p.setBrightness(100)
-loops.forever(() => {
+forever(() => {
     p.setPhotonMode(PhotonMode.PenUp);
     p.setPhotonPenColor(Math.randomRange(0, 255));
     distance = n - 1;
     for (let i = 0; i < n; ++i) {
         for (let i = 0; i < distance; ++i) {
             p.photonForward(1);
-            loops.pause(ms);
+            pause(ms);
         }
         p.setPhotonMode(PhotonMode.PenDown);
         p.setPhotonMode(PhotonMode.PenUp);
         for (let i = 0; i < distance; ++i) {
             p.photonForward(-1);
-            loops.pause(ms);
+            pause(ms);
         }
         distance -= 1;
     }
-    loops.pause(ms)
+    pause(ms)
     p.setPhotonMode(PhotonMode.Eraser);
     distance = 1;
     for (let i = 0; i < n; ++i) {
         for (let i = 0; i < distance; ++i) {
             p.photonForward(1);
-            loops.pause(ms);
+            pause(ms);
         }
         for (let i = 0; i < distance; ++i) {
             p.photonForward(-1);
-            loops.pause(ms);
+            pause(ms);
         }
         distance += 1;
     }

--- a/libs/light/docs/examples/photon-color-wipe.md
+++ b/libs/light/docs/examples/photon-color-wipe.md
@@ -2,17 +2,17 @@
 
 ```blocks
 let pixels = light.createStrip();
-loops.forever(function() {
+forever(function() {
     pixels.setPhotonPenHue(Math.randomRange(0, 256))
     pixels.setPhotonMode(PhotonMode.PenDown);
     for (let i = 0; i < 9; i++) {
         pixels.photonForward(1);
-        loops.pause(20);
+        pause(20);
     }
     pixels.setPhotonMode(PhotonMode.Eraser);
     for (let i = 0; i < 9; i++) {
         pixels.photonForward(1);
-        loops.pause(20);
+        pause(20);
     }
 })
 ```

--- a/libs/light/docs/examples/photon-rainbow.md
+++ b/libs/light/docs/examples/photon-rainbow.md
@@ -3,7 +3,7 @@
 ```blocks
 let c = 0;
 let pixels = light.createStrip();
-loops.forever(function() {
+forever(function() {
     pixels.setPhotonPenHue(c);
     pixels.photonForward(1);
     c += 16;

--- a/libs/light/docs/examples/photon-roundtrip.md
+++ b/libs/light/docs/examples/photon-roundtrip.md
@@ -8,13 +8,13 @@ input.buttonA.onEvent(ButtonEvent.Click, function() {
     pixels.setPhotonPenHue(Math.randomRange(0, 256));
     for (let i = 0; i < 10; i++) {
         pixels.photonForward(1);
-        loops.pause(50);
+        pause(50);
     }
-    loops.pause(1000);
+    pause(1000);
     pixels.setPhotonMode(PhotonMode.Eraser);
     for (let i = 0; i < 10; i++) {
         pixels.photonForward(-1);
-        loops.pause(50);
+        pause(50);
     }
 });
 ```

--- a/libs/light/docs/examples/photon-spark.md
+++ b/libs/light/docs/examples/photon-spark.md
@@ -4,9 +4,9 @@
 let pixels = light.createStrip();
 
 pixels.setPhotonMode(PhotonMode.PenUp);
-loops.forever(function() {
+forever(function() {
     pixels.photonForward(Math.randomRange(0, 10))
-    loops.pause(20)
+    pause(20)
 })
 ```
 

--- a/libs/light/docs/examples/photon-wand.md
+++ b/libs/light/docs/examples/photon-wand.md
@@ -11,11 +11,11 @@ input.onGesture(Gesture.Shake, function() {
 
     for (let i = 0; i < 50; i++) {
         pixels.photonForward(Math.randomRange(0, 51));
-        loops.pause(20);
+        pause(20);
     }
     pixels.setPhotonMode(PhotonMode.PenDown);
 })
-loops.forever(function() {
+forever(function() {
     pixels.photonForward(1);
     pixels.setPhotonPenHue(c);
     c += 16;

--- a/libs/light/docs/reference/light/color-wipe-animation.md
+++ b/libs/light/docs/reference/light/color-wipe-animation.md
@@ -13,7 +13,7 @@ light.colorWipeAnimation
 ## Example
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     light.builtin.showAnimationFrame(light.colorWipeAnimation)
 })
 ```

--- a/libs/light/docs/reference/light/comet-animation.md
+++ b/libs/light/docs/reference/light/comet-animation.md
@@ -12,7 +12,7 @@ light.cometAnimation();
 ## Example
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     light.builtin.showAnimationFrame(light.cometAnimation())
 })
 ```

--- a/libs/light/docs/reference/light/neopixelstrip/graph.md
+++ b/libs/light/docs/reference/light/neopixelstrip/graph.md
@@ -39,7 +39,7 @@ Graph 10 values between 0 and 100 on the pixels.
 let strip = light.createStrip()
 for (let i = 0; i <= 10; i++) {
     strip.graph(i * 10, 100)
-    loops.pause(500)
+    pause(500)
 }
 ```
 ### Auto range graph #ex2
@@ -49,9 +49,9 @@ Graph the value of `1000`. Graph other values but let them auto scale when displ
 ```blocks
 let strip = light.createStrip()
 strip.graph(1000, 0)
-loops.forever(() => {
+forever(() => {
     strip.graph(Math.randomRange(0, 1000), 0)
-    loops.pause(500)
+    pause(500)
 })
 ```
 ## See also

--- a/libs/light/docs/reference/light/neopixelstrip/length.md
+++ b/libs/light/docs/reference/light/neopixelstrip/length.md
@@ -18,7 +18,7 @@ Shift an `orange` pixel from the beginning of the pixel strip to the end.
 let strip = light.createStrip()
 strip.setPixelColor(0, Colors.Orange)
 for (let i = 0; i < strip.length() - 1; i++) {
-    loops.pause(500)
+    pause(500)
     strip.move(LightMove.Shift, 1)
 }
 ```

--- a/libs/light/docs/reference/light/neopixelstrip/move.md
+++ b/libs/light/docs/reference/light/neopixelstrip/move.md
@@ -27,9 +27,9 @@ Make two blue pixels rotate around the strip one pixel spot at a time.
 let strip = light.createStrip()
 strip.setPixelColor(0, Colors.Blue)
 strip.setPixelColor(1, Colors.Blue)
-loops.forever(() => {
+forever(() => {
     strip.move(LightMove.Rotate, 1)
-    loops.pause(500)
+    pause(500)
 })
 ```
 

--- a/libs/light/docs/reference/light/neopixelstrip/photon-flip.md
+++ b/libs/light/docs/reference/light/neopixelstrip/photon-flip.md
@@ -20,7 +20,7 @@ let strip = light.createStrip()
 for (let i = 0; i <= 5; i++) {
     for (let j = 0; j < strip.length(); j++) {
         strip.photonForward(1)
-        loops.pause(50)
+        pause(50)
     }
     strip.photonFlip()
 }

--- a/libs/light/docs/reference/light/neopixelstrip/photon-forward.md
+++ b/libs/light/docs/reference/light/neopixelstrip/photon-forward.md
@@ -22,7 +22,7 @@ Move a photon across the entire length of the pixel strip.
 let strip = light.createStrip()
 for (let i = 0; i < strip.length(); i++) {
     strip.photonForward(1)
-    loops.pause(150)
+    pause(150)
 }
 ```
 ## See also

--- a/libs/light/docs/reference/light/neopixelstrip/range.md
+++ b/libs/light/docs/reference/light/neopixelstrip/range.md
@@ -47,7 +47,7 @@ of the new pixel strip to its end.
 let smallStrip = light.createStrip().range(0, 4)
 smallStrip.setPixelColor(0, Colors.Red)
 for (let i = 0; i < smallStrip.length() - 1; i++) {
-    loops.pause(500)
+    pause(500)
     smallStrip.move(LightMove.Shift, 1)
 }
 ```

--- a/libs/light/docs/reference/light/neopixelstrip/set-photon-mode.md
+++ b/libs/light/docs/reference/light/neopixelstrip/set-photon-mode.md
@@ -28,7 +28,7 @@ so it erases when it moves backward.
 let strip = light.createStrip()
 let forward = true
 strip.setPhotonPenHue(191)
-loops.forever(() => {
+forever(() => {
     if (forward) {
         strip.setPhotonMode(PhotonMode.PenDown)
     } else {
@@ -36,7 +36,7 @@ loops.forever(() => {
     }
     for (let i = 0; i < strip.length(); i++) {
         strip.photonForward(1)
-        loops.pause(100)
+        pause(100)
     }
     forward = !forward
     strip.photonFlip()
@@ -55,14 +55,14 @@ strip.setPhotonPenHue(191)
 strip.setPhotonMode(PhotonMode.PenDown)
 for (let i = 1; i < strip.length(); i++) {
     strip.photonForward(1)
-    loops.pause(500)
+    pause(500)
 }
 
 strip.setPhotonPenHue(86)
 strip.setPhotonMode(PhotonMode.PenUp)
 for (let i = 1; i < strip.length(); i++) {
     strip.photonForward(1)
-    loops.pause(500)
+    pause(500)
 }
 ```
 

--- a/libs/light/docs/reference/light/neopixelstrip/set-photon-pen-color.md
+++ b/libs/light/docs/reference/light/neopixelstrip/set-photon-pen-color.md
@@ -20,10 +20,10 @@ Pulse an blue photon forward and backward across the pixel strip.
 ```blocks
 let strip = light.createStrip()
 strip.setPhotonPenColor(Colors.Blue)
-loops.forever(() => {
+forever(() => {
     for (let i = 0; i < strip.length(); i++) {
         strip.photonForward(1)
-        loops.pause(100)
+        pause(100)
     }
     strip.photonFlip()
 })

--- a/libs/light/docs/reference/light/neopixelstrip/set-photon-pen-hue.md
+++ b/libs/light/docs/reference/light/neopixelstrip/set-photon-pen-hue.md
@@ -35,11 +35,11 @@ Pulse an rainbow photon forward and backward across the pixel strip.
 ```blocks
 let hue = 0;
 let strip = light.createStrip()
-loops.forever(() => {
+forever(() => {
     strip.setPhotonPenHue(hue)
     for (let i = 0; i < strip.length(); i++) {
         strip.photonForward(1)
-        loops.pause(100)
+        pause(100)
     }
     strip.photonFlip()
     hue = hue + 1;

--- a/libs/light/docs/reference/light/rainbow-cycle-animation.md
+++ b/libs/light/docs/reference/light/rainbow-cycle-animation.md
@@ -12,7 +12,7 @@ light.rainbowCycleAnimation();
 ## Example
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     light.builtin.showAnimationFrame(light.rainbowCycleAnimation())
 })
 ```

--- a/libs/light/docs/reference/light/running-lights-animation.md
+++ b/libs/light/docs/reference/light/running-lights-animation.md
@@ -12,7 +12,7 @@ light.runningLightsAnimation();
 ## Example
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     light.builtin.showAnimationFrame(light.runningLightsAnimation())
 })
 ```

--- a/libs/light/docs/reference/light/sparkle-animation.md
+++ b/libs/light/docs/reference/light/sparkle-animation.md
@@ -12,7 +12,7 @@ light.sparkleAnimation();
 ## Example
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     light.builtin.showAnimationFrame(light.sparkleAnimation(), 500)
 })
 ```

--- a/libs/light/docs/reference/light/theatre-chase-animation.md
+++ b/libs/light/docs/reference/light/theatre-chase-animation.md
@@ -12,7 +12,7 @@ light.theatreChaseAnimation();
 ## Example
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     light.builtin.showAnimationFrame(light.theatreChaseAnimation(), 500)
 })
 ```

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -402,7 +402,7 @@ namespace light {
          * @param length number of pixels in the range, eg: 4
          */
         //% blockId="light_range" block="%strip|range from %start|with %length|pixels"
-        //% help="light/neopixelstrip/range"   
+        //% help="light/neopixelstrip/range"
         //% parts="neopixel"
         //% weight=99 blockGap=30
         range(start: number, length: number): NeoPixelStrip {
@@ -641,7 +641,7 @@ namespace light {
                         tempColor = "";
                         if (pi == n) {
                             this.show();
-                            loops.pause(interval);
+                            pause(interval);
                             pi = 0;
                             break;
                         }

--- a/libs/light/test.ts
+++ b/libs/light/test.ts
@@ -5,7 +5,7 @@ strip.setBrightness(20)
 function flash(n: number) {
     control.runInParallel(() => {
         strip.setPixelColor(n, 0x0000ff)
-        loops.pause(1000)
+        pause(1000)
         strip.setPixelColor(n, 0x000000)
     })
 }

--- a/libs/lightsensor/docs/reference/input/light-level.md
+++ b/libs/lightsensor/docs/reference/input/light-level.md
@@ -39,7 +39,7 @@ If you carry the @boardname@ around to different places with different light lev
 ```blocks
 let pixels = light.createStrip();
 
-loops.forever(function() {
+forever(function() {
     pixels.graph(
         input.lightLevel(),
         0

--- a/libs/lightsensor/test.ts
+++ b/libs/lightsensor/test.ts
@@ -1,3 +1,3 @@
-loops.forever(() => {
+forever(() => {
     serial.writeLine(`light=${input.lightLevel()}`);
 })

--- a/libs/microphone/docs/reference/input/on-loud-sound.md
+++ b/libs/microphone/docs/reference/input/on-loud-sound.md
@@ -19,7 +19,7 @@ let pixels = light.createStrip()
 
 input.onLoudSound(() => {
 	pixels.setAll(Colors.Red);
-	loops.pause(100);
+	pause(100);
 	pixels.setAll(Colors.Black);
 });
 ```

--- a/libs/microphone/docs/reference/input/set-loud-sound-threshold.md
+++ b/libs/microphone/docs/reference/input/set-loud-sound-threshold.md
@@ -24,7 +24,7 @@ input.setLoudSoundThreshold(768);
 
 input.onLoudSound(() => {
 	pixels.setAll(Colors.Pink);
-    loops.pause(200);
+    pause(200);
     pixels.clear();
 });
 ```

--- a/libs/microphone/docs/reference/input/sound-level.md
+++ b/libs/microphone/docs/reference/input/sound-level.md
@@ -17,7 +17,7 @@ Use the pixels to make a sound meter. If loud sounds are detected, more pixels l
 let lastLevel = 0;
 let pixels = light.createStrip();
 
-loops.forever(() => {
+forever(() => {
     let level = input.soundLevel();
     if (lastLevel != level) {
         pixels.clear();

--- a/libs/microphone/test.ts
+++ b/libs/microphone/test.ts
@@ -1,4 +1,4 @@
-loops.forever(() => {
+forever(() => {
     let level = input.soundLevel()
     serial.writeValue("sound", level)
 })

--- a/libs/mouse/test.ts
+++ b/libs/mouse/test.ts
@@ -1,42 +1,42 @@
 function moveXY() {
     //move x direction
     mouse.move(50, 0);
-    loops.pause(500); //wait
+    pause(500); //wait
     mouse.move(-50, 0);
-    loops.pause(500); //wait
+    pause(500); //wait
 
     //move y direction
     mouse.move(0, 50);
-    loops.pause(500); //wait
+    pause(500); //wait
     mouse.move(0, -50);
-    loops.pause(500); //wait
+    pause(500); //wait
 }
 
 function clicks() {
     mouse.setButton(MouseButton.Left, false);
-    loops.pause(500); //wait
+    pause(500); //wait
     mouse.setButton(MouseButton.Left, true);
-    loops.pause(500); //wait
+    pause(500); //wait
 
     mouse.setButton(MouseButton.Middle, false);
-    loops.pause(500); //wait
+    pause(500); //wait
     mouse.setButton(MouseButton.Middle, true);
-    loops.pause(500); //wait
+    pause(500); //wait
 
     mouse.setButton(MouseButton.Right, true);
-    loops.pause(500); //wait
+    pause(500); //wait
     mouse.setButton(MouseButton.Right, true);
-    loops.pause(500); //wait
+    pause(500); //wait
 }
 
 function wheel() {
     mouse.turnWheel(50);
-    loops.pause(500); //wait
+    pause(500); //wait
     mouse.turnWheel(-50);
-    loops.pause(500); //wait
+    pause(500); //wait
 }
 
-loops.forever(function () {
+forever(function () {
     moveXY();
     clicks();
     wheel();

--- a/libs/music/docs/reference/music/rest.md
+++ b/libs/music/docs/reference/music/rest.md
@@ -22,7 +22,7 @@ Play a 'C' note for one second and then rest for one second. Do it again, and ag
 
 ```blocks
 let frequency = music.noteFrequency(Note.C)
-loops.forever(() => {
+forever(() => {
   music.playTone(frequency, 1000)
   music.rest(1000)
 })

--- a/libs/music/docs/reference/music/ring-tone.md
+++ b/libs/music/docs/reference/music/ring-tone.md
@@ -31,7 +31,7 @@ speeds up, the pitch of the tone gets higher. If it slows down, the
 pitch gets lower. It's fun -- try it!
 
 ```blocks
-loops.forever(() => {
+forever(() => {
     music.ringTone(input.acceleration(Dimension.X));
 })
 ```

--- a/libs/music/melodies.ts
+++ b/libs/music/melodies.ts
@@ -101,7 +101,7 @@ namespace music {
             queue.cancel();
             queue.runUntilDone(() => melody.playNextNote());
         })
-        loops.pause(1);
+        pause(1);
     }
 
 

--- a/libs/switch/docs/reference/input/on-switch-moved.md
+++ b/libs/switch/docs/reference/input/on-switch-moved.md
@@ -24,14 +24,14 @@ pixels.setAll(Colors.Red);
 input.onSwitchMoved(SwitchDirection.Right, () => {
     for (let i = 0; i < pixels.length(); i++) {
         pixels.photonForward(1);
-        loops.pause(50);
+        pause(50);
     }
     pixels.photonFlip();
 });
 input.onSwitchMoved(SwitchDirection.Left, () => {
     for (let i = 0; i < pixels.length(); i++) {
         pixels.photonForward(1);
-        loops.pause(50);
+        pause(50);
     }
     pixels.photonFlip();
 })

--- a/libs/tests/README.md
+++ b/libs/tests/README.md
@@ -9,7 +9,7 @@ Tests are registered as event handlers. They will automatically run once ``on st
 ```blocks
 tests.test("lgB set speed 10", () => {
     motors.largeB.setSpeed(10);
-    loops.pause(100)
+    pause(100)
     tests.assertClose("speedB", 10, motors.largeB.speed(), 2)
 });
 ```

--- a/libs/tests/tests.ts
+++ b/libs/tests/tests.ts
@@ -85,14 +85,14 @@ namespace tests {
             _tests = [];
             control.runInParallel(function () {
                 // should run after on start
-                loops.pause(100)
+                pause(100)
                 run()
             })
         }
         _tests.push(new Test(name, handler));
     }
 
-    /** 
+    /**
      * Checks a boolean condition
      */
     //% blockId=testAssert block="assert %message|%condition"
@@ -121,7 +121,7 @@ namespace tests {
 
     /**
      * Registers code to be called at various points in the test execution
-     * @param handler 
+     * @param handler
      */
     //% blockGap=8
     //% weight=10

--- a/libs/thermometer/docs/reference/input/temperature.md
+++ b/libs/thermometer/docs/reference/input/temperature.md
@@ -25,12 +25,12 @@ The @boardname@ might warm up a little if you make it work hard, though!
 
 ### @boardname@ thermometer #ex1
 
-Use **temperature** and **set all** to vary the brightness of the pixels depending on the temperature in the room. 
+Use **temperature** and **set all** to vary the brightness of the pixels depending on the temperature in the room.
 
 ```blocks
 let pixels = light.createStrip();
 
-loops.forever(() => {
+forever(() => {
     pixels.setBrightness(Math.map(
         input.temperature(TemperatureUnit.Celsius),
         0,
@@ -50,7 +50,7 @@ Measure the temperature using degrees in Fahrenheit.
 ```blocks
 let pixels = light.createStrip()
 
-loops.forever(() => {
+forever(() => {
     pixels.setBrightness(Math.map(
         input.temperature(TemperatureUnit.Fahrenheit),
         30,
@@ -67,7 +67,7 @@ loops.forever(() => {
 
 Try comparing the temperature your @boardname@ shows to a real thermometer in the same place.
 You might be able to figure out how much to subtract from the number the @boardname@
-shows to get the real temperature. Then you can change your program so the @boardname@ is a 
+shows to get the real temperature. Then you can change your program so the @boardname@ is a
 better thermometer.
 
 ### ~

--- a/libs/touch/docs/reference/input/touch/value.md
+++ b/libs/touch/docs/reference/input/touch/value.md
@@ -17,13 +17,13 @@ Measure the touch values at pin **A2**. If they are greater than `512`, then fla
 
 ```blocks
 input.pinA2.setThreshold(100)
-loops.forever(function () {
+forever(function () {
     if (input.pinA2.value() > 512) {
         light.setAll(Colors.Green)
-        loops.pause(100)
+        pause(100)
         light.setAll(Colors.Black)
     }
-    loops.pause(500)
+    pause(500)
 })
 ```
 


### PR DESCRIPTION
Moving both of those functions to be top-level, just like `pauseUntil()`. In other words:
1. `loops.forever(() => {})` is now `forever(() => {})`
2. `loops.pause(500)` is now `pause(500)`

This shouldn't break anybody. The new functions I defined have the same block id as the old functions so hopefully old block scripts will be automatically converted when we compile to TS.

The old functions are still there so that we don't break TS scripts, but they have `deprecated=true` and I changed the block ids.

Adding DO NOT MERGE because I want to make sure everyone is aware of this change before I merge it in.