### PR TITLE
Message should only be pushed if not empty

### DIFF
--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -241,7 +241,10 @@ namespace game {
                 }
             }
 
-            screens.push(current)
+            //Only pushes the last part of the message to the screen when current isn't empty 
+            if(current !== ""){
+                screens.push(current);
+            }
 
             return screens;
         }

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -242,7 +242,7 @@ namespace game {
             }
 
             //Only pushes the last part of the message to the screen when current isn't empty 
-            if(current !== ""){
+            if (current) {
                 screens.push(current);
             }
 

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -241,7 +241,7 @@ namespace game {
                 }
             }
 
-            //Only pushes the last part of the message to the screen when current isn't empty 
+            // Only pushes the last part of the message to the screen when current isn't empty 
             if (current) {
                 screens.push(current);
             }


### PR DESCRIPTION
Fixes Microsoft/pxt-arcade#195

To reproduce the bug you need to use the "show long text" block and display a message that will go up to a third row of characters. Then when you click space (a) an extra message block will show up with nothing in it. 

What the program was doing before was it would push rows of messages to a screen  and ultimately it pushed the last row of characters and reset the message to blank and push it once more.

To fix this I added a piece of logic so that whenever the message contains any string then it would push the row of the message to the screen. This works because there would be no point it pushing a row of nothing.