### PR TITLE
Tweaking wording of image APIs

### DIFF
--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -4,7 +4,7 @@ interface Image {
      * Fill a rectangle
      */
     //% helper=imageFillRect blockNamespace="images" inlineInputMode="inline" group="Drawing"
-    //% block="fill rectangle in %myImage=variables_get at x %x y %y width %w height %h %c=colorindexpicker"
+    //% block="fill rectangle in %picture=variables_get at x %x y %y width %w height %h %c=colorindexpicker"
     //% help=images/image/fill-rect
     fillRect(x: number, y: number, w: number, h: number, c: color): void;
 
@@ -12,7 +12,7 @@ interface Image {
      * Draw a line
      */
     //% helper=imageDrawLine blockNamespace="images" inlineInputMode="inline" group="Drawing"
-    //% block="draw line in %myImage=variables_get from x %x0 y %y0 to x %x1 y %y1 %c=colorindexpicker"
+    //% block="draw line in %picture=variables_get from x %x0 y %y0 to x %x1 y %y1 %c=colorindexpicker"
     //% help=images/image/draw-line
     drawLine(x0: number, y0: number, x1: number, y1: number, c: color): void;
 
@@ -20,7 +20,7 @@ interface Image {
      * Draw an empty rectangle
      */
     //% helper=imageDrawRect blockNamespace="images" inlineInputMode="inline" group="Drawing"
-    //% block="outline rectangle in %myImage=variables_get at x %x y %y width %w height %h %c=colorindexpicker"
+    //% block="draw rectangle in %picture=variables_get at x %x y %y width %w height %h %c=colorindexpicker"
     //% help=images/image/draw-rect
     drawRect(x: number, y: number, w: number, h: number, c: color): void;
 
@@ -28,7 +28,7 @@ interface Image {
      * Set pixel color
      */
     //% shim=ImageMethods::setPixel blockNamespace="images" group="Drawing"
-    //% block="set pixel of %myImage=variables_get at x %x y %y to %c=colorindexpicker"
+    //% block="set %picture=variables_get color at x %x y %y to %c=colorindexpicker"
     //% help=images/image/set-pixel
     setPixel(x: int32, y: int32, c: int32): void;
 
@@ -36,7 +36,7 @@ interface Image {
      * Get a pixel color
      */
     //% shim=ImageMethods::getPixel blockNamespace="images" group="Drawing"
-    //% block="%myImage=variables_get pixel color at x %x y %y"
+    //% block="%picture=variables_get color at x %x y %y"
     //% help=images/image/get-pixel
     getPixel(x: int32, y: int32): int32;
 
@@ -44,7 +44,7 @@ interface Image {
      * Fill entire image with a given color
      */
     //% shim=ImageMethods::fill blockNamespace="images" group="Drawing"
-    //% block="fill %myImage=variables_get with %c=colorindexpicker"
+    //% block="fill %picture=variables_get with %c=colorindexpicker"
     //% help=images/image/fill
     fill(c: int32): void;
 
@@ -52,7 +52,7 @@ interface Image {
      * Return a copy of the current image
      */
     //% shim=ImageMethods::clone blockNamespace="images" group="Create"
-    //% block="clone %myImage=variables_get"
+    //% block="clone %picture=variables_get"
     //% help=images/image/clone
     clone(): Image;
 
@@ -60,7 +60,7 @@ interface Image {
      * Flips (mirrors) pixels horizontally in the current image
      */
     //% shim=ImageMethods::flipX blockNamespace="images" group="Transformations"
-    //% block="flip %myImage=variables_get horizontally"
+    //% block="flip %picture=variables_get horizontally"
     //% help=images/image/flip-x
     flipX(): void;
 
@@ -68,7 +68,7 @@ interface Image {
      * Flips (mirrors) pixels vertically in the current image
      */
     //% shim=ImageMethods::flipY blockNamespace="images" group="Transformations"
-    //% block="flip %myImage=variables_get vertically"
+    //% block="flip %picture=variables_get vertically"
     //% help=images/image/flip-y
     flipY(): void;
 
@@ -76,7 +76,6 @@ interface Image {
      * Every pixel in image is moved by (dx,dy)
      */
     //% shim=ImageMethods::scroll blockNamespace="images" group="Transformations"
-    //% block="scroll %myImage=variables_get by dx %dx dy %dy"
     //% help=images/image/scroll
     scroll(dx: int32, dy: int32): void;
 
@@ -84,7 +83,7 @@ interface Image {
      * Replaces one color in an image with another
      */
     //% shim=ImageMethods::replace blockNamespace="images" group="Transformations"
-    //% block="change color in %myImage=variables_get from %from=colorindexpicker to %to=colorindexpicker"
+    //% block="change color in %picture=variables_get from %from=colorindexpicker to %to=colorindexpicker"
     //% help=images/image/replace
     replace(from: int32, to: int32): void;
 }


### PR DESCRIPTION
Changes we discussed offline. I think this is *technically* a breaking change for Image blocks because of that old buggy behavior where the block definition sets the name of the block input.