### PR TITLE
Fixes for small Arcade issues

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -89,6 +89,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         // 3: go through sprite and handle collisions
         const scene = game.currentScene();
         const tm = scene.tileMap;
+
         for (const sprite of colliders) {
             const overSprites = scene.physicsEngine.overlaps(sprite);
             for (const overlapper of overSprites) {
@@ -145,7 +146,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             return;
         }
 
-        if (tm) {
+        if (tm && !(s.flags & sprites.Flag.Ghost)) {
             s._hitboxes.forEach(box => {
                 const t0 = box.top >> 4;
                 const r0 = box.right >> 4;

--- a/libs/game/prompt.ts
+++ b/libs/game/prompt.ts
@@ -187,7 +187,7 @@ namespace game {
         }
 
         private drawPromptText() {
-            const prompt = sprites.create(layoutText(this.message, CONTENT_WIDTH, PROMPT_HEIGHT, this.theme.colorPrompt));
+            const prompt = sprites.create(layoutText(this.message, CONTENT_WIDTH, PROMPT_HEIGHT, this.theme.colorPrompt), -1);
             prompt.x = screen.width / 2
             prompt.y = CONTENT_TOP + Math.floor((PROMPT_HEIGHT - prompt.height) / 2) + Math.floor(prompt.height / 2);
         }
@@ -205,7 +205,7 @@ namespace game {
                 const col = i % ALPHABET_ROW_LENGTH;
                 const row = Math.floor(i / ALPHABET_ROW_LENGTH);
 
-                const s = sprites.create(blank);
+                const s = sprites.create(blank, -1);
                 s.x = answerLeft + col * CELL_WIDTH;
                 s.y = INPUT_TOP + row * CELL_HEIGHT;
                 this.inputs.push(s);
@@ -215,7 +215,7 @@ namespace game {
         private drawKeyboard() {
             const cursorImage = image.create(CELL_WIDTH, CELL_HEIGHT);
             cursorImage.fill(this.theme.colorCursor);
-            this.cursor = sprites.create(cursorImage);
+            this.cursor = sprites.create(cursorImage, -1);
             this.cursor.z = -1;
             this.updateCursor();
 
@@ -226,7 +226,7 @@ namespace game {
                 const col2 = j % ALPHABET_ROW_LENGTH;
                 const row2 = Math.floor(j / ALPHABET_ROW_LENGTH);
 
-                const t = sprites.create(letter);
+                const t = sprites.create(letter, -1);
                 t.x = ROW_LEFT + col2 * CELL_WIDTH;
                 t.y = ALPHABET_TOP + row2 * CELL_HEIGHT;
 
@@ -239,16 +239,16 @@ namespace game {
             const bg = image.create(screen.width, BOTTOM_BAR_HEIGHT);
             bg.fill(this.theme.colorBottomBackground);
 
-            const bgSprite = sprites.create(bg);
+            const bgSprite = sprites.create(bg, -1);
             bgSprite.x = screen.width / 2;
             bgSprite.y = BOTTOM_BAR_TOP + BOTTOM_BAR_HEIGHT / 2;
             bgSprite.z = -1;
 
-            this.shiftButton = sprites.create(image.create(BOTTOM_BAR_BUTTON_WIDTH, BOTTOM_BAR_HEIGHT));
+            this.shiftButton = sprites.create(image.create(BOTTOM_BAR_BUTTON_WIDTH, BOTTOM_BAR_HEIGHT), -1);
             this.shiftButton.x = Math.floor(BOTTOM_BAR_BUTTON_WIDTH / 2);
             this.shiftButton.y = BOTTOM_BAR_TOP + Math.ceil(BOTTOM_BAR_HEIGHT / 2);
 
-            this.confirmButton = sprites.create(image.create(BOTTOM_BAR_BUTTON_WIDTH, BOTTOM_BAR_HEIGHT));
+            this.confirmButton = sprites.create(image.create(BOTTOM_BAR_BUTTON_WIDTH, BOTTOM_BAR_HEIGHT), -1);
             this.confirmButton.x = CONFIRM_BUTTON_LEFT + Math.floor(BOTTOM_BAR_BUTTON_WIDTH / 2);
             this.confirmButton.y = BOTTOM_BAR_TOP + Math.ceil(BOTTOM_BAR_HEIGHT / 2);
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -60,12 +60,8 @@ class Sprite implements SpriteLike {
     //% group="Properties" blockSetVariable="mySprite"
     //% blockCombine block="ay (acceleration y)"
     ay: number
-    /**
-     * The type of sprite
-     */
-    //% group="Properties" blockSetVariable="mySprite"
-    //% blockCombine block="kind"
-    type: number
+
+    _type: number;
 
     /**
      * A bitset of layer. Each bit is a layer, default is 1.
@@ -112,7 +108,7 @@ class Sprite implements SpriteLike {
         this.ay = 0
         this.flags = 0
         this.setImage(img);
-        this.type = 0; // not a member of any type by default
+        this.type = -1; // not a member of any type by default
         this.layer = 1; // by default, in layer 1
         this.lifespan = undefined;
     }
@@ -204,6 +200,33 @@ class Sprite implements SpriteLike {
     set bottom(value: number) {
         this.y = value - (this.height >> 1);
     }
+    /**
+     * The type of sprite
+     */
+    //% group="Properties" blockSetVariable="mySprite"
+    //% blockCombine block="kind"
+    get type() {
+        return this._type;
+    }
+    /**
+     * The type of sprite
+     */
+    //% group="Properties" blockSetVariable="mySprite"
+    //% blockCombine block="kind"
+    set type(value: number) {
+        if (value == undefined || this._type === value) return;
+
+        const spritesByKind = game.currentScene().spritesByKind;
+        if (this._type >= 0 && spritesByKind[this._type])
+            spritesByKind[this._type].removeElement(this);
+
+        if (value >= 0) {
+            if (!spritesByKind[value]) spritesByKind[value] = [];
+            spritesByKind[value].push(this);
+        }
+
+        this._type = value;
+    }
 
     /**
      * Sets the sprite position
@@ -275,7 +298,8 @@ class Sprite implements SpriteLike {
             this.sayBubbleSprite.destroy();
         }
 
-        this.sayBubbleSprite = sprites.create(image.create(bubbleWidth, font.charHeight + bubblePadding));
+        this.sayBubbleSprite = sprites.create(image.create(bubbleWidth, font.charHeight + bubblePadding), -1);
+
         this.sayBubbleSprite.setFlag(SpriteFlag.Ghost, true);
         this.updateSay = dt => {
             // Update box stuff as long as timeOnScreen doesn't exist or it can still be on the screen
@@ -508,7 +532,8 @@ class Sprite implements SpriteLike {
             this.sayBubbleSprite.destroy();
         }
         scene.allSprites.removeElement(this);
-        scene.spritesByKind[this.type].removeElement(this);
+        if (this.type >= 0 && scene.spritesByKind[this.type])
+            scene.spritesByKind[this.type].removeElement(this);
         scene.physicsEngine.removeSprite(this);
         if (this.destroyHandler)
             this.destroyHandler();

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -493,6 +493,7 @@ class Sprite implements SpriteLike {
     }
 
     registerObstacle(direction: CollisionDirection, other: sprites.Obstacle) {
+        if (other == undefined) return;
         if (!this._obstacles)
             this._obstacles = [];
         this._obstacles[direction] = other;

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -28,14 +28,10 @@ namespace sprites {
     export function create(img: Image, kind?: number): Sprite {
         const scene = game.currentScene();
         const sprite = new Sprite(img)
-        sprite.type = kind || 0;
+        sprite.type = kind;
         scene.allSprites.push(sprite)
         sprite.id = scene.allSprites.length
         scene.physicsEngine.addSprite(sprite);
-        if (scene.spritesByKind[sprite.type])
-            scene.spritesByKind[sprite.type].push(sprite);
-        else
-            scene.spritesByKind[sprite.type] = [sprite];
 
         // run on created handlers
         scene.createdHandlers
@@ -50,14 +46,12 @@ namespace sprites {
      * @param kind the target kind
      */
     //% blockId=allOfKind block="array of sprites of kind %kind=spritetype"
-    //% blockNamespace="arrays"
+    //% blockNamespace="arrays" blockSetVariable="sprite list"
     //% weight=87
     export function allOfKind(kind: number): Sprite[] {
         const spritesByKind = game.currentScene().spritesByKind;
-        if (kind == undefined || spritesByKind.length <= kind || spritesByKind[kind] == null)
-            return [];
-        else
-            return spritesByKind[kind].slice(0, spritesByKind[kind].length);
+        if (!(kind >= 0) || spritesByKind[kind] == undefined) return [];
+        else return spritesByKind[kind].slice(0, spritesByKind[kind].length);
     }
 
     /**

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -387,7 +387,7 @@ namespace game {
         }
 
         const dialog = new Dialog(width, height);
-        const s = sprites.create(dialog.image);
+        const s = sprites.create(dialog.image, -1);
         s.top = top;
         s.left = left;
 
@@ -539,7 +539,7 @@ namespace game {
         dialog.setText(title);
         if (subtitle) dialog.setSubtext(subtitle);
 
-        const s = sprites.create(dialog.image);
+        const s = sprites.create(dialog.image, -1);
         let pressed = true;
         let done = false;
 

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -131,7 +131,7 @@ namespace tiles {
         public collisions(s: Sprite): sprites.Obstacle[] {
             let overlappers: sprites.StaticObstacle[] = [];
 
-            if (s.layer & this.layer) {
+            if ((s.layer & this.layer) && !(s.flags & sprites.Flag.Ghost)) {
                 const x0 = Math.max(0, s.left >> 4);
                 const xn = Math.min(this._map.width, (s.right >> 4) + 1);
                 const y0 = Math.max(0, s.top >> 4);

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -31,7 +31,7 @@ namespace images {
     //% img.fieldEditor="sprite"
     //% img.fieldOptions.taggedTemplate="img"
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
-    //% img.fieldOptions.sizes="10,8;16,16;32,32;48,48;64,64;16,32;32,48"
+    //% img.fieldOptions.sizes="10,8;16,16;32,32;48,48;64,64;16,32;32,48;32,8;64,8"
     //% weight=100 group="Create"
     //% blockHidden=1
     export function _tileMapImage(img: Image) {


### PR DESCRIPTION
Issues:
* fixes Microsoft/pxt-arcade#230
* resolves Microsoft/pxt-arcade#235
* fixes Microsoft/pxt-arcade#237
* fixes Microsoft/pxt-arcade#238 and issues relating to sprite.say causing overlaps with the sprite that created it (if it is SpriteKind.Player, and there is an overlap event between two SpriteKind.Player)
* fixes Microsoft/pxt-arcade#243 (same as 237)
* fixes jwunderl/pxt-corgio#3 (same as 243 and 237)
* modifying sprite.type moves sprite to proper array for arrayOfKind; I missed that it was exposed before