### PR TITLE
Tag cp doc sections for overrides - 01

### DIFF
--- a/libs/accelerometer/docs/reference/input/acceleration.md
+++ b/libs/accelerometer/docs/reference/input/acceleration.md
@@ -1,6 +1,6 @@
 # acceleration
 
-GGet the acceleration value (milli g-force) in one of three dimensions, or the combined force in all directions (x, y, and z).
+Get the acceleration value (milli g-force) in one of three dimensions, or the combined force in all directions (x, y, and z).
 
 Find the acceleration of the @boardname@ (how fast it is speeding up or slowing down).
 

--- a/libs/accelerometer/docs/reference/input/acceleration.md
+++ b/libs/accelerometer/docs/reference/input/acceleration.md
@@ -1,47 +1,65 @@
-# Acceleration
+# acceleration
 
-Get the acceleration value (milli g-force), in one of the three dimensions.
+GGet the acceleration value (milli g-force) in one of three dimensions, or the combined force in all directions (x, y, and z).
+
+Find the acceleration of the @boardname@ (how fast it is speeding up or slowing down).
 
 ```sig
 input.acceleration(Dimension.X);
 ```
 
-Find the acceleration of the @boardname@ (how fast it is speeding up or slowing down).
-
 ## ~hint
 
 You measure acceleration with the **milli-g**, which is 1/1000 of a **g**.
-A **g** is the same amount of acceleration as you get from Earth's gravity.
+A **g** is as much acceleration as you get from Earth's gravity.
 
 ## ~
 
-### Parameters
+## Parameters
 
-* ``dimension`` the direction to check for any acceleration. This is:
-> * `X`: left or right
-> * `Y`: forward or backward
-> * `Z`: up or down
+* **dimension**: the direction you are checking for acceleration, or the total strength of force.
+>`x`: acceleration in the left and right direction.<br/>
+`y`: acceleration in the forward and backward direction.<br/>
+`z`: acceleration in the up and down direction.<br/>
+`strength`: the resulting strength of acceleration from all three dimensions (directions).
 
-### Returns
+### ~hint
 
-* a [number](/types/number) that is the amount of acceleration. When the @boardname@ is lying flat on a surface with the screen pointing up, `x` is `0`, `y` is `0`, and `z` is `-1023`.
+**Forces in space**
 
-### Example: bar chart #example
+Since we don't live on a flat world, forces happen in three dimensional space. If the movement of an object isn't exactly in the direction of one axis, we need a way to calculate its acceleration from the values measured for all the axes together.
 
