### PR TITLE
Update light sensor ref docs for level parms

### DIFF
--- a/libs/lightsensor/docs/reference/input/on-light-condition-changed.md
+++ b/libs/lightsensor/docs/reference/input/on-light-condition-changed.md
@@ -21,7 +21,7 @@ Dim the red pixels to half intensity when light conditions turn dark.
 
 ```blocks
 input.onLightConditionChanged(LightCondition.Dark, function() {
-	light.createStrip().setBrightness(light.fade(light.rgb(255, 0, 0), 128))
+	light.createStrip().setAll(light.fade(light.rgb(255, 0, 0), 128))
 })
 ```
 

--- a/libs/lightsensor/docs/reference/input/on-light-condition-changed.md
+++ b/libs/lightsensor/docs/reference/input/on-light-condition-changed.md
@@ -6,13 +6,13 @@ Run some code when the light conditions change.
 input.onLightConditionChanged(LightCondition.Dark, function() {
 });
 ```
-What decides that the light condition is dark or bright? A number between `0` and `1023` is chosen for the light level that will mean either dark or bright.
+What decides that the light condition is dark or bright? A number between `0` and `255` is set for both of these light level conditions. These light level values decide which condition means ``dark`` and which condition means ``bright``. They are set by the ``||input:set light threshold||`` function.
 
 ## Parameters
 
 * **condition**: the lighting condition to detect
->  * ``Dark``: Dark, no light detected
->  * ``Bright``: Light is bright enough to detect
+>  * ``dark``: Dark, no light detected
+>  * ``bright``: Light is bright enough to detect
 * **handler**: code to run when light conditions change
 
 ## Example #example
@@ -21,10 +21,11 @@ Dim the red pixels to half intensity when light conditions turn dark.
 
 ```blocks
 input.onLightConditionChanged(LightCondition.Dark, function() {
-	light.createStrip().setBrightness(light.fade(0xff0000, 128))
+	light.createStrip().setBrightness(light.fade(light.rgb(255, 0, 0), 128))
 })
 ```
 
 ## See also #seealso
 
-[light level](/reference/input/light-level)
+[light level](/reference/input/light-level),
+[set light threshold](/reference/input/set-light-threshold)

--- a/libs/lightsensor/docs/reference/input/set-light-threshold.md
+++ b/libs/lightsensor/docs/reference/input/set-light-threshold.md
@@ -19,8 +19,7 @@ light gets brighter or darker.
 
 ## Example #example
 
-Set a light condition for when light goes from bright to half dark. Make the pixels fade to half red when
-that happens.
+Set a light condition for when light goes from bright to half dark. Make the pixels fade to half red when that happens.
 
 ```blocks
 const halfBright = 127;
@@ -29,7 +28,7 @@ let pixels = light.createStrip();
 pixels.setAll(0xff0000);
 input.setLightThreshold(LightCondition.Dark, halfBright);
 input.onLightConditionChanged(LightCondition.Dark, () => {
-	pixels.setBrightness(light.fade(light.rgb(255, 0, 0), halfBright));
+	pixels.setAll(light.fade(light.rgb(255, 0, 0), halfBright));
 });
 ```
 

--- a/libs/lightsensor/docs/reference/input/set-light-threshold.md
+++ b/libs/lightsensor/docs/reference/input/set-light-threshold.md
@@ -15,7 +15,7 @@ light gets brighter or darker.
 ## Parameters
 
 * **conditon**: the light condition you are checking for, either `dark` or `bright`.
-* **value**: a [number](/types/number) which is the brightness value that will make a light event happen.
+* **value**: a [number](/types/number) which is the brightness value that will make a light event happen. This is a number between `0` (completely dark) and `255` (very bright).
 
 ## Example #example
 
@@ -29,7 +29,7 @@ let pixels = light.createStrip();
 pixels.setAll(0xff0000);
 input.setLightThreshold(LightCondition.Dark, halfBright);
 input.onLightConditionChanged(LightCondition.Dark, () => {
-	pixels.setBrightness(light.fade(0xff0000, halfBright));
+	pixels.setBrightness(light.fade(light.rgb(255, 0, 0), halfBright));
 });
 ```
 


### PR DESCRIPTION
RE: https://github.com/Microsoft/pxt-adafruit/issues/707

- [x] Fix the parameter ranges for light levels in descriptions.
- [x] Fix RBG values in examples.