### PR TITLE
New arcade physics

### DIFF
--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -29,6 +29,9 @@ namespace scene {
                 this.offsetY = scene.tileMap.offsetY(this.offsetY);
             }
 
+            this.offsetX |= 0;
+            this.offsetY |= 0;
+
             if (this.oldOffsetX != this.offsetX
                 || this.oldOffsetY != this.offsetY) {
                 this.oldOffsetX = this.offsetX;

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -1,0 +1,82 @@
+namespace game {
+    export class Hitbox {
+        parent: Sprite;
+        ox: number;
+        oy: number;
+        width: number;
+        height: number;
+
+        constructor(parent: Sprite, width: number, height: number, ox: number, oy: number) {
+            this.width = width;
+            this.height = height;
+            this.parent = parent;
+            this.ox = ox;
+            this.oy = oy;
+        }
+
+        get left() {
+            return this.parent.left + this.ox;
+        }
+
+        get top() {
+            return this.parent.top + this.oy;
+        }
+
+        get right() {
+            return this.left + this.width - 1;
+        }
+
+        get bottom() {
+            return this.top + this.height - 1;
+        }
+    }
+
+
+    export function calculateHitBoxes(s: Sprite): Hitbox[] {
+        const i = s.image;
+        let minX = i.width;
+        let minY = i.height;
+        let maxX = 0;
+        let maxY = 0;
+
+        for (let c = 0; c < i.width; c++) {
+            for (let r = 0; r < i.height; r++) {
+                if (i.getPixel(c, r)) {
+                    minX = Math.min(minX, c);
+                    minY = Math.min(minY, r);
+                    maxX = Math.max(maxX, c);
+                    maxY = Math.max(maxY, r);
+                }
+            }
+        }
+
+        const width = maxX - minX + 1;
+        const height = maxY - minY + 1;
+        if (width <= 0 || height <= 0) {
+            return [];
+        }
+        else if (width < 16 && height < 16) {
+            return [new Hitbox(s, width, height, minX, minY)]
+        }
+
+        const rows = Math.idiv(height, 15) + 1;
+        const columns = Math.idiv(width, 15) + 1;
+        const boxes: Hitbox[] = [];
+        for (let c = 0; c < columns; c++) {
+            let boxWidth = 15;
+            if (c === columns - 1) {
+                boxWidth = width % 15;
+            }
+
+            for (let r = 0; r < rows; r++) {
+                let boxHeight = 15;
+                if (r === rows - 1) {
+                    boxHeight = height % 15;
+                }
+                if (boxWidth > 0 && boxHeight > 0)
+                    boxes.push(new Hitbox(s, boxWidth, boxHeight, minX + c * 15, minY + r * 15));
+            }
+        }
+        return boxes;
+    }
+}

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -23,12 +23,17 @@ class PhysicsEngine {
     overlaps(sprite: Sprite): Sprite[] { return []; }
 }
 
+const MAX_DISTANCE = 15; // pixels
+const MAX_TIME_STEP = 0.1; // seconds
+const MAX_VELOCITY = MAX_DISTANCE / MAX_TIME_STEP;
+const GAP = 0.1;
+
 /**
  * A physics engine that does simple AABB bounding box check
  */
 class ArcadePhysicsEngine extends PhysicsEngine {
-    private sprites: Sprite[];
-    private map: sprites.SpriteMap;
+    protected sprites: Sprite[];
+    protected map: sprites.SpriteMap;
 
     constructor() {
         super();
@@ -49,15 +54,19 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     }
 
     move(dt: number) {
+        dt = Math.min(MAX_TIME_STEP, dt);
         const dt2 = dt / 2;
-        // 1: move sprites
+
+        const tm = game.currentScene().tileMap;
+
         for (let s of this.sprites) {
-            const ovx = s.vx;
-            const ovy = s.vy;
-            s.vx += s.ax * dt
-            s.vy += s.ay * dt
-            s.x += (ovx + s.vx) * dt2;
-            s.y += (ovy + s.vy) * dt2;
+            const ovx = constrain(s.vx);
+            const ovy = constrain(s.vy);
+
+            s.vx = constrain(s.vx + s.ax * dt)
+            s.vy = constrain(s.vy + s.ay * dt)
+
+            this.moveSprite(s, tm, (s.vx + ovx) * dt2, (s.vy + ovy) * dt2);
         }
     }
 
@@ -79,6 +88,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
         // 3: go through sprite and handle collisions
         const scene = game.currentScene();
+        const tm = scene.tileMap;
         for (const sprite of colliders) {
             const overSprites = scene.physicsEngine.overlaps(sprite);
             for (const overlapper of overSprites) {
@@ -93,38 +103,15 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     .forEach(h => control.runInParallel(() => h.handler(tmpsprite, tmp)));
             }
 
-            if (scene.tileMap) {
-                const obstacles = scene.tileMap.collisions(sprite);
-                for (const o of obstacles) {
-                    const bottom = o.top + o.image.height;
-                    const right = o.left + o.image.width;
-                    // find the shortest distance into the obstacle
-                    let toperr = sprite.bottom - o.top; if (toperr < 0) toperr = 1 << 30;
-                    let bottomerr = bottom - sprite.top; if (bottomerr < 0) bottomerr = 1 << 30;
-                    let lefterr = sprite.right - o.left; if (lefterr < 0) lefterr = 1 << 30;
-                    let righterr = right - sprite.left; if (righterr < 0) righterr = 1 << 30;
-                    const min = Math.min(toperr, Math.min(bottomerr, Math.min(lefterr, righterr)));
-                    if (toperr == min) {
-                        sprite.bottom = o.top;
-                        if (sprite.vy > 0) sprite.vy = 0;
-                        sprite.registerObstacle(CollisionDirection.Bottom, o);
-                    }
-                    else if (bottomerr == min) {
-                        sprite.top = bottom;
-                        if (sprite.vy < 0) sprite.vy = 0;
-                        sprite.registerObstacle(CollisionDirection.Top, o);
-                    }
-                    else if (lefterr == min) {
-                        sprite.right = o.left;
-                        if (sprite.vx > 0) sprite.vx = 0;
-                        sprite.registerObstacle(CollisionDirection.Right, o);
-                    }
-                    else {
-                        sprite.left = right;
-                        if (sprite.vx < 0) sprite.vx = 0;
-                        sprite.registerObstacle(CollisionDirection.Left, o);
-                    }
-                }
+            const xDiff = sprite.x - sprite._lastX;
+            const yDiff = sprite.y - sprite._lastY;
+            if ((xDiff !== 0 || yDiff !== 0) && Math.abs(xDiff) < MAX_DISTANCE && Math.abs(yDiff) < MAX_DISTANCE) {
+                // Undo the move
+                sprite.x = sprite._lastX;
+                sprite.y = sprite._lastY;
+
+                // Now move it with the tilemap in mind
+                this.moveSprite(sprite, tm, xDiff, yDiff);
             }
         }
     }
@@ -138,7 +125,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         if (this.map)
             return this.map.overlaps(sprite);
         else {
-            // brute force            
+            // brute force
             const layer = sprite.layer;
             const r: Sprite[] = [];
             const n = this.sprites.length;
@@ -150,4 +137,102 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             return r;
         }
     }
+
+    protected moveSprite(s: Sprite, tm: tiles.TileMap, dx: number, dy: number) {
+        if (dx === 0 && dy === 0) {
+            s._lastX = s.x;
+            s._lastY = s.y;
+            return;
+        }
+
+        if (tm) {
+            s._hitboxes.forEach(box => {
+                const t0 = box.top >> 4;
+                const r0 = box.right >> 4;
+                const b0 = box.bottom >> 4;
+                const l0 = box.left >> 4;
+
+                if (dx > 0) {
+                    let topCollide = tm.isObstacle(r0 + 1, t0);
+                    if (topCollide || tm.isObstacle(r0 + 1, b0)) {
+                        const nextRight = box.right + dx;
+                        const maxRight = ((r0 + 1) << 4) - GAP
+                        if (nextRight > maxRight) {
+                            dx -= (nextRight - maxRight);
+                            s.registerObstacle(CollisionDirection.Right, tm.getObstacle(r0 + 1, topCollide ? t0 : b0))
+                        }
+                    }
+                }
+                else if (dx < 0) {
+                    const topCollide = tm.isObstacle(l0 - 1, t0);
+                    if (topCollide || tm.isObstacle(l0 - 1, b0)) {
+                        const nextLeft = box.left + dx;
+                        const minLeft = (l0 << 4) + GAP;
+                        if (nextLeft < minLeft) {
+                            dx -= (nextLeft - minLeft);
+                            s.registerObstacle(CollisionDirection.Left, tm.getObstacle(l0 - 1, topCollide ? t0 : b0))
+                        }
+                    }
+                }
+
+                if (dy > 0) {
+                    const rightCollide = tm.isObstacle(r0, b0 + 1);
+                    if (rightCollide || tm.isObstacle(l0, b0 + 1)) {
+                        const nextBottom = box.bottom + dy;
+                        const maxBottom = ((b0 + 1) << 4) - GAP;
+                        if (nextBottom > maxBottom) {
+                            dy -= (nextBottom - maxBottom);
+                            s.registerObstacle(CollisionDirection.Bottom, tm.getObstacle(rightCollide ? r0 : l0, b0 + 1))
+                        }
+                    }
+                }
+                else if (dy < 0) {
+                    const rightCollide = tm.isObstacle(r0, t0 - 1);
+                    if (tm.isObstacle(r0, t0 - 1) || tm.isObstacle(l0, t0 - 1)) {
+                        const nextTop = box.top + dy;
+                        const minTop = (t0 << 4) + GAP;
+                        if (nextTop < minTop) {
+                            dy -= (nextTop - minTop);
+                            s.registerObstacle(CollisionDirection.Top, tm.getObstacle(rightCollide ? r0 : l0, t0 - 1))
+                        }
+                    }
+                }
+
+                // Now check each corner and bump out if necessary. This step is needed for
+                // the case where a hitbox goes diagonally into the corner of a tile.
+                const t1 = (box.top + dy) >> 4;
+                const r1 = (box.right + dx) >> 4;
+                const b1 = (box.bottom + dy) >> 4;
+                const l1 = (box.left + dx) >> 4;
+
+                if (tm.isObstacle(r1, t1)) {
+                    // bump left
+                    dx -= (box.right + dx - ((r1 << 4) - GAP))
+                    s.registerObstacle(CollisionDirection.Right, tm.getObstacle(r1, t1));
+                }
+                else if (tm.isObstacle(l1, t1)) {
+                    // bump right
+                    dx -= (box.left + dx - (((l1 + 1) << 4) + GAP));
+                    s.registerObstacle(CollisionDirection.Left, tm.getObstacle(l1, t1));
+                }
+                else {
+                    const rightCollide = tm.isObstacle(r1, b1);
+                    if (rightCollide || tm.isObstacle(l1, b1)) {
+                        // bump up because that is usually better for platformers
+                        dy -= (box.bottom + dy - ((b1 << 4) - GAP));
+                        s.registerObstacle(CollisionDirection.Bottom, tm.getObstacle(rightCollide ? r1 : l1, b1));
+                    }
+                }
+            });
+        }
+
+        s.x += dx;
+        s.y += dy;
+        s._lastX = s.x;
+        s._lastY = s.y;
+    }
+}
+
+function constrain(v: number) {
+    return Math.abs(v) > MAX_VELOCITY ? Math.sign(v) * MAX_VELOCITY : v;
 }

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -3,6 +3,7 @@
     "description": "The game and sprite library - beta",
     "files": [
         "animation.ts",
+        "hitbox.ts",
         "sprites.ts",
         "sprite.ts",
         "spritemap.ts",

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -81,8 +81,8 @@ namespace scene {
             this.eventContext.registerFrameHandler(30, () => {
                 performance.startTimer("collisions")
                 const dt = this.eventContext.deltaTime;
-                this.camera.update();
                 this.physicsEngine.collisions();
+                this.camera.update();
                 for (const s of this.allSprites)
                     s.__update(this.camera, dt);
                 performance.stopTimer("collisions")

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -85,12 +85,12 @@ namespace scene {
     export function setTileMap(map: Image) {
         const scene = game.currentScene();
         if (!scene.tileMap)
-            scene.tileMap = new tiles.TileMap(scene.camera, 16, 16);
+            scene.tileMap = new tiles.TileMap();
         scene.tileMap.setMap(map);
     }
 
     /**
-     * Sets the tile image at the given index
+     * Sets the tile image at the given index. Tiles should be 16x16 images
      * @param index
      * @param img
      */
@@ -100,7 +100,7 @@ namespace scene {
     export function setTile(index: number, img: Image, wall?: boolean) {
         const scene = game.currentScene();
         if (!scene.tileMap)
-            scene.tileMap = new tiles.TileMap(scene.camera, img.width, img.height);
+            scene.tileMap = new tiles.TileMap();
         scene.tileMap.setTile(index, img, !!wall);
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -273,8 +273,14 @@ class Sprite implements SpriteLike {
                 font);
         }
         // debug info
-        if (game.debug)
-            screen.drawRect(l, t, this.width, this.height, 3);
+        if (game.debug) {
+            let color = 1;
+            this._hitboxes.forEach(box => {
+                this._image.drawRect(box.ox, box.oy, box.width, box.height, color);
+                color++;
+                if (color >= 15) color = 1;
+            });
+        }
     }
 
     __update(camera: scene.Camera, dt: number) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -81,6 +81,9 @@ class Sprite implements SpriteLike {
     //% group="Properties"
     layer: number;
 
+    _lastX: number;
+    _lastY: number;
+
     /**
      * Time to live in game ticks. The lifespan decreases by 1 on each game update
      * and the sprite gets destroyed when it reaches 0.
@@ -96,6 +99,8 @@ class Sprite implements SpriteLike {
     private _currentAnimation: sprites.TimedAnimation;
     private _animationQueue: AnimationAction[];
 
+    _hitboxes: game.Hitbox[];
+
     flags: number
     id: number
 
@@ -107,12 +112,14 @@ class Sprite implements SpriteLike {
         this.x = screen.width >> 1;
         this.y = screen.height >> 1;
         this._z = 0
+        this._lastX = this.x;
+        this._lastY = this.y;
         this.vx = 0
         this.vy = 0
         this.ax = 0
         this.ay = 0
         this.flags = 0
-        this._image = img
+        this.setImage(img);
         this.type = 0; // not a member of any type by default
         this.layer = 1; // by default, in layer 1
         this.lifespan = undefined
@@ -135,6 +142,7 @@ class Sprite implements SpriteLike {
     setImage(img: Image) {
         if (!img) return; // don't break the sprite
         this._image = img;
+        this._hitboxes = game.calculateHitBoxes(this);
     }
 
     //% group="Properties"

--- a/libs/game/temp.d.ts
+++ b/libs/game/temp.d.ts
@@ -32,6 +32,7 @@ declare namespace Math {
     function sqrt(a: number): number;
     function randomRange(a: number, b: number): number;
     function idiv(x: number, y: number): number;
+    function sign(x: number): number;
 }
 
 declare const img: any;

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -9,10 +9,6 @@ namespace tiles {
     }
 
     export class TileMap implements SpriteLike {
-        camera: scene.Camera;
-        tileWidth: number;
-        tileHeight: number;
-
         id: number;
         z: number;
 
@@ -21,11 +17,7 @@ namespace tiles {
         private _map: Image;
         private _tiles: Tile[];
 
-        constructor(camera: scene.Camera, tileWidth: number, tileHeight: number) {
-            this.camera = camera;
-            this.tileWidth = tileWidth;
-            this.tileHeight = tileHeight;
-
+        constructor() {
             this._map = img`1`;
             this._tiles = [];
             this._layer = 1;
@@ -39,11 +31,11 @@ namespace tiles {
         }
 
         offsetX(value: number) {
-            return Math.max(0, Math.min(this._map.width * this.tileWidth - screen.width, value));
+            return Math.max(0, Math.min((this._map.width << 4) - screen.width, value));
         }
 
         offsetY(value: number) {
-            return Math.max(0, Math.min(this._map.height * this.tileHeight - screen.height, value));
+            return Math.max(0, Math.min((this._map.height << 4) - screen.height, value));
         }
 
         get layer(): number {
@@ -68,23 +60,22 @@ namespace tiles {
         __update(camera: scene.Camera, dt: number): void { }
 
         /**
-         * This draws all non-obstacle tiles so that we can reduce the number of
-         * sprites created
+         * Draws all visible
          */
         __draw(camera: scene.Camera): void {
-            const offsetX = camera.offsetX % this.tileWidth;
-            const offsetY = camera.offsetY % this.tileHeight;
-            const x0 = Math.max(0, Math.floor(camera.offsetX/ this.tileWidth));
-            const xn = Math.min(this._map.width, Math.ceil((camera.offsetX + screen.width) / this.tileWidth));
-            const y0 = Math.max(0, Math.floor(camera.offsetY / this.tileHeight));
-            const yn = Math.min(this._map.height, Math.ceil((camera.offsetY + screen.height) / this.tileHeight));
+            const offsetX = camera.offsetX & 0xf;
+            const offsetY = camera.offsetY & 0xf;
+            const x0 = Math.max(0, camera.offsetX >> 4);
+            const xn = Math.min(this._map.width, ((camera.offsetX + screen.width) >> 4) + 1);
+            const y0 = Math.max(0, camera.offsetY >> 4);
+            const yn = Math.min(this._map.height, ((camera.offsetY + screen.height) >> 4) + 1);
 
             for (let x = x0; x <= xn; ++x) {
                 for (let y = y0; y <= yn; ++y) {
                     const index = this._map.getPixel(x, y);
                     const tile = this._tiles[index] || this.generateTile(index);
                     if (tile) {
-                        screen.drawImage(tile.image, (x - x0) * this.tileWidth - offsetX, (y - y0) * this.tileHeight - offsetY)
+                        screen.drawImage(tile.image, ((x - x0) << 4) - offsetX, ((y - y0) << 4) - offsetY)
                     }
                 }
             }
@@ -93,7 +84,7 @@ namespace tiles {
         private generateTile(index: number): Tile {
             if (index == 0) return undefined;
 
-            const img = image.create(this.tileWidth, this.tileHeight);
+            const img = image.create(16, 16);
             img.fill(index);
             return this._tiles[index] = new Tile(img, false);
         }
@@ -103,23 +94,23 @@ namespace tiles {
             if (game.debug) {
                 const offsetX = -camera.offsetX;
                 const offsetY = -camera.offsetY;
-                const x0 = Math.max(0, Math.floor(-offsetX / this.tileWidth));
-                const xn = Math.min(this._map.width, Math.ceil((-offsetX + screen.width) / this.tileWidth));
-                const y0 = Math.max(0, Math.floor(-offsetY / this.tileHeight));
-                const yn = Math.min(this._map.height, Math.ceil((-offsetY + screen.height) / this.tileHeight));
+                const x0 = Math.max(0, -(offsetX >> 4));
+                const xn = Math.min(this._map.width, (-offsetX + screen.width) >> 4);
+                const y0 = Math.max(0, -(offsetY >> 4));
+                const yn = Math.min(this._map.height, (-offsetY + screen.height) >> 4);
                 for (let x = x0; x <= xn; ++x) {
                     screen.drawLine(
-                        x * this.tileWidth + offsetX,
+                        (x << 4) + offsetX,
                         offsetY,
-                        x * this.tileWidth + offsetX,
-                        this._map.height * this.tileHeight + offsetY, 1)
+                        (x << 4) + offsetX,
+                        (this._map.height << 4) + offsetY, 1)
                 }
                 for (let y = y0; y <= yn; ++y) {
                     screen.drawLine(
                         offsetX,
-                        y * this.tileHeight + offsetY,
-                        this.tileWidth * this._map.width + offsetX,
-                        y * this.tileHeight + offsetY,
+                        (y  << 4) + offsetY,
+                        (this._map.width << 4) + offsetX,
+                        (y << 4) + offsetY,
                         1)
                 }
             }
@@ -132,32 +123,19 @@ namespace tiles {
             let overlappers: sprites.StaticObstacle[] = [];
 
             if (s.layer & this.layer) {
-                let x0: number;
-                let xn: number;
-                let y0: number;
-                let yn: number;
-
-                if (this.tileWidth === this.tileHeight && this.tileHeight === 16) {
-                    x0 = Math.max(0, s.left >> 4);
-                    xn = Math.min(this._map.width, (s.right >> 4) + 1);
-                    y0 = Math.max(0, s.top >> 4);
-                    yn = Math.min(this._map.height, (s.bottom >> 4) + 1);
-                }
-                else {
-                    x0 = Math.max(0, Math.floor(s.left / this.tileWidth));
-                    xn = Math.min(this._map.width, Math.ceil(s.right / this.tileWidth));
-                    y0 = Math.max(0, Math.floor(s.top / this.tileHeight));
-                    yn = Math.min(this._map.height, Math.ceil(s.bottom / this.tileHeight));
-                }
+                const x0 = Math.max(0, s.left >> 4);
+                const xn = Math.min(this._map.width, (s.right >> 4) + 1);
+                const y0 = Math.max(0, s.top >> 4);
+                const yn = Math.min(this._map.height, (s.bottom >> 4) + 1);
 
                 // let res = `x: ${x0}-${xn} y: ${y0}-${yn} HIT:`;
                 for (let x = x0; x <= xn; ++x) {
-                    const left = x * this.tileWidth;
+                    const left = x << 4;
                     for (let y = y0; y <= yn; ++y) {
                         const index = this._map.getPixel(x, y);
                         const tile = this._tiles[index] || this.generateTile(index);
                         if (tile && tile.obstacle) {
-                            const top = y * this.tileHeight;
+                            const top = y << 4;
                             if (tile.image.overlapsWith(s.image, s.left - left, s.top - top)) {
                                 overlappers.push(new sprites.StaticObstacle(tile.image, top, left, this.layer, index));
                             }

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -168,5 +168,24 @@ namespace tiles {
 
             return overlappers;
         }
+
+        public isObstacle(col: number, row: number) {
+            if (!this._map) return false;
+            if (col < 0 || col >= this._map.width || row < 0 || row >= this._map.height) return true;
+
+            return this._tiles[this._map.getPixel(col, row)].obstacle;
+        }
+
+        public getObstacle(col: number, row: number) {
+            if (!this._map) return undefined;
+            if (col < 0 || col >= this._map.width || row < 0 || row >= this._map.height) return undefined;
+
+            const index = this._map.getPixel(col, row);
+            const tile = this._tiles[index] || this.generateTile(index);
+            if (tile.obstacle) {
+                return new sprites.StaticObstacle(tile.image, row << 4, col << 4, this.layer, index);
+            }
+            return undefined;
+        }
     }
 }


### PR DESCRIPTION
Changes:

1. All tiles are now 16x16 px
2. Physics now has a maximum velocity of 15px per step
3. Collisions are now based on hitboxes and not overlaps

Hitboxes for sprites are calculated based on the content of the image but are always rectangular. Swapping images will recalculate the hitboxes. Sprites that are larger than 15x15 px have multiple hitboxes because there is a hard limit based on the tile size;, having a ton of hitboxes doesn't really have a noticeable impact on perf so we're all good.

Things I still need to do before merging:

1. Render hitboxes when debug is on
2. Figure out what to do if an image is changed directly (i.e. when you draw to an image we should maybe recalculate hitboxes)

*NOTE:* This PR only affects the TileMap. Overlap behavior is still exactly the same.