### PR TITLE
converting sprite type to layer (bitmask)

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -79,16 +79,17 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     /**
      * Returns sprites that overlap with the given sprite. If type is non-zero, also filter by type.
      * @param sprite
-     * @param spriteType
+     * @param layer
      */
-    overlaps(sprite: Sprite, spriteType: number): Sprite[] {
+    overlaps(sprite: Sprite, layer: number): Sprite[] {
         if (this.map)
-            return this.map.overlaps(sprite, spriteType);
+            return this.map.overlaps(sprite, layer);
         else {
             const r: Sprite[] = [];
             const n = this.sprites.length;
             for (let i = 0; i < n; ++i) {
-                if ((!spriteType || spriteType == this.sprites[i].type) && sprite.overlapsWith(this.sprites[i]))
+                if ((!layer || !!(layer & this.sprites[i].layer)) 
+                    && sprite.overlapsWith(this.sprites[i]))
                     r.push(this.sprites[i]);
             }
             return r;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -30,8 +30,8 @@ class Sprite {
     //% blockCombine block="ay"
     ay: number
     //% group="Properties"
-    //% blockCombine block="type"
-    type: number
+    //% blockCombine block="layer"
+    layer: number
     //% group="Properties"
     //% blockCombine block="life"
     life: number;
@@ -55,7 +55,7 @@ class Sprite {
         this.ay = 0
         this.flags = 0
         this._image = img
-        this.type = 0
+        this.layer = 0
         this.life = -1
     }
 

--- a/libs/game/spritemap.ts
+++ b/libs/game/spritemap.ts
@@ -13,14 +13,14 @@ namespace sprites {
         /**
          * Returns a potential list of neighbors
          */
-        neighbors(sprite: Sprite, spriteType: number): Sprite[] {
+        neighbors(sprite: Sprite, layer: number): Sprite[] {
             if (this.isOob(sprite)) return [];
 
             const n: Sprite[] = [];
-            this.mergeAtKey(sprite.left, sprite.top, spriteType, n)
-            this.mergeAtKey(sprite.left, sprite.bottom, spriteType, n)
-            this.mergeAtKey(sprite.right, sprite.top, spriteType, n)
-            this.mergeAtKey(sprite.right, sprite.bottom, spriteType, n)
+            this.mergeAtKey(sprite.left, sprite.top, layer, n)
+            this.mergeAtKey(sprite.left, sprite.bottom, layer, n)
+            this.mergeAtKey(sprite.right, sprite.top, layer, n)
+            this.mergeAtKey(sprite.right, sprite.bottom, layer, n)
             n.removeElement(sprite);
             return n;
         }
@@ -29,15 +29,15 @@ namespace sprites {
          * Gets the overlaping sprites if any
          * @param sprite 
          */
-        overlaps(sprite: Sprite, spriteType: number): Sprite[] {
-            const n = this.neighbors(sprite, spriteType);
+        overlaps(sprite: Sprite, layer: number): Sprite[] {
+            const n = this.neighbors(sprite, layer);
             const o = n.filter(neighbor => sprite.overlapsWith(neighbor));
             return o;
         }
 
         draw() {
-            for(let x = 0; x < this.columnCount; ++x) {
-                for(let y = 0; y < this.rowCount; ++y) {
+            for (let x = 0; x < this.columnCount; ++x) {
+                for (let y = 0; y < this.rowCount; ++y) {
                     const left = x * this.cellWidth;
                     const top = y * this.cellHeight;
                     const k = this.key(left, top);
@@ -99,17 +99,18 @@ namespace sprites {
             const top = sprite.top;
             const xn = Math.ceil(sprite.width / this.cellWidth)
             const yn = Math.ceil(sprite.height / this.cellHeight);
-            for(let x = 0; x <= xn; x ++)
-                for(let y = 0; y <= yn; y ++)
+            for (let x = 0; x <= xn; x++)
+                for (let y = 0; y <= yn; y++)
                     this.insertAtKey(left + Math.min(sprite.width, x * this.cellWidth), top + Math.min(sprite.height, y * this.cellHeight), sprite)
         }
 
-        private mergeAtKey(x: number, y: number, type: number, n: Sprite[]) {
+        private mergeAtKey(x: number, y: number, layer: number, n: Sprite[]) {
             const k = this.key(x, y);
             const bucket = this.buckets[k];
             if (bucket) {
                 for (const sprite of bucket)
-                    if ((!type || sprite.type == type) && n.indexOf(sprite) < 0)
+                    if ((!layer || !!(sprite.layer & layer))
+                        && n.indexOf(sprite) < 0)
                         n.push(sprite);
             }
         }

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -28,7 +28,7 @@ namespace tiles {
         private _needsUpdate: boolean;
         private _offsetX: number;
         private _offsetY: number;
-        private _spriteType: number;
+        private _layer: number;
     
         private _map: Image;
         private _tiles: Tile[];
@@ -69,13 +69,13 @@ namespace tiles {
             }
         }
     
-        get spriteType(): number {
-            return this._spriteType;
+        get layer(): number {
+            return this._layer;
         }
     
-        set spriteType(value: number) {
-            this._spriteType = value;
-            this._tileSprites.forEach(sp => sp.sprite.type = this._spriteType);
+        set layer(value: number) {
+            this._layer = value;
+            this._tileSprites.forEach(sp => sp.sprite.layer = this._layer);
         }
     
         setTile(index: number, img: Image, collisions: boolean) {
@@ -132,7 +132,7 @@ namespace tiles {
                     const tile = this._tiles[index];
                     if (tile && !this._tileSprites.some(ts => ts.x == x && ts.y == y)) {
                         const tileSprite = new TileSprite(x, y, index, sprites.create(tile.image));
-                        tileSprite.sprite.type = this._spriteType;
+                        tileSprite.sprite.layer = this._layer;
                         tileSprite.sprite.z = -1;
                         if (!tile.collisions)
                             tileSprite.sprite.setFlag(SpriteFlag.Ghost, true)


### PR DESCRIPTION
It's more flexible to treat the "sprite type" as a layer and a bitmask. So a sprite can be part of multiple "layers" efficiently.