### PR TITLE
Section tagging for target overrides in docs - 02

### DIFF
--- a/libs/base/docs/reference/control/wait-for-event.md
+++ b/libs/base/docs/reference/control/wait-for-event.md
@@ -6,7 +6,7 @@ Stop running the current code and wait for an event.
 control.waitForEvent(0, 0)
 ```
 You might want your code to stop for a while until some event you're expecting happens.
-If you want your code to pause until a known event happens, use a ``||corntrol:wait for event||`` block.
+If you want your code to pause until a known event happens, use a ``||control:wait for event||`` block.
 A known event is something you identify that happens on the board or in your program.
 An event has both a source and a cause. The source is where the event comes from, like a sensor or
 some condition in your program. The cause is what made the event happen at the source.
@@ -60,4 +60,4 @@ pixels.setPixelColor(0, Colors.Yellow);
 
 ## See also #seealso
 
-[``||raise event||``](/reference/control/raise-event), [``||on event||``](/reference/control/on-event)
+[raise event](/reference/control/raise-event), [on event](/reference/control/on-event)

--- a/libs/base/docs/reference/serial/write-number.md
+++ b/libs/base/docs/reference/serial/write-number.md
@@ -27,6 +27,6 @@ forever(() => {
 
 ## See also #seealso
 
-[``||write line||``](/reference/serial/write-line),
-[``||write value||``](/reference/serial/write-value)
+[write line](/reference/serial/write-line),
+[write value](/reference/serial/write-value)
 

--- a/libs/buttons/docs/reference/input/button/is-pressed.md
+++ b/libs/buttons/docs/reference/input/button/is-pressed.md
@@ -24,7 +24,7 @@ Read about [**touch sensors**](/reference/input/button/touch-sensors) and using 
 
 * a [boolean](types/boolean): `true` if the button is pressed, `false` if the button is not pressed
 
-## Example
+## Example #example
 
 Set all the pixels to green when button `A` is pressed. When the button is not pressed, the pixels are red.
 
@@ -40,9 +40,9 @@ forever(function() {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||was pressed||``](/reference/input/button/was-pressed),
-[``||on event||``](/reference/input/button/on-event)
+[was pressed](/reference/input/button/was-pressed),
+[on event](/reference/input/button/on-event)
 
 [Touch sensors](/reference/input/button/touch-sensors)

--- a/libs/buttons/docs/reference/input/button/on-event.md
+++ b/libs/buttons/docs/reference/input/button/on-event.md
@@ -35,7 +35,7 @@ Read about [**touch sensors**](/reference/input/button/touch-sensors) and using 
 > * ``held``: button was pressed and is still pressed
 * ``body`` the code you want to run when something happens with a button
 
-## Examples #exsection
+## Examples #example
 
 ### Next light please #ex1
 
@@ -72,7 +72,7 @@ input.buttonB.onEvent(ButtonEvent.Up, function() {
 })
 ```
 
-### Touch down
+### Touch down #ex3
 
 Make a pixel turn `pink` when you touch the capacitive pin `pin A1` on the board. The pixel then turns
 `green` when you lift your finger off of the pin.
