### PR TITLE
Improving tile map performance

### DIFF
--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -6,12 +6,12 @@ namespace scene {
     export enum Flag {
         NeedsSorting = 1 << 1,
     }
-    
+
     export class Scene {
         eventContext: control.EventContext;
         background: Background;
         tileMap: tiles.TileMap;
-        allSprites: Sprite[];
+        allSprites: SpriteLike[];
         physicsEngine: PhysicsEngine;
         camera: scene.Camera;
         flags: number;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -18,11 +18,18 @@ enum CollisionDirection {
     Bottom = 3
 }
 
+interface SpriteLike {
+    z: number;
+    id: number;
+    __update(camera: scene.Camera, dt: number): void;
+    __draw(camera: scene.Camera): void;
+}
+
 /**
  * A sprite on screem
  **/
 //% blockNamespace=Sprites color="#23c47e" blockGap=8
-class Sprite {
+class Sprite implements SpriteLike {
     //% group="Properties"
     //% blockCombine block="x"
     x: number
@@ -260,8 +267,8 @@ class Sprite {
 
     /**
      * Registers code when the sprite collides with another sprite
-     * @param direction 
-     * @param handler 
+     * @param direction
+     * @param handler
      */
     //% group="Collisions"
     //% blockId=spriteoncollision block="on %sprite collided %direction with"
@@ -269,13 +276,13 @@ class Sprite {
     onCollision(direction: CollisionDirection, handler: (other: Sprite) => void) {
         if (!this.collisionHandlers)
             this.collisionHandlers = [];
-        direction = Math.max(0, Math.min(3, direction | 0));       
+        direction = Math.max(0, Math.min(3, direction | 0));
         this.collisionHandlers[direction] = handler;
     }
 
     /**
      * Determines if there is an obstacle in the given direction
-     * @param direction 
+     * @param direction
      */
     //% blockId=spritehasobstacle block="has %sprite obstacle %direction"
     //% group="Collisions"
@@ -285,7 +292,7 @@ class Sprite {
 
     /**
      * Gets the obstacle sprite in a given direction if any
-     * @param direction 
+     * @param direction
      */
     //% blockId=spritehasobstacle block="%sprite obstacle %direction"
     //% group="Collisions"
@@ -300,7 +307,7 @@ class Sprite {
     registerObstacle(direction: CollisionDirection, other: Sprite) {
         if (!this._obstacles)
             this._obstacles = [];
-        this._obstacles[direction] = other;        
+        this._obstacles[direction] = other;
 
         const handler = this.collisionHandlers ? this.collisionHandlers[direction] : undefined;
         if (handler)


### PR DESCRIPTION
The tile map creates a sprite for every tile, even if the tile isn't an obstacle. This change makes it so that the tilemap only creates sprites for obstacles and draws all of the ghost-tiles at once. This improves render time by a lot (roughly 10x on the princess walking program).