### PR TITLE
Arcade bugs 

### DIFF
--- a/libs/game/docs/reference/scene/get-background-color.md
+++ b/libs/game/docs/reference/scene/get-background-color.md
@@ -1,0 +1,31 @@
+# get Background Color
+
+Get the background color of the screen.
+
+```sig
+scene.backgroundColor()
+```
+
+You can get the background color of the screen anytime. The background color is always behind other images shown on the screen.
+
+## Example #example
+
+Show a purple square on the screen. Every second, switch the background color between light and dark.
+
+```blocks
+let showSquare: Sprite = null
+let purpleSquare: Image = null
+let toggle = false
+toggle = true
+purpleSquare = image.create(32, 32)
+purpleSquare.fill(11)
+showSquare = sprites.create(purpleSquare)
+game.onUpdateInterval(1000, function () {
+    scene.setBackgroundColor((scene.backgroundColor() + 1) % 2) //toggle between 0 and 1
+
+})
+```
+
+## See also #seealso
+
+[set background color](/reference/scene/set-background-color)

--- a/libs/game/docs/reference/scene/get-background-image.md
+++ b/libs/game/docs/reference/scene/get-background-image.md
@@ -1,0 +1,40 @@
+# get Background Image
+
+Gets the background image for the screen.
+
+```sig
+scene.backgroundImage()
+```
+
+You can get the current image for the background of the screen. The background image is always behind other images shown on the screen.
+
+## Example #example
+
+Create and empty image that's the size of the screen. Fill the image with four colored squares. Set the image as the screen background and rotate the colors every `2` seconds.
+
+```blocks
+let screenY = 0
+let backImage: Image = null
+let screenX = 0
+screenX = scene.screenWidth()
+screenY = scene.screenHeight()
+backImage = image.create(screenX, screenY)
+backImage.fillRect(0, 0, screenX / 2, screenY / 2, 7)
+backImage.fillRect(screenX / 2, 0, screenX / 2, screenY / 2, 10)
+backImage.fillRect(0, screenY / 2, screenX / 2, screenY / 2, 14)
+backImage.fillRect(screenX / 2, screenY / 2, screenX / 2, screenY / 2, 4)
+scene.setBackgroundImage(backImage)
+
+game.onUpdateInterval(2000, function () {
+    let curImage = scene.backgroundImage();
+    curImage.replace(4, 0)
+    curImage.replace(10, 4)
+    curImage.replace(7, 10)
+    curImage.replace(14, 7)
+    curImage.replace(0, 14)
+})
+```
+
+## See also #seealso
+
+[set background image](/reference/scene/set-background-image)

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -41,6 +41,19 @@ namespace scene {
     }
 
     /**
+     * Sets the game background color
+     * @param color
+     */
+    //% group="Screen"
+    //% weight=22
+    //% blockId=gamebackgroundcolor block="background color"
+    //% help=scene/get-background-color
+    export function backgroundColor() : number {
+        const scene = game.currentScene();
+        return scene.background.color;
+    }
+
+    /**
      * Sets the picture on the background
      */
     //% group="Screen"
@@ -55,8 +68,10 @@ namespace scene {
     /**
      * Returns the background image
      */
-    //% weight=23
+    //% weight=22
     //% group="Screen"
+    //% blockId=gamebackgroundimage block="background image"
+    //% help=scene/get-background-image
     export function backgroundImage(): Image {
         const scene = game.currentScene();
         return scene.background.image;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -119,6 +119,9 @@ class Sprite implements SpriteLike {
     /**
      * Gets the current image
      */
+    //% group="Lifecycle"
+    //% blockId=spriteimage block="%sprite(agent) image"
+    //% weight=8
     get image(): Image {
         return this._image;
     }
@@ -126,6 +129,9 @@ class Sprite implements SpriteLike {
     /**
      * Sets the image on the sprite
      */
+    //% group="Lifecycle"
+    //% blockId=spritesetimage block="set %sprite(agent) image to %img=screen_image_picker"
+    //% weight=7
     setImage(img: Image) {
         if (!img) return; // don't break the sprite
         this._image = img;
@@ -303,6 +309,7 @@ class Sprite implements SpriteLike {
      */
     //% group="Properties"
     //% blockId=spritesetsetflag block="set %sprite(agent) %flag %on=toggleOnOff"
+    //% flag.defl=SpriteFlag.StayInScreen
     setFlag(flag: SpriteFlag, on: boolean) {
         if (on) this.flags |= flag
         else this.flags = ~(~this.flags | flag);


### PR DESCRIPTION
- Exposes backgroundImage and backgroundColor as API's (Fixes https://github.com/Microsoft/pxt-arcade/issues/190)
- "Stay in screen" is the default for setflag API (Fixes https://github.com/Microsoft/pxt-arcade/issues/183). We decided to skip another API for auto destroy.
- Get and Set image of the sprite are back to facilitate custom animations.