@@ -88,10 +88,10 @@ input.pinA1.onEvent(ButtonEvent.Up, () => {
 })
 ```
 
-### See also
+## See also #seealso
 
-[``||is pressed||``](/reference/input/button/is-pressed),
-[``||was pressed||``](/reference/input/button/was-pressed),
-[``||random||``](/blocks/math#random-value)
+[is pressed](/reference/input/button/is-pressed),
+[was pressed](/reference/input/button/was-pressed),
+[random](/blocks/math#random-value)
 
 [Touch sensors](/reference/input/button/touch-sensors)

--- a/libs/buttons/docs/reference/input/button/touch-sensors.md
+++ b/libs/buttons/docs/reference/input/button/touch-sensors.md
@@ -37,8 +37,8 @@ The capacitive touch pins on your board work as touch sensors by themselves, **W
 You can even attach wires to them to make a bigger sensor with other conductive material.
 ## ~
 
-## See Also
+## See also #seealso
 
-[``||on event||``](/reference/input/button/on-event)
-[``||is pressed||``](/reference/input/button/is-pressed),
-[``||on event||``](/reference/input/button/on-event)
+[on event](/reference/input/button/on-event)
+[is pressed](/reference/input/button/is-pressed),
+[on event](/reference/input/button/on-event)

--- a/libs/buttons/docs/reference/input/button/was-pressed.md
+++ b/libs/buttons/docs/reference/input/button/was-pressed.md
@@ -29,7 +29,7 @@ Read about [**touch sensors**](/reference/input/button/touch-sensors) and using 
 
 * a [boolean](types/boolean): `true` if the button was pressed before, `false` if the button was not pressed before
 
-## Example
+## Example #example
 
 Set all the pixels to green if button `A` was pressed before button `B`. If not, turn all pixels off when button `B`is pressed.
 
@@ -44,9 +44,9 @@ input.buttonB.onEvent(ButtonEvent.Click, function() {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||is pressed||``](/reference/input/button/is-pressed),
-[``||on event||``](/reference/input/button/on-event)
+[is pressed](/reference/input/button/is-pressed),
+[on event](/reference/input/button/on-event)
 
 [Touch sensors](/reference/input/button/touch-sensors)

--- a/libs/cable/docs/reference/network/cable-send-number.md
+++ b/libs/cable/docs/reference/network/cable-send-number.md
@@ -12,7 +12,7 @@ The cable transmitter on your board will send a number as part of a data message
 
 * **value**: the [number](types/number) to send to another @boardname@ using a cable.
 
-## Example #ex1
+## Example #example
 
 Send the numbers `0` to `9` to another @boardname@. Wait a little bit between each send to let the
 receiving board think about the number it just got.
@@ -24,9 +24,9 @@ for (let i = 0; i <= 9; i++) {
 }
 ```
 
-## See also
+## See also #seealso
 
-[``||network:on cable received number||``](/reference/network/on-cable-received-number)
+[on cable received number](/reference/network/on-cable-received-number)
 
 ```package
 cable

--- a/libs/cable/docs/reference/network/on-cable-received-number.md
+++ b/libs/cable/docs/reference/network/on-cable-received-number.md
@@ -19,7 +19,7 @@ board wants to send you so your program just receives the _data_ part of the pac
 This function takes 1 argument:
 * ``num``: a single [number](/types/number) value from the sender.
 
-## Example #ex1
+## Example #example
 
 Show the value of a number received from an cable data message. The number is shown by lighting the same number of pixels on the pixel strip.
 
@@ -31,9 +31,9 @@ network.onCableReceivedNumber(function (num) {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||network:cable send number||``](/reference/network/cable-send-number)
+[cable send number](/reference/network/cable-send-number)
 
 ```package
 cable

--- a/libs/core/docs/reference/pins/analog-set-period.md
+++ b/libs/core/docs/reference/pins/analog-set-period.md
@@ -17,7 +17,7 @@ microseconds and 1 millisecond is 1000 microseconds.
 
 * **period**: a [number](types/number) that is the period for the pulse signal sent at the pin.
 
-## Example #ex1
+## Example #example
 
 Set the period for a PWM signal to 20 milliseconds.
 
@@ -25,9 +25,9 @@ Set the period for a PWM signal to 20 milliseconds.
 pins.A1.analogSetPeriod(20000)
 ```
 
-## See Also
+## See also #seealso
 
-[``||servo write||``](/reference/pins/servo-write),
-[``||servo set pulse||``](/reference/pins/servo-set-pulse)
+[servo write](/reference/pins/servo-write),
+[servo set pulse](/reference/pins/servo-set-pulse)
 
 [What is PWM?](/reference/pins/what-is-pwm)

--- a/libs/core/docs/reference/pins/analog-write.md
+++ b/libs/core/docs/reference/pins/analog-write.md
@@ -17,7 +17,7 @@ voltage range used by your board.
 *  **value**: a [number](types/number) between `0` (no signal) and `1023` (full signal)
 
 
-## Example #ex1
+## Example #example
 
 Create a sawtooth wave signal on pin `A0`.
 
@@ -38,6 +38,6 @@ forever(() => {
 
 ```
 
