### PR TITLE
Adding percent chance block

### DIFF
--- a/libs/game/mathUtil.ts
+++ b/libs/game/mathUtil.ts
@@ -1,0 +1,18 @@
+namespace Math {
+    /**
+     * Returns a random boolean that is true the given percentage of the time.
+     * @param percentage The percentage chance that the returned value will be true from 0 - 100
+     */
+    //% weight=1
+    //% blockId=percentchance block="%percentage|\\% chance"
+    //% percentage.min=0 percentage.max=100;
+    export function percentChance(percentage: number): boolean {
+        if (percentage >= 100) {
+            return true;
+        }
+        else if (percentage <= 0) {
+            return false;
+        }
+        return Math.randomRange(0, 99) < percentage;
+    }
+}

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -17,7 +17,8 @@
         "scenes.ts",
         "game.ts",
         "targetoverrides.cpp",
-        "targetoverrides.ts"
+        "targetoverrides.ts",
+        "mathUtil.ts"
     ],
     "public": true,
     "dependencies": {


### PR DESCRIPTION
Randomness comes up a ton in games and while `Math.random()` is great it isn't the friendliest thing to read. This adds a utility function to the game package that uses a percentage (0 - 100). Any ideas for other useful functions to add? I was thinking `Math.clamp()` but I didn't want to re-export it in this file.