### PR TITLE
Removing playSound's default value

### DIFF
--- a/libs/music/melodies.ts
+++ b/libs/music/melodies.ts
@@ -88,7 +88,7 @@ namespace music {
     /**
      * Start playing a sound and don't wait for it to finish.
      * Notes are expressed as a string of characters with this format: NOTE[octave][:duration]
-     * @param sound the melody to play, eg: "b5:1 e6:3"
+     * @param sound the melody to play
      */
     //% help=music/play-sound
     //% blockId=music_play_sound block="play sound %sound=music_sounds"
@@ -108,7 +108,7 @@ namespace music {
     /**
      * Play a sound and wait until the sound is done.
      * Notes are expressed as a string of characters with this format: NOTE[octave][:duration]
-     * @param sound the melody to play, eg: Sounds.PowerUp
+     * @param sound the melody to play
      */
     //% help=music/play-sound-until-done
     //% blockId=music_play_sound_until_done block="play sound %sound=music_sounds|until done"


### PR DESCRIPTION
This at least gets us the old behavior in the toolbox (Power Up is selected by default) and the completions from Monaco are no longer broken (you get an empty string; not ideal but whatever)

Any other fix will require changes to PXT. Just to break down why this is an issue:

`playSound()` takes a string argument but uses a shadow block called `sound()` for the default value in blocks

`sound()` takes an enum argument and returns a string

In PXT when you give a default value for an argument then that value is sent to the shadow block in the toolbox and also the completion snippets in Monaco. Usually that works because the shadow block doesn't do anything to the value (shim=TD_ID) and so the same default argument for the shadow block also works for the parameter. Because the `sound()` shadow block actually does something to the argument it is passed (turns a number into a string) our strategy breaks down here.

We need a new authoring syntax for specifying default values on the shadow and for the actual API.