-Show the acceleration of the @boardname@ with a bar graph.
+If you put your @boardname@ on a level table and push it diagonally, you have an acceleration in two dimensions. You can find the acceleration in that direction just like how you calculate the long side of a triangle using the two shorter sides (**X** and **Y**): 
+
+```strength2D = Math.sqrt((accelX * accelX) + (accelY * accelY))```
+
+If you decide to lift your @boardname@ off the table, then you've just added another dimension, so insert the acceleration value for the **Z** axis into the equation:
+
+```strength3D = Math.sqrt((accelX * accelX) + (accelY * accelY) + (accelZ * accelZ))```
+
+This calculation is called the [Euclidean norm](https://en.wikipedia.org/wiki/Euclidean_norm) of acceleration.
+
+### ~
+
+## Returns
+
+* a [number](/types/number) that means the amount of acceleration. When the @boardname@ is lying flat on a surface with the screen pointing up, `x` is `0`, `y` is `0`, `z` is `-1023`, and `strength` is `1023`.
+
+## Example: bar chart #example
+
+Write the acceleration of the @boardname@ to the console.
 
 ```blocks
-let pixels = light.createStrip();
 forever(() => {
-    pixels.graph(input.acceleration(Dimension.X), 1023)
+    console.logValue("accel", input.acceleration(Dimension.X))
+    loops.pause(500)
 })
 ```
 
-### See also
+## See also #seealso
 
-[``||set accelerometer range||``](/reference/input/set-accelerometer-range),
-[``||light level||``](/reference/input/light-level)
-
+[set accelerometer range](/reference/input/set-accelerometer-range),
+[light level](/reference/input/light-level)
 
 ```package
 accelerometer

--- a/libs/accelerometer/docs/reference/input/on-gesture.md
+++ b/libs/accelerometer/docs/reference/input/on-gesture.md
@@ -7,7 +7,7 @@ input.onGesture(Gesture.Shake,() => {
 })
 ```
 
-### Parameters
+## Parameters
 
 * ``gesture``: the gesture to detect. A gesture is the way you hold or move the @boardname@. Gestures are:
 > * `shake`: shake the board
@@ -22,7 +22,7 @@ input.onGesture(Gesture.Shake,() => {
 > * `6g`: acceleration force of 6 g
 * ``body``: code to run when the gesture event occurs
 
-### Example: random number #example
+## Example: random number #example
 
 Show a random color when you shake the @boardname@.
 
@@ -32,6 +32,8 @@ input.onGesture(Gesture.Shake,() => {
     pixels.setAll(light.hsv(Math.randomRange(0, 256), 255, 127));
 })
 ```
+
+## #seeaslo
 
 ```package
 accelerometer

--- a/libs/accelerometer/docs/reference/input/rotation.md
+++ b/libs/accelerometer/docs/reference/input/rotation.md
@@ -13,17 +13,17 @@ check the ways that the @boardname@ is moving.
 
 ## ~
 
-### Parameters
+## Parameters
 
 * ``kind`` the direction you are checking:
 > * `Pitch`: up or down
 > * `Roll`: left or right
 
-### Returns
+## Returns
 
 * a [number](/types/number) that tells how much the @boardname@ is tilted in the direction you say, from `0` to `360` degrees
 
-### Example: @boardname@ leveler #example
+## Example: @boardname@ leveler #example
 
 This program helps you move the @boardname@ until it is level. When
 it is levelled, the @boardname@ shows turns blue.
@@ -42,15 +42,15 @@ forever(() => {
     }
 });
 ```
-#### ~hint
+### ~hint
 **Simulator**
 
 If you are running this program in a browser, you can tilt the @boardname@ with your mouse.
-#### ~
+### ~
 
-### See also
+## See also #seealso
 
-[``||acceleration||``](/reference/input/acceleration)
+[acceleration](/reference/input/acceleration)
 
 ```package
 accelerometer

--- a/libs/accelerometer/docs/reference/input/set-accelerometer-range.md
+++ b/libs/accelerometer/docs/reference/input/set-accelerometer-range.md
@@ -9,13 +9,13 @@ g-force you will want to measure.
 input.setAccelerometerRange(AcceleratorRange.OneG);
 ```
 
-### Parameters
+## Parameters
 
 * ``range`` the biggest g-force (acceleration) number you will measure: `1g`, `2g`, `4g`, or `8g`.
 Any bigger numbers measured by your @boardname@ are ignored. So, you won't receive
 events or measurments to your program when a bigger g-force occurs.
 
-### Example #example
+## Example #example
 
 Set the highest g-force that your @boardname@
 will measure up to 4 g. Then, write to **serial** the acceleration measured when you move the board side to side.
@@ -27,15 +27,15 @@ forever(() => {
 })
 ```
 
-#### ~hint
+### ~hint
 **Simulator**
 
 This program only works when on the @boardname@. You have to download it first before trying it out.
-#### ~
+### ~
 
-### See Also
+## See also #seealso
 
-[``||acceleration||``](/reference/input/acceleration)
+[acceleration](/reference/input/acceleration)
 
 ```package
 accelerometer

--- a/libs/base/docs/reference/console/log-value.md
+++ b/libs/base/docs/reference/console/log-value.md
@@ -19,7 +19,7 @@ sends it as a pair.
 * **name**: a [string](/types/string) that is the name part of the _name:value_ pair
 * **value**: a [number](/types/number) that is the value part of the _name:value_ pair 
 
-## Example
+## Example #example
 
 Send _name:value_ pairs for odd and even numbers to the console output.
 
@@ -33,6 +33,6 @@ for (let i = 0; i < 10; i++) {
 }
 ```
 
-## See also
+## See also #seealso
 
-[``||log||``](/reference/console/log)
+[log](/reference/console/log)

--- a/libs/base/docs/reference/console/log.md
+++ b/libs/base/docs/reference/console/log.md
@@ -18,7 +18,7 @@ With ``||console:log||``, the new line characters are automatically added for yo
 
 * **text**: the [string](/types/string) to write to the console output.
 
-## Example
+## Example #example
 
 Write two greeting messages to the console output.
 
@@ -28,6 +28,6 @@ pause(5000);
 console.log("Well that's great! I'm doing well too.");
 ```
 
-## See also
+## See also #seealso
 
-[``||log value||``](/reference/console/log-value)
+[log value](/reference/console/log-value)

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -13,7 +13,7 @@ You can insist that your program will stop at an assert block if a certain condi
 * **cond**: a [boolean](/types/boolean) where true means everything is ok or false which means, stop the program!
 * **code**: an error [number](/types/number) you match to an error situation in your program.
 
-## Example
+## Example #example
 
 Stop the program if a sensor connected to pin `A0` sends a low (`0`) signal.
 
@@ -24,7 +24,7 @@ forever(function () {
 })
 ```
 
-## See also
+## See also #seealso
 
 [panic](/reference/control/panic)
 

--- a/libs/base/docs/reference/control/device-dal-version.md
+++ b/libs/base/docs/reference/control/device-dal-version.md
@@ -10,7 +10,7 @@ control.deviceDalVersion()
 
 * a [string](/types/string) that represents the version of the system software (DAL) on the board.
 
-## Example
+## Example #example
 
 Write the system software version to the serial port.
 
@@ -18,6 +18,6 @@ Write the system software version to the serial port.
 serial.writeLine("DAL version = " + control.deviceDalVersion());
 ```
 
-# See also
+## See also #seealso
 
 [device serial number](/reference/control/device-serial-number)

--- a/libs/base/docs/reference/control/device-serial-number.md
+++ b/libs/base/docs/reference/control/device-serial-number.md
@@ -12,7 +12,7 @@ The system software in your board creates a unique number to identify the board.
 
 * a [number](/types/number) that is created to uniquely identify this board.
 
-## Example
+## Example #example
 
 Write the board serial number to the serial port.
 
@@ -20,6 +20,6 @@ Write the board serial number to the serial port.
 serial.writeValue("serialnumber", control.deviceSerialNumber());
 ```
 
-## See also
+## See also #seealso
 
 [device dal version](/reference/control/device-dal-version)

--- a/libs/base/docs/reference/control/millis.md
+++ b/libs/base/docs/reference/control/millis.md
@@ -10,7 +10,7 @@ control.millis()
 
 * the [number](/types/number) of milliseconds of time since the board was turned on.
 
-## Example
+## Example #example
 
 Find how many days, hours, minutes, and seconds the @boardname@ has been running.
 
@@ -21,3 +21,5 @@ let mins = seconds / 60
 let hours = mins / 60
 let days = hours / 24
 ```
+
+## #seealso

--- a/libs/base/docs/reference/control/on-event.md
+++ b/libs/base/docs/reference/control/on-event.md
@@ -64,7 +64,7 @@ to your board. You could make it known to your program that any event that comes
 * **value**: a [number](/types/number) that tells what the cause of the event is, like: `4`.
 * **handler**: the code to run when the event happens.
 
-## Example #exsection
+## Example #example
 
 Register two events coming from source `22`. Make pixels light up on the pixel strip when
 the events of `0` and `1` are _raised_.
@@ -89,6 +89,6 @@ control.onEvent(pixelLighter, 1, () => {
 })
 ```
 
-## See also
+## See also ##seealso
 
-[``||raise event||``](/reference/control/raise-event)
+[raise event](/reference/control/raise-event)

--- a/libs/base/docs/reference/control/panic.md
+++ b/libs/base/docs/reference/control/panic.md
@@ -16,7 +16,7 @@ happened and your program can't run properly anymore.
 
 * **code**: an error [number](/types/number) you match to an error situation in your program.
 
-## Example
+## Example #example
 
 Send a 'code red' error that you created to the error display if the input from pin `A0` is
 lower than `10`.
@@ -30,6 +30,6 @@ if (pins.A0.analogRead() < 10) {
 }
 ```
 
-## See also
+## See also #seealso
 
 [assert](/reference/control/assert)

--- a/libs/base/docs/reference/control/raise-event.md
+++ b/libs/base/docs/reference/control/raise-event.md
@@ -5,13 +5,13 @@ Announce that something happened at an event source.
 ```sig
 control.raiseEvent(0, 0)
 ```
-You use ``||raise event||`` to announce that something happened with the board or something special
+You use ``||control:raise event||`` to announce that something happened with the board or something special
 happened in your program. You do this if there are other parts of your program that might want
 to know about it.
 
-If you've added some [``||on event||``](/reference/control/on-event) blocks to your program,
+If you've added some [``||control:on event||``](/reference/control/on-event) blocks to your program,
 the code inside them will run if the **src** and **value** numbers are the same as those with
-``||raise event||``. The **src** tells about where the event is coming from. You pick a number
+``||control:raise event||``. The **src** tells about where the event is coming from. You pick a number
 for it to identify something like a sensor or a special situation in your program. If you want
 to announce that it's getting dark, you can make **src** something like `51` for the light sensor's
 source number. This means that anything you want to announce about the light sensor, you raise
@@ -32,7 +32,7 @@ control.raiseEvent(51, 1)
 * **src**: the identification [number](/types/number) (the source) of this event, such as: `10`.
 * **value**: a [number](/types/number) tells what the cause of the event is, like: `4`.
 
-## Example #exsection
+## Example #example
 
 Register two events coming from source `22`. Make pixels light up on the pixel strip when
 the events of `0` and `1` are _raised_.
@@ -57,6 +57,6 @@ control.onEvent(pixelLighter, 1, () => {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||on event||``](/reference/control/on-event), [``||wait for event||``](/reference/control/wait-for-event)
+[on event](/reference/control/on-event), [wait for event](/reference/control/wait-for-event)

--- a/libs/base/docs/reference/control/reset.md
+++ b/libs/base/docs/reference/control/reset.md
@@ -5,13 +5,16 @@ Reset the board and start the program from the beginning.
 ```sig
 control.reset()
 ```
+
 Everything that the program did with the board is set back to the way it was before the
 program started. The program starts over again from the beginning.
 
-## Example
+## Example #example
 
 Reset the board and begin again.
 
 ```blocks
 control.reset()
 ```
+
+## #seealso

--- a/libs/base/docs/reference/control/run-in-parallel.md
+++ b/libs/base/docs/reference/control/run-in-parallel.md
@@ -11,6 +11,8 @@ always put in [``||on start||``](/blocks/on-start). But, you can also put some o
 program in ``||control:run in parallel||``. This is useful when you want your program to keep doing important things
 and you don't want to wait for some other actions to happen first.
 
+## Separate tasks #tasks
+
 As an example, you could have a small task to rotate the pixel lights the pixel strip. This is
 placed inside a ``||control:run in parallel||`` block:
 
@@ -25,6 +27,7 @@ control.runInParallel(() => {
     }
 })
 ```
+
 Code is added to the main part of the program to turn the pixels on. It turns on one pixel, waits
 for `5` seconds and turns on another pixel. Then, it waits for `5` more seconds and stops the rotate
 loop in the background task.
@@ -45,9 +48,7 @@ pixels.clear();
 
 * **a**: the code to run in the background.
 
-## Example #exsection
-
-### Pixel conveyor #ex1
+## Example #example
 
 Automatically rotate lighted pixels as they are added to the pixel strip.
 
@@ -78,3 +79,5 @@ for (let i = 0; i < 5; i++) {
     pixels.setPixelColor(0, Colors.Blue);
 }
 ```
+
+## #seealso

--- a/libs/base/docs/reference/control/wait-for-event.md
+++ b/libs/base/docs/reference/control/wait-for-event.md
@@ -36,7 +36,7 @@ control.waitForEvent(myTimer, timerTimeout)
 * **id**: the identification [number](/types/number) (the source) of this event, such as: `10`.
 * **value**: a [number](/types/number) tells what the cause of the event is, like: `4`.
 
-## Example #exsection
+## Example #example
 
 Make a timeout timer to signal every 2 seconds. Wait two times and light a pixel each time.
 
@@ -58,6 +58,6 @@ control.waitForEvent(myTimer, timerTimeout);
 pixels.setPixelColor(0, Colors.Yellow);
 ```
 
-## See also
+## See also #seealso
 
 [``||raise event||``](/reference/control/raise-event), [``||on event||``](/reference/control/on-event)

--- a/libs/base/docs/reference/control/wait-micros.md
+++ b/libs/base/docs/reference/control/wait-micros.md
@@ -5,14 +5,14 @@ Make the part of the program running right now wait for some number of microseco
 ```sig
 control.waitMicros(10)
 ```
-The code inside the current block, such as a ``||on start||``, ``||run in parallel||``, and 
-``||on event||`` , waits for some amount of time. The time number is in microseconds (one-millionth of a second).
+The code inside the current block, such as a ``||on start||``, ``||control:run in parallel||``, and 
+``||control:on event||`` , waits for some amount of time. The time number is in microseconds (one-millionth of a second).
 
 ## Parameters
 
-* **micros**: the [number](/types/number) of microseconds that this block of code to wait for.
+* **micros**: the [number](/types/number) of microseconds for this block of code to wait for.
 
-## Example
+## Example #example
 
 Turn on an a sensor that has a control signal connected to pin `D4`. Wait `20` microseconds
 for the sensor to detect something, then read the sensor value on pin `A4`.
@@ -22,3 +22,5 @@ pins.D4.digitalWrite(true)
 control.waitMicros(20)
 let temperature = pins.A4.analogRead()
 ```
+
+## #seealso

--- a/libs/base/docs/reference/loops/forever.md
+++ b/libs/base/docs/reference/loops/forever.md
@@ -7,15 +7,15 @@ forever(() => {
 })
 ```
 
-The code you have in a ``||forever||`` loop will run and keep repeating itself the whole time your
-program is active. Code in other parts of your program won't stop while your ``||forever||``
-loop is running. This includes other ``||forever||`` loops and the [``||control:run in parallel||``](/reference/control/run-in-parallel) block.
+The code you have in a ``||loops:forever||`` loop will run and keep repeating itself the whole time your
+program is active. Code in other parts of your program won't stop while your ``||loops:forever||``
+loop is running. This includes other ``||loops:forever||`` loops and the [``||control:run in parallel||``](/reference/control/run-in-parallel) block.
 
 ## Parameters
 
 * **a**: the code to keep running over and over again.
 
-## Example
+## Example #example
 
 Rotate a blue pixel along the pixel strip (one pixel at a time) and keep it rotating.
 
@@ -33,7 +33,7 @@ forever(() => {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||while||``](/blocks/loops/while), [``||repeat||``](/blocks/loops/repeat),
-[``||run in parallel||``](/reference/control/run-in-parallel)
+[while](/blocks/loops/while), [repeat](/blocks/loops/repeat),
+[run in parallel](/reference/control/run-in-parallel)

--- a/libs/base/docs/reference/loops/pause.md
+++ b/libs/base/docs/reference/loops/pause.md
@@ -7,14 +7,14 @@ pause(400)
 ```
 
 When code in a block comes to a ``||control:pause||``, it will wait the amount of time you tell it to. Code
-in blocks like ``||forever||`` and ``||control:run in parallel||`` will keep running while code in some other
+in blocks like ``||loops:forever||`` and ``||control:run in parallel||`` will keep running while code in some other
 block is waiting at a ``||control:pause||``.
 
 ## Parameters
 
 * **ms**: the [number](/types/number) of milliseconds that you want to pause for. So, 100 milliseconds = 1/10 second, and 1000 milliseconds = 1 second.
 
-## Example
+## Example #example
 
 Light up to `5` pixels but wait one-half second before lighting each pixel.
 
@@ -26,7 +26,7 @@ for (let i = 0; i < 5; i++) {
 }
 ```
 
-## See also
+## See also #seealso
 
-[``||while||``](/blocks/loops/while), [``||for||``](/blocks/loops/for),
-[``||forever||``](/reference/loops/forever)
+[while](/blocks/loops/while), [for](/blocks/loops/for),
+[forever](/reference/loops/forever)

--- a/libs/base/docs/reference/serial/write-buffer.md
+++ b/libs/base/docs/reference/serial/write-buffer.md
@@ -5,14 +5,14 @@ Write a buffer to the serial communication port.
 ```sig
 serial.writeBuffer(pins.createBuffer(0));
 ```
-Information in a buffer is sent out the serial port with ``||write buffer||``. This is used
+Information in a buffer is sent out the serial port with ``||serial:write buffer||``. This is used
 when you want to send information that is more complex and not just simple text or a number.
 
 ## Parameters
 
 * **buffer**: the buffer to write to the serial port
 
-## Example
+## Example #example
 
 Set some special data values in a buffer and send the buffer across the serial connection.
 
@@ -25,7 +25,7 @@ sdv.setNumber(NumberFormat.Int8LE, 3, 87)
 serial.writeBuffer(sdv);
 ```
 
-## See also
+## See also #seealso
 
-[``||write line||``](/reference/serial/write-line),
-[``||write number||``](/reference/serial/write-number)
+[write line](/reference/serial/write-line),
+[write number](/reference/serial/write-number)

--- a/libs/base/docs/reference/serial/write-line.md
+++ b/libs/base/docs/reference/serial/write-line.md
@@ -10,16 +10,16 @@ A line of text is string that has two special characters added at the end: _carr
 and _line feed_. These characters are really just codes that mean start a new line.
 Sometimes they appear in code as ``"\r\n"``.
 
-After using a ``||write line||``, any new text written to the serial port will begin on a new line.
+After using a ``||serial:write line||``, any new text written to the serial port will begin on a new line.
 
-With ``||write line||``, the new line characters are automatically added for you. You only need to
+With ``||serial:write line||``, the new line characters are automatically added for you. You only need to
 give the text you want to write.
 
 ## Parameters
 
 * **text**: the [string](/types/string) to write to the serial port
 
-## Example
+## Example #example
 
 Write two greeting messages to the serial port.
 
@@ -29,8 +29,8 @@ pause(5000);
 serial.writeLine("Well that's great! I'm doing well too.");
 ```
 
-## See also
+## See also #seealso
 
-[``||write number||``](/reference/serial/write-number),
-[``||write string||``](/reference/serial/write-string),
-[``||write value||``](/reference/serial/write-value)
+[write number](/reference/serial/write-number),
+[write string](/reference/serial/write-string),
+[write value](/reference/serial/write-value)

--- a/libs/base/docs/reference/serial/write-number.md
+++ b/libs/base/docs/reference/serial/write-number.md
@@ -14,7 +14,7 @@ started when it's finished.
 
 * **value**: the [number](/types/number) to write to the serial port
 
-## Example
+## Example #example
 
 Write a 10-digit number to the serial port many, many times.
 
@@ -25,7 +25,7 @@ forever(() => {
 });
 ```
 
-## See also
+## See also #seealso
 
 [``||write line||``](/reference/serial/write-line),
 [``||write value||``](/reference/serial/write-value)

--- a/libs/base/docs/reference/serial/write-string.md
+++ b/libs/base/docs/reference/serial/write-string.md
@@ -13,7 +13,7 @@ a new line.
 
 * **text**: the [string](/types/string) to write to the serial port
 
-## Example
+## Example #example
 
 Writes the word `JUMBO` to the serial port a bunch of times, without any new lines.
 
@@ -24,8 +24,8 @@ forever(() => {
 });
 ```
 
-## See also
+## See also #seealso
 
-[``||write line||``](/reference/serial/write-line),
-[``||write number||``](/reference/serial/write-number),
-[``||write value||``](/reference/serial/write-value)
+[write line](/reference/serial/write-line),
+[write number](/reference/serial/write-number),
+[write value](/reference/serial/write-value)

--- a/libs/base/docs/reference/serial/write-value.md
+++ b/libs/base/docs/reference/serial/write-value.md
@@ -11,7 +11,7 @@ itself. If you want to send a temperature value of 32 degrees as a _name:value_ 
 it would go to the serial port as this: "temperature:32". This is a good way to
 connect a number value to it's meaning.
 
-So, ``||write value||`` does this but you give the name and the value as two parts and it
+So, ``||serial:write value||`` does this but you give the name and the value as two parts and it
 sends it as a pair.
 
 ## Parameters
@@ -19,7 +19,7 @@ sends it as a pair.
 * **name**: a [string](/types/string) that is the name part of the _name:value_ pair
 * **value**: a [number](/types/number) that is the value part of the _name:value_ pair 
 
-## Example
+## Example #example
 
 Send _name:value_ pairs for odd and even numbers to the serial port.
 
@@ -33,8 +33,8 @@ for (let i = 0; i < 10; i++) {
 }
 ```
 
-## See also
+## See also #seealso
 
-[``||write line||``](/reference/serial/write-line),
-[``||write number||``](/reference/serial/write-number)
+[write line](/reference/serial/write-line),
+[write number](/reference/serial/write-number)
 

--- a/libs/core/docs/reference/pins/analog-read.md
+++ b/libs/core/docs/reference/pins/analog-read.md
@@ -15,7 +15,7 @@ is something between `0` and `1023`.  A `0` is no signal and `1023` is a full si
 
 * a [number](types/number) between `0` and `1023` that is amount of signal at the pin.
 
-## Example #ex1
+## Example #example
 
 Use the pixel strip as a signal meter. Read from pin `A2` and display the value as a graph on the pixel
 strip. Also, output the value to the serial port.
@@ -31,6 +31,6 @@ forever(function() {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||analog write||``](/reference/pins/analog-write)
+[analog write](/reference/pins/analog-write)

--- a/libs/thermometer/docs/reference/input/on-temperature-condition-changed.md
+++ b/libs/thermometer/docs/reference/input/on-temperature-condition-changed.md
@@ -24,7 +24,7 @@ Or, you use ``warm`` to run your code when it warms to your temperature _thresho
 * **unit**: the unit of temperature, Celcius or Fahrenheit
 * **handler**: the code to run when the temperature changes
 
-## Example
+## Example #example
 
 Make all the pixels show `blue` when the temperature gets cool. The cool setting is `10` degrees Celsius or colder.
 
@@ -33,9 +33,9 @@ input.onTemperatureConditionChanged(TemperatureCondition.Cold, 10, TemperatureUn
 	light.createStrip().setAll(Colors.Blue);
 })
 ```
-# See also
+## See also #seealso
 
-[``||temperature||``](/reference/input/temperature)
+[temperature](/reference/input/temperature)
 
 ```package
 temperature

--- a/libs/thermometer/docs/reference/input/temperature.md
+++ b/libs/thermometer/docs/reference/input/temperature.md
@@ -72,7 +72,7 @@ better thermometer.
 
 ### ~
 
-## See also
+## See also #seeaslo
 
-[``||on temperature condition changed||``](/reference/input/on-temperature-condition-changed)
+[on temperature condition changed](/reference/input/on-temperature-condition-changed)
 


### PR DESCRIPTION
First batch of mods for CP docs for sections to override in targets.

- [x] Add section ids for 'Example' and 'See also'.
- [x] Remove block styling from 'See also' links.
- [x] Update 'acceleration' topic.