-## See also
+## See also #seealso
 
-[``||analog read||``](/reference/pins/analog-read)
+[analog read](/reference/pins/analog-read)

--- a/libs/core/docs/reference/pins/digital-read.md
+++ b/libs/core/docs/reference/pins/digital-read.md
@@ -5,6 +5,7 @@ Read a digital `false` or `true` from a pin.
 ```sig
 pins.A0.digitalRead()
 ```
+
 Digital pins read one of two values: `false` or `true`. Often the `false` means something connected
 to the pin is turned **off** or its status is `false`. In a similar way, `true` means something
 connected to the pin is **on** or has a status of `true`.
@@ -13,7 +14,7 @@ connected to the pin is **on** or has a status of `true`.
 
 * a [boolean](types/boolean) value that is either `false` or `true`. The meaning of the value depends on how something connected to the pin decides on what value to give.
 
-## Example #ex1
+## Example #example
 
 See if a switch on your bread board is on or off. The switch is connected to pin `D4`. If
 the switch is on, change the pixel at position `2` on the pixel strip to `green`.
@@ -29,6 +30,6 @@ if (mySwitchOn) {
 }
 ```
 
-## See also
+## See also #seealso
 
-[``||digital write||``](/reference/pins/digital-write)
+[digital write](/reference/pins/digital-write)

--- a/libs/core/docs/reference/pins/digital-write.md
+++ b/libs/core/docs/reference/pins/digital-write.md
@@ -9,14 +9,14 @@ Digital pins write one of two values: `false` or `true`. Often the `false` means
 to the pin is turned **off** or its status is `false`. In a similar way, `true` means something
 connected to the pin is **on** or has a status of `true`.
 
-The value from the last ``||digital write||`` stays at the pin until another ``||digital write||``
+The value from the last ``||pins:digital write||`` stays at the pin until another ``||pins:digital write||``
 happens.
 
 ## Parameters
 
 * **value**: a [boolean](types/boolean) value that is either `false` or `true`. The meaning of the value depends on how something connected to the pin behaves when it gets the new value.
 
-## Example #ex1
+## Example #example
 
 Light an LED on your bread board that is connected to pin `D4`. You write the value `true` to the pin.
 
@@ -24,6 +24,6 @@ Light an LED on your bread board that is connected to pin `D4`. You write the va
 pins.D4.digitalWrite(true)
 ```
 
-## See also
+## See also #seealso
 
-[``||digital read||``](/reference/pins/digital-read)
+[digital read](/reference/pins/digital-read)

--- a/libs/core/docs/reference/pins/i2c-read-number.md
+++ b/libs/core/docs/reference/pins/i2c-read-number.md
@@ -47,7 +47,7 @@ again right away.
 * a [number](types/number) that is read from the I2C bus. It is one or more
 bytes in size depending on what type you asked for in **format**.
 
-## Example #ex1
+## Example #example
 
 Connect a temperature sensor on a breadboard to the **SDA** and **SCL** pins on your board. Set your sensor
 to respond to address `24`. Every 30 seconds, read the temperature from the sensor and write it as Fahrenheit
@@ -62,6 +62,6 @@ forever(() => {
 })
 ```
 
-## See Also
+## See also #seealso
 
-[``||i2c write number||``](/reference/pins/i2c-write-number)
+[i2c write number](/reference/pins/i2c-write-number)

--- a/libs/core/docs/reference/pins/i2c-write-number.md
+++ b/libs/core/docs/reference/pins/i2c-write-number.md
@@ -44,7 +44,7 @@ again right away.
 >This is usually `false` if you wait for a while before reading from, or writing to, the bus again.
 
 
-## Example #ex1
+## Example #example
 
 Connect a 12-bit digital-to-analog converter (DAC) on a breadboard to the **SDA** and **SCL** pins on your
 board. Set your DAC to respond to address `99`. Write numbers to the DAC to have it make a sawtooth wave
@@ -66,6 +66,6 @@ forever(() => {
 })
 ```
 
-## See Also
+## See also #seealso
 
-[``||i2c read number||``](/reference/pins/i2c-read-number)
+[i2c read number](/reference/pins/i2c-read-number)

--- a/libs/core/docs/reference/pins/on-pulsed.md
+++ b/libs/core/docs/reference/pins/on-pulsed.md
@@ -11,7 +11,7 @@ to the pin is pressed or a sensor attached to the pin wants to give a signal. A 
 changing voltage from high to low, or from low to high. The input to a pin is normally made to stay
 at either a high or low voltage when it isn't pulsed (its _unsignalled state_). You can decide what
 input value to keep the pin at is when it's not pulsed. You do this by giving it a _pull_ direction
-with [``||set pull||``](/reference/pins/set-pull).
+with [``||pins:set pull||``](/reference/pins/set-pull).
 
 Your code is inside an event block that starts when the input voltage at the pin changes. You give the
 pulse direction  you want the code to run for. Make the value for **pulse** be `high` if you want
@@ -23,7 +23,7 @@ you want your code to run when the voltage at the pin goes from high to low.
 * **pulse**: the pulse value to run code for, either `high` or `low`.
 * **body**: the code to run when the pin is pulsed.
 
-## Example #ex1
+## Example #example
 
 When pin `D4` is pulsed `low`, run code that flashes an LED connected to pin `D13` .
 
@@ -37,6 +37,6 @@ pins.D4.onPulsed(PulseValue.Low, () => {
 })
 ```
 
-## See Also
+## See also #seealso
 
-[``||pulse in||``](/reference/pins/pulse-in), [``||set pull||``](/reference/pins/set-pull)
+[pulse in](/reference/pins/pulse-in), [set pull](/reference/pins/set-pull)

--- a/libs/core/docs/reference/pins/pulse-duration.md
+++ b/libs/core/docs/reference/pins/pulse-duration.md
@@ -6,17 +6,17 @@ Get the length of time for last pulse at any of the digital pins.
 pins.pulseDuration()
 ```
 
-If you have code in an [``||on pulsed||``](/reference/pins/on-pulsed) event and you want to know how long the pulse lasted on that pin, use ``||pulse duration||``. 
+If you have code in an [``||pins:on pulsed||``](/reference/pins/on-pulsed) event and you want to know how long the pulse lasted on that pin, use ``||pins:pulse duration||``. 
 
-The ``||pulse duration||`` block remembers how many microseconds the last pulse was. This is only for the most
-recent pulse period that happened at any of the pins. So, you use it in an ``||on pulsed||`` event block so that
+The ``||pins:pulse duration||`` block remembers how many microseconds the last pulse was. This is only for the most
+recent pulse period that happened at any of the pins. So, you use it in an ``||pins:on pulsed||`` event block so that
 you know which pin the pulse was on.
 
 ## Returns
 
 * a [number](/types/number) that is length of time (duration) of the last pulse, in microseconds.
 
-## Example #ex1
+## Example #example
 
 Count every pulse on pin `D4` that is longer than 2 milleseconds in duration. Write the total
 number of pulses to the serial port every time the count adds another thousand pulses.
@@ -35,7 +35,7 @@ pins.D4.onPulsed(PulseValue.Low, () => {
 })
 ```
 
-## See Also
+## See also #seealso
 
-[``||digital read||``](/reference/pins/digital-read), [``||set pull||``](/reference/pins/set-pull),
-[``||on pulsed||``](/reference/pins/on-pulsed)
+[digital read](/reference/pins/digital-read), [set pull](/reference/pins/set-pull),
+[on pulsed](/reference/pins/on-pulsed)

--- a/libs/core/docs/reference/pins/pulse-in.md
+++ b/libs/core/docs/reference/pins/pulse-in.md
@@ -33,7 +33,7 @@ is in microseconds (1 second = 1000000 microseconds).
 
 * a [number](/types/number) that is how long the pulse happened. The pulse time is a number of microseconds.
 
-## Example #ex1
+## Example #example
 
 Check for a `low` pulse on pin `D5` every one-half of a second. Make the first pixel on the pixel strip `red`
 if there was a pulse.
@@ -54,7 +54,7 @@ forever(function() {
 })
 ```
 
-## See Also
+## See also #seealso
 
-[``||digital read||``](/reference/pins/digital-read), [``||set pull||``](/reference/pins/set-pull),
-[``||on pulsed||``](/reference/pins/on-pulsed)
+[digital read](/reference/pins/digital-read), [set pull](/reference/pins/set-pull),
+[on pulsed](/reference/pins/on-pulsed)

--- a/libs/core/docs/reference/pins/servo-set-pulse.md
+++ b/libs/core/docs/reference/pins/servo-set-pulse.md
@@ -38,7 +38,7 @@ you send a pulse number other than `1500` milliseconds to the servo. Instead of 
 Most, but not all, hobby servos that are made use the 1 to 2 millisecond pulse time to control the shaft rotation. Some
 might have smaller amount of rotation or use different pulse times for positions and speed. If you have one
 of those types of servos, find out what pulse times move the shaft where you want and use them in
-``||servo set pulse||``.
+``||pins:servo set pulse||``.
 #### ~
 
 ### PWM
@@ -54,7 +54,7 @@ long as you use a 20 millisecond signalling period.
 > * _continuous rotation_: the speed to turn the shaft in one direction or the other.
 >> * Most often, `1000` is turn full speed to the left, `2000` is full speed to the right, and `1500` stopped.
 
-## Example #ex1
+## Example #example
 
 Turn a standard serve to 135 degrees connected to pin `A1`. Wait for 3 seconds and set it back to neutral.
 
@@ -64,8 +64,8 @@ pause(3000)
 pins.A1.servoWrite(1500)
 ```
 
-## See Also
+## See also #seealso
 
-[``||servo write||``](/reference/pins/servo-write)
+[servo write](/reference/pins/servo-write)
 
 [What is PWM](/reference/pins/what-is-pwm)

--- a/libs/core/docs/reference/pins/servo-write.md
+++ b/libs/core/docs/reference/pins/servo-write.md
@@ -40,7 +40,7 @@ a speed rating in one of the directions. The number `0` is full speed rotating t
 >> * `90` to `180`, the shaft spins faster rotating to the _right_ as the number reaches `180`.
 >> * `180` full speed rotating to the _right_.
 
-## Example #ex1
+## Example #example
 
 Connect a servo to pin `A1`. Wag (rotate right and left) the arm on the servo shaft 45 degrees in each
 direction for 5 times.
@@ -54,9 +54,9 @@ for (let i = 1; i <= 5; i++) {
 }
 ```
 
-## See Also
+## See also #seealso
 
-[``||servo set pulse||``](/reference/pins/servo-set-pulse),
-[``||analog set period||``](/reference/pins/analog-set-period)
+[servo set pulse](/reference/pins/servo-set-pulse),
+[analog set period](/reference/pins/analog-set-period)
 
 [What is PWM](/reference/pins/what-is-pwm)

--- a/libs/core/docs/reference/pins/set-pull.md
+++ b/libs/core/docs/reference/pins/set-pull.md
@@ -34,7 +34,7 @@ called a _pulse_ event.
 > * `none`: the pin is not connected to either high or low voltage. An external resistor or other
 electronics will make the pull direction.
 
-## Example #ex1
+## Example #example
 
 Set the pull direction for digital pin `D4` to `up`. Flash the LED connected to pin `D13` for
 one-fourth of a second when pin `D4` is pulsed `low`.
@@ -49,8 +49,8 @@ pins.D4.onPulsed(PulseValue.Low, () => {
 })
 ```
 
-## See Also
+## See also #seealso
 
-[``||digital read||``](/reference/pins/digital-read),
-[``||on pulsed||``](/reference/pins/on-pulsed),
-[``||pulse in||``](/reference/pins/pulse-in)
+[digital read](/reference/pins/digital-read),
+[on pulsed](/reference/pins/on-pulsed),
+[pulse in](/reference/pins/pulse-in)

--- a/libs/core/docs/reference/pins/what-is-pwm.md
+++ b/libs/core/docs/reference/pins/what-is-pwm.md
@@ -26,7 +26,7 @@ To make servos work, you have to keep sending a signal to them over and over aga
 servo gets this signal is called its period. For common servos, they have a signaling period of
 20 milliseconds. This means that they get a new command every 20 milliseconds which is 50 times
 every second. You might think that they are really busy but they can handle it. You probably don't
-have to use ``||analog set period||`` before writing to your servos. Servos don't use all of the
+have to use ``||pins:analog set period||`` before writing to your servos. Servos don't use all of the
 period to tell how much to turn the shaft. They usally get that information from a pulse that
 is between 5 percent and 10 percent of the signal period.
 
@@ -34,16 +34,16 @@ is between 5 percent and 10 percent of the signal period.
 
 You know that when you write a value to an analog pin you use a number between 0 and 1023. This
 creates a different voltage that is detected at the pin. Some boards will have a secret way to
-make it look like the voltage changes when you write a different value with ``||analog write||``.
+make it look like the voltage changes when you write a different value with ``||pins:analog write||``.
 The analog pin can actully make just two voltages: low (0 volts) and high (3.3 volts or 5 volts).
 In order to make many voltages, a pulse is sent for some amount time that is only part of the
 signal period. If your board can make 3.3 volts for the pin output, it can pretend to make half
-that voltage (1.65 volts) when you write `511` using ``||analog write||``. How? Well, to do it,
+that voltage (1.65 volts) when you write `511` using ``||pins:analog write||``. How? Well, to do it,
 it sends a pulse that lasts only half of the time of the period. If the period is short enough,
 many times per second, other circuits detect that the pin is giving 1.65 volts. Tricky, right!
 
-## See Also
+## See also
 
-[``||servo set pulse||``](/reference/pins/servo-set-pulse),
-[``||servo write||``](/reference/pins/servo-write)
-[``||analog set period||``](/reference/pins/analog-set-period)
+[servo set pulse](/reference/pins/servo-set-pulse),
+[servo write](/reference/pins/servo-write)
+[analog set period](/reference/pins/analog-set-period)

--- a/libs/infrared/docs/reference/network/infrared-send-number.md
+++ b/libs/infrared/docs/reference/network/infrared-send-number.md
@@ -12,7 +12,7 @@ The infrared transmitter on your board will send a number as part of a data mess
 
 * **value**: the [number](types/number) to send to another @boardname@ using infrared.
 
-## Example #ex1
+## Example #example
 
 Send the numbers `0` to `9` to another @boardname@. Wait a little bit between each send to let the
 receiving board think about the number it just got.
@@ -24,9 +24,9 @@ for (let irDataNumber = 0; irDataNumber <= 9; irDataNumber++) {
 }
 ```
 
-## See also
+## See also #seealso
 
-[``||network:on infrared received number||``](/reference/network/on-infrared-received-number)
+[on infrared received number](/reference/network/on-infrared-received-number)
 
 ```package
 infrared

--- a/libs/infrared/docs/reference/network/on-infrared-received-number.md
+++ b/libs/infrared/docs/reference/network/on-infrared-received-number.md
@@ -19,7 +19,7 @@ board wants to send you so your program just receives the _data_ part of the pac
 This function has one argument:
 * ``num``: a single [number](/types/number) value received from the sender.
 
-## Example #ex1
+## Example #example
 
 Show the value of a number received from an infrared data message. The number is shown by lighting the same number of pixels on the pixel strip.
 
@@ -33,9 +33,9 @@ network.onInfraredReceivedNumber(function (num) {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||network:infrared send number||``](/reference/network/infrared-send-number)
+[infrared send number](/reference/network/infrared-send-number)
 
 ```package
 infrared


### PR DESCRIPTION
- [x] Add section ids for 'Example' and 'See also'.
- [x] Remove block styling from 'See also' links.