### PR TITLE
Fix comment style preventing switchRight method from being auto-gen'd

### DIFF
--- a/libs/switch/switch.cpp
+++ b/libs/switch/switch.cpp
@@ -38,7 +38,7 @@ void onSwitchMoved(SwitchDirection direction, Action handler) {
     registerWithDal(getWSwitch()->slideSwitch.id, (int)direction, handler);
 }
 
-/*
+/**
 * Gets a value indicating if the switch is positioned to the right
 */
 //% blockId=device_switch_direction block="switch right"


### PR DESCRIPTION
# Description
The cpp => ts code generator appears to look for a particular comment style when generating the `shims.d.ts` file. This patch fixes the comment style for the `switchRight()` method in `switch.cpp` so that the corresponding method gets generated in `switch/shims.d.ts`.

I ran a local pxt-adafruit editor with this change and confirmed that the `switchRight()` method gets generated, and that a `<switch right>` block shows up in the UI:

<img width="497" alt="screenshot 2018-06-28 22 31 47" src="https://user-images.githubusercontent.com/231357/42070785-04c55c30-7b26-11e8-9024-b62b7c8d68f5.png">

I also confirmed that the block works as expected, in this sketch:

<img width="797" alt="screenshot 2018-06-28 22 31 35" src="https://user-images.githubusercontent.com/231357/42070796-10035dea-7b26-11e8-947f-517175ad6a7f.png">

# Why
I noticed that there was no block in the Adafruit editor representing the state of the switch, and I tracked it down to this comment.