### PR TITLE
Add section ids for target overrides - 03

### DIFF
--- a/libs/lightsensor/docs/reference/input/light-level.md
+++ b/libs/lightsensor/docs/reference/input/light-level.md
@@ -16,7 +16,9 @@ has to be turned on first.
 
 * a [number](/types/number) that is a light level from ``0`` (dark) to ``255`` (bright).
 
-## Example: show light level
+## Examples #example
+
+### Show light level #ex1
 
 When you press button `A` on the @boardname@, this
 program changes the brightness of the pixels accordingly.
@@ -31,7 +33,7 @@ input.buttonA.onEvent(ButtonEvent.Click, function() {
 });
 ```
 
-## Example: chart light level
+### Chart light level #ex2
 
 This program shows the light level with a [graph](/reference/light/graph) on the @boardname@ with the LEDs.
 If you carry the @boardname@ around to different places with different light levels, the graph will change.
@@ -47,7 +49,7 @@ forever(function() {
 });
 ```
 
-## See also
+## See also #seealso
 
-[``||acceleration||``](/reference/input/acceleration)
+[acceleration](/reference/input/acceleration)
 

--- a/libs/lightsensor/docs/reference/input/on-light-condition-changed.md
+++ b/libs/lightsensor/docs/reference/input/on-light-condition-changed.md
@@ -15,7 +15,7 @@ What decides that the light condition is dark or bright? A number between `0` an
 >  * ``Bright``: Light is bright enough to detect
 * **handler**: code to run when light conditions change
 
-## Example
+## Example #example
 
 Dim the red pixels to half intensity when light conditions turn dark.
 
@@ -25,6 +25,6 @@ input.onLightConditionChanged(LightCondition.Dark, function() {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||light level||``](/reference/input/light-level)
+[light level](/reference/input/light-level)

--- a/libs/lightsensor/docs/reference/input/set-light-threshold.md
+++ b/libs/lightsensor/docs/reference/input/set-light-threshold.md
@@ -33,9 +33,9 @@ input.onLightConditionChanged(LightCondition.Dark, () => {
 });
 ```
 
-## See also
+## See also #seealso
 
-[``||on light condition changed||``](/reference/input/on-light-condition-changed)
+[on light condition changed](/reference/input/on-light-condition-changed)
 
 ```package
 lightsensor

--- a/libs/microphone/docs/reference/input/on-loud-sound.md
+++ b/libs/microphone/docs/reference/input/on-loud-sound.md
@@ -10,7 +10,7 @@ input.onLoudSound(() => {});
 
 * **handler**: the code to run when a loud sound is heard.
 
-## Example
+## Example #example
 
 Flash the pixels when a loud sound is detected.
 
@@ -23,9 +23,10 @@ input.onLoudSound(() => {
 	pixels.setAll(Colors.Black);
 });
 ```
-# See also
 
-[``||sound level||``](/reference/input/sound-level)
+# See also #seealso
+
+[sound level](/reference/input/sound-level)
 
 ```package
 microphone

--- a/libs/microphone/docs/reference/input/set-loud-sound-threshold.md
+++ b/libs/microphone/docs/reference/input/set-loud-sound-threshold.md
@@ -29,9 +29,9 @@ input.onLoudSound(() => {
 });
 ```
 
-## See Also
+## See also #seealso
 
-[``||on loud sound||``](/reference/input/on-loud-sound)
+[on loud sound](/reference/input/on-loud-sound)
 
 ```package
 microphone

--- a/libs/microphone/docs/reference/input/sound-level.md
+++ b/libs/microphone/docs/reference/input/sound-level.md
@@ -28,9 +28,9 @@ forever(() => {
     }
 });
 ```
-## See also
+## See also #seealso
 
-[``||on loud sound||``](/reference/input/on-loud-sound)
+[on loud sound](/reference/input/on-loud-sound)
 
 ```package
 microphone

--- a/libs/music/docs/reference/music/beat.md
+++ b/libs/music/docs/reference/music/beat.md
@@ -14,17 +14,17 @@ music.beat(BeatFraction.Whole)
 
 * a [number](/types/number) that is the amount of time in milliseconds (one-thousandth of a second) for the beat fraction.
 
-## Example
+## Example #xample
 
 ```blocks
 music.playTone(Note.C, music.beat(BeatFraction.Quarter))
 ```
 
-## See also
+## See also #seealso
 
-[``||play tone||``](/reference/music/play-tone), [``||ring tone||``](/reference/music/ring-tone),
-[``||rest||``](/reference/music/rest), [``||set tempo||``](/reference/music/set-tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 ```package
 music

--- a/libs/music/docs/reference/music/beat.md
+++ b/libs/music/docs/reference/music/beat.md
@@ -14,7 +14,7 @@ music.beat(BeatFraction.Whole)
 
 * a [number](/types/number) that is the amount of time in milliseconds (one-thousandth of a second) for the beat fraction.
 
-## Example #xample
+## Example #example
 
 ```blocks
 music.playTone(Note.C, music.beat(BeatFraction.Quarter))

--- a/libs/music/docs/reference/music/change-tempo-by.md
+++ b/libs/music/docs/reference/music/change-tempo-by.md
@@ -11,13 +11,13 @@ This function only works on the @boardname@ and in some browsers.
 music.changeTempoBy(20)
 ```
 
-### Parameters
+## Parameters
 
 * ``bpm`` is a [number](/types/number) that says how much to
   change the bpm (beats per minute, or number of beats in a minute of
   the music that the @boardname@ is playing).
 
-### Examples
+## Example #example
 
 This program makes the music faster by 12 bpm.
 
@@ -31,7 +31,7 @@ This program makes the music _slower_ by 12 bpm.
 music.changeTempoBy(-12)
 ```
 
-### See also
+## See also #seealso
 
 [play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone) 
 

--- a/libs/music/docs/reference/music/note-frequency.md
+++ b/libs/music/docs/reference/music/note-frequency.md
@@ -22,9 +22,9 @@ music.playTone(music.noteFrequency(Note.C), 1000)
 music.rest(1000)
 music.playTone(music.noteFrequency(Note.A), 1000)
 ```
-## See also
+## See also #seealso
 
-[``||play tone||``](/reference/music/play-tone), [``||ring tone||``](/reference/music/ring-tone),
-[``||rest||``](/reference/music/rest), [``||tempo||``](/reference/music/tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [tempo](/reference/music/tempo),
+[change tempo by](/reference/music/change-tempo-by)
 

--- a/libs/music/docs/reference/music/play-sound-until-done.md
+++ b/libs/music/docs/reference/music/play-sound-until-done.md
@@ -31,7 +31,7 @@ music.playSoundUntilDone(music.sounds(Sounds.JumpUp))
 [composing sounds](/reference/music/composing-sounds) to find out how to make the sound string.
 
 
-## Examples #exsection
+## Examples #example
 
 ### My sound string #ex1
 
@@ -54,9 +54,9 @@ music.playSoundUntilDone(music.sounds(Sounds.BaDing))
 
 ## See also
 
-[``||play sound||``](/reference/music/play-sound), [``||sounds|``](/reference/music/sounds),
-[``||tempo||``](/reference/music/tempo), [``||set tempo||``](/reference/music/set-tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play sound](/reference/music/play-sound), [sounds](/reference/music/sounds),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 [Composing sounds](/reference/music/composing-sounds)
 

--- a/libs/music/docs/reference/music/play-sound-until-done.md
+++ b/libs/music/docs/reference/music/play-sound-until-done.md
@@ -52,7 +52,7 @@ Play a the built-in sound called `BaDing`.
 music.playSoundUntilDone(music.sounds(Sounds.BaDing))
 ```
 
-## See also
+## See also #seealso
 
 [play sound](/reference/music/play-sound), [sounds](/reference/music/sounds),
 [tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),

--- a/libs/music/docs/reference/music/play-sound.md
+++ b/libs/music/docs/reference/music/play-sound.md
@@ -30,7 +30,7 @@ music.playSound(music.sounds(Sounds.JumpUp))
 * ``sound``: a string containing the notes of a sound you want to play. Look at
 [composing sounds](/reference/music/composing-sounds) to find out how to make the sound string.
 
-## Examples #exsection
+## Examples #example
 
 ### My sound string #ex1
 
@@ -50,11 +50,11 @@ Play a the built-in sound called `BaDing`.
 music.playSound(music.sounds(Sounds.BaDing))
 ```
 
-## See also
+## See also #seealso
 
-[``||play sound until done||``](/reference/music/play-sound-until-done), [``||sounds|``](/reference/music/sounds),
-[``||tempo||``](/reference/music/tempo), [``||set tempo||``](/reference/music/set-tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play sound until done](/reference/music/play-sound-until-done), [sounds](/reference/music/sounds),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 [Composing sounds](/reference/music/composing-sounds)
 

--- a/libs/music/docs/reference/music/play-tone.md
+++ b/libs/music/docs/reference/music/play-tone.md
@@ -29,10 +29,10 @@ let freq = music.noteFrequency(Note.C);
 music.playTone(freq, 1000)
 ```
 
-## See also
+## See also #seealso
 
-[``||rest||``](/reference/music/rest), [``||ring tone||``](/reference/music/ring-tone) , [``||tempo||``](/reference/music/tempo),
-[``||set tempo||``](/reference/music/set-tempo), [``||change tempo by||``](/reference/music/change-tempo-by)
+[rest](/reference/music/rest), [ring tone](/reference/music/ring-tone) , [tempo](/reference/music/tempo),
+[set tempo](/reference/music/set-tempo), [change tempo by](/reference/music/change-tempo-by)
 
 ```package
 music

--- a/libs/music/docs/reference/music/rest.md
+++ b/libs/music/docs/reference/music/rest.md
@@ -28,11 +28,11 @@ forever(() => {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||play tone||``](/reference/music/play-tone), [``||ring tone||``](/reference/music/ring-tone),
-[``||tempo||``](/reference/music/tempo), [``||set tempo||``](/reference/music/set-tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 ```package
 music

--- a/libs/music/docs/reference/music/ring-tone.md
+++ b/libs/music/docs/reference/music/ring-tone.md
@@ -8,9 +8,9 @@ music.ringTone(0);
 ```
 
 ## #simnote
-#### ~hint
+### ~hint
 **Sim**: ``||ring tone||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~
 
 The tone will keep playing until you stop it with [``||stop all sounds||``](/reference/music/stop-all-sounds).
 
@@ -36,11 +36,11 @@ forever(() => {
 })
 ```
 
-### See also
+## See also #seealso
 
-[``||rest||``](/reference/music/rest), [``||play tone||``](/reference/music/play-tone),
-[``||tempo||``](/reference/music/tempo), [``||set tempo||``](/reference/music/set-tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[rest](/reference/music/rest), [play tone](/reference/music/play-tone),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 ```package
 accelerometer

--- a/libs/music/docs/reference/music/set-output.md
+++ b/libs/music/docs/reference/music/set-output.md
@@ -9,17 +9,17 @@ When your board has a speaker or analog output pins, you can play sounds on them
 to choose where you want to play your sounds.
 
 ## #simnote
-#### ~hint
+### ~hint
 **Simulator**
 
-``||set Output||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+``||set output||`` works on the @boardname@. It might not work in the simulator on every browser.
+### ~
 
 ## Parameters
 
 * ``out``: this is where the sound output will go. You can choose ``speaker`` or ``pin``.
 
-## Example
+## Example #example
 
 Change the output for the sound to go to a pin on @boardname@.
 
@@ -31,6 +31,6 @@ music.playTone(
 )
 ```
 
-## See also
+## See also #seealso
 
-[``||set pitch pin||``](/reference/music/set-pitch-pin)
+[set pitch pin](/reference/music/set-pitch-pin)

--- a/libs/music/docs/reference/music/set-pitch-pin.md
+++ b/libs/music/docs/reference/music/set-pitch-pin.md
@@ -6,21 +6,22 @@ Choose which pin to play on when sound is supposed to go to a pin.
 music.setPitchPin(pins.A3)
 ```
 ## #pins
+
 Some of the pins on the @boardname@ can play sounds. These are probably the analog output pins on the board.
 Not all of the pins on your board are output pins or can play sound.
 
 ## #simnote
-#### ~hint
+### ~hint
 **Simulator**
 
 ``||set Pitch Pin||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~
 
 ## Parameters
 
 * ``pin``: the pin to play sound at when sound goes to a pin.
 
-## Example
+## Example #example
 
 Set pitch pin to ``A1``. Switch the sound output to ``pin`` and play a tone.
 
@@ -34,6 +35,6 @@ music.playTone(
 )
 ```
 
-## See also
+## See also #seealso
 
-[``||set output||``](/reference/music/set-output)
+[set output](/reference/music/set-output)

--- a/libs/music/docs/reference/music/set-speaker-volume.md
+++ b/libs/music/docs/reference/music/set-speaker-volume.md
@@ -16,7 +16,7 @@ music.setSpeakerVolume(128)
 * ``volume``: the volume of of the sounds played on the speaker. The volume [number](/reference/types) can be
 between `0` for silent and `255` for the loudest sound.
 
-## Example #exsection
+## Example #example
 
 Set the speaker volume to something quieter.
 
@@ -25,7 +25,7 @@ music.setSpeakerVolume(50)
 music.playSound(music.sounds(Sounds.BaDing))
 ```
 
-## See also
+## See also #seealso
 
-[``||play sound||``](/reference/music/play-sound), [``||sounds|``](/reference/music/sounds)
+[play sound](/reference/music/play-sound), [sounds](/reference/music/sounds)
 

--- a/libs/music/docs/reference/music/set-tempo.md
+++ b/libs/music/docs/reference/music/set-tempo.md
@@ -16,7 +16,7 @@ music.setTempo(60)
 * ``bpm`` is a [number](/types/number) that means the amount _beats per minute_ you want. This is how fast
 you want @boardname@ to play music.
 
-## Example
+## Example #example
 
 Set the music tempo to 240 beats per minute.
 
@@ -24,11 +24,11 @@ Set the music tempo to 240 beats per minute.
 music.setTempo(240)
 ```
 
-## See also
+## See also #seealso
 
-[``||play tone||``](/reference/music/play-tone), [``||ring tone||``](/reference/music/ring-tone),
-[``||rest||``](/reference/music/rest), [``||tempo||``](/reference/music/tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [tempo](/reference/music/tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 ```package
 music

--- a/libs/music/docs/reference/music/set-tone.md
+++ b/libs/music/docs/reference/music/set-tone.md
@@ -17,9 +17,9 @@ music.setTone(null)
 
 * ``buffer``: a buffer containing 1024 10bit unsigned samples.
 
-## #examples
+## #example
 
-### #ex1
+## #seealso
 
 ```package
 music

--- a/libs/music/docs/reference/music/set-volume.md
+++ b/libs/music/docs/reference/music/set-volume.md
@@ -18,7 +18,7 @@ music.setVolume(128)
 
 * ``volume``: the volume of of the sounds played to the sound output. The volume [number](/reference/types) can be between `0` for silent and `255` for the loudest sound.
 
-## Example #exsection
+## Example #example
 
 Set the synthesizer volume to something quieter.
 
@@ -27,7 +27,7 @@ music.setVolume(50)
 music.playSound(music.sounds(Sounds.BaDing))
 ```
 
-## See also
+## See also #seealso
 
-[``||play sound||``](/reference/music/play-sound), [``||sounds|``](/reference/music/sounds)
+[play sound](/reference/music/play-sound), [sounds](/reference/music/sounds)
 

--- a/libs/music/docs/reference/music/sounds.md
+++ b/libs/music/docs/reference/music/sounds.md
@@ -16,7 +16,7 @@ can use these sounds to make actions with the @boardname@ seem more interesting.
 
 * a [string](/types/string) that is the composed sound of a built-in sound.
 
-## Example #ex1
+## Example #example
 
 Play the ``magic wand`` sound when you shake the @boardname@.
 
@@ -26,9 +26,9 @@ input.onGesture(Gesture.Shake, () => {
 })
 ```
 
-## See also
+## See also #seealso
 
-[``||play sound||``](/reference/music/play-sound)
+[play sound](/reference/music/play-sound)
 
 [Composing sounds](/reference/music/composing-sounds)
 

--- a/libs/music/docs/reference/music/stop-all-sounds.md
+++ b/libs/music/docs/reference/music/stop-all-sounds.md
@@ -15,7 +15,7 @@ sounds waiting to play with ``||stop all sounds||``.
 **Sim**: ``||stop all sounds||`` works on the @boardname@. It might not work in the simulator on every browser.
 #### ~
 
-## Example #exsection
+## Example #example
 
 Play a sound but stop it right away.
 
@@ -24,9 +24,9 @@ music.playSound(music.sounds(Sounds.Wawawawaa))
 music.stopAllSounds()
 ```
 
-## See also
+## See also #seealso
 
-[``||play sound||``](/reference/music/play-sound), [``||play sound until done||``](/reference/music/play-sound-until-done)
+[play sound](/reference/music/play-sound), [play sound until done](/reference/music/play-sound-until-done)
 
 ```package
 music

--- a/libs/music/docs/reference/music/tempo.md
+++ b/libs/music/docs/reference/music/tempo.md
@@ -6,16 +6,18 @@ Find the tempo (speed) of the music that is playing right now.
 music.tempo()
 ```
 
+## #example
+
 ## Returns
 
 * a [number](/types/number) that means the count of beats per minute (number of
   beats in a minute of the music that the @boardname@ is playing right now).
 
-## See also
+## See also #seealso
 
-[``||play tone||``](/reference/music/play-tone), [``||ring tone||``](/reference/music/ring-tone),
-[``||rest||``](/reference/music/rest), [``||set tempo||``](/reference/music/set-tempo),
-[``||change tempo by||``](/reference/music/change-tempo-by)
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)
 
 ```package
 music


### PR DESCRIPTION
- [x] Add section ids for 'Example' and 'See also' in Music and Light Sensor
- [x] Remove block styling from See also links.