### PR TITLE
Make scene.centerCameraAt() center camera properly / fix microsoft/pxt-arcade#155

### DIFF
--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -141,7 +141,7 @@ namespace scene {
     export function centerCameraAt(x: number, y: number) {
         const scene = game.currentScene();
         scene.camera.sprite = undefined;
-        scene.camera.offsetX = x;
-        scene.camera.offsetY = y;
+        scene.camera.offsetX = x - screen.width / 2;
+        scene.camera.offsetY = y - screen.height / 2;
     }
 }

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -141,7 +141,7 @@ namespace scene {
     export function centerCameraAt(x: number, y: number) {
         const scene = game.currentScene();
         scene.camera.sprite = undefined;
-        scene.camera.offsetX = x - screen.width / 2;
-        scene.camera.offsetY = y - screen.height / 2;
+        scene.camera.offsetX = x - (screen.width >> 1);
+        scene.camera.offsetY = y - (screen.height >> 1);
     }
 }


### PR DESCRIPTION
Quick fix for microsoft/pxt-arcade#155 so we can use it in the course.