### PR TITLE
Don't do custom memset on linux

### DIFF
--- a/libs/core/buffer.ts
+++ b/libs/core/buffer.ts
@@ -40,7 +40,7 @@ namespace pins {
      */
     //%
     export function createBufferFromArray(bytes: number[]) {
-        let buf = createBuffer(bytes.length)
+        let buf = control.createBuffer(bytes.length)
         for (let i = 0; i < bytes.length; ++i)
             buf[i] = bytes[i]
         return buf
@@ -113,7 +113,7 @@ namespace pins {
     }
 
     export function packBuffer(format: string, nums: number[]) {
-        let buf = createBuffer(packedSize(format))
+        let buf = control.createBuffer(packedSize(format))
         packUnpackCore(format, nums, buf, true)
         return buf
     }
@@ -214,7 +214,7 @@ namespace msgpack {
         for (let n of nums) {
             off += packNumberCore(null, off, n)
         }
-        let buf = pins.createBuffer(off)
+        let buf = control.createBuffer(off)
         off = 0
         for (let n of nums) {
             off += packNumberCore(buf, off, n)

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -929,6 +929,7 @@ Buffer doubledIcon(Buffer icon) {
 // This is  6.5x faster than standard on word-aligned copy
 // probably should move to codal
 
+#ifndef __linux__
 extern "C" void *memcpy(void *dst, const void *src, size_t sz) {
     if (sz >= 4 && !((uintptr_t)dst & 3) && !((uintptr_t)src & 3)) {
         size_t cnt = sz >> 2;
@@ -972,3 +973,4 @@ extern "C" void *memset(void *dst, int v, size_t sz) {
 
     return dst;
 }
+#endif


### PR DESCRIPTION
This just adds `#ifndef __linux__` around memset/memcpy, but I also fixed line endings, hence the diff... 