### PR TITLE
Arcade tilemap bugs

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -10,6 +10,8 @@ class PhysicsEngine {
 
     removeSprite(sprite: Sprite) { }
 
+    moveSprite(s: Sprite, tm: tiles.TileMap, dx: number, dy: number) { }
+
     draw() { }
 
     /** Apply physics */
@@ -139,7 +141,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         }
     }
 
-    protected moveSprite(s: Sprite, tm: tiles.TileMap, dx: number, dy: number) {
+    public moveSprite(s: Sprite, tm: tiles.TileMap, dx: number, dy: number) {
         if (dx === 0 && dy === 0) {
             s._lastX = s.x;
             s._lastY = s.y;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -174,34 +174,26 @@ class Sprite implements SpriteLike {
         // bump image if collision with surrounding walls due to changed size
         // beyond tile size. Only attempt if new sprite fits within a single tile.
         if (this.width <= 16 && this.height <= 16 && (~this.flags & SpriteFlag.Ghost)) {
-            let l = this.left >> 4;
-            let r = this.right >> 4;
-            let t = this.top >> 4;
-            let b = this.bottom >> 4;
+            let l = nMinX >> 4;
+            let r = nMaxX >> 4;
+            let t = nMinY >> 4;
+            let b = nMaxY >> 4;
 
-            if (minXDiff > 0 || minYDiff > 0) {
-                if (tmap.isObstacle(l, t)) {
-                    this.left += minXDiff;
-                    this.top += minYDiff;
-                }
+            if (tmap.isObstacle(l, t) && (minXDiff > 0 || minYDiff > 0)) {
+                this.left += minXDiff;
+                this.top += minYDiff;
             }
-            if (maxXDiff < 0 || minYDiff > 0) {
-                if (tmap.isObstacle(r, t)) {
-                    this.right += maxXDiff;
-                    this.top += minYDiff;
-                }
+            if (tmap.isObstacle(r, t) && (maxXDiff < 0 || minYDiff > 0)) {
+                this.right += maxXDiff;
+                this.top += minYDiff;
             }
-            if (minXDiff > 0 || maxYDiff < 0) {
-                if (tmap.isObstacle(l, b)) {
-                    this.left += minXDiff;
-                    this.bottom += maxYDiff;
-                }
+            if (tmap.isObstacle(l, b) && (minXDiff > 0 || maxYDiff < 0)) {
+                this.left += minXDiff;
+                this.bottom += maxYDiff;
             }
-            if (maxXDiff < 0 || maxYDiff < 0) {
-                if(tmap.isObstacle(r, b)) {
-                    this.right += maxXDiff;
-                    this.bottom += maxYDiff;
-                }
+            if (tmap.isObstacle(r, b) && (maxXDiff < 0 || maxYDiff < 0)) {
+                this.right += maxXDiff;
+                this.bottom += maxYDiff;
             }
         }
     }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -171,15 +171,21 @@ class Sprite implements SpriteLike {
         const scene = game.currentScene();
         const tmap = scene.tileMap;
 
-        if (scene.tileMap) {
-            if (minXDiff > 0 || minYDiff > 0)
+        if (scene.tileMap && this.width <= 16 && this.height <= 16) {
+            const l = (nMinX + this.left) >> 4;
+            const r = (nMaxX + this.left) >> 4;
+            const t = (nMinY + this.top) >> 4;
+            const b = (nMaxY + this.top) >> 4;
+
+            if (tmap.isObstacle(l, t) && (minXDiff > 0 || minYDiff > 0)) {
                 scene.physicsEngine.moveSprite(this, scene.tileMap, minXDiff, minYDiff);
-            if (maxXDiff < 0 || minYDiff > 0)
+            } else if (tmap.isObstacle(r, t) && (maxXDiff < 0 || minYDiff > 0)) {
                 scene.physicsEngine.moveSprite(this, scene.tileMap, maxXDiff, minYDiff);
-            if (minXDiff > 0 || maxYDiff < 0) 
+            } else if (tmap.isObstacle(l, b) && (minXDiff > 0 || maxYDiff < 0)) {
                 scene.physicsEngine.moveSprite(this, scene.tileMap, minXDiff, maxYDiff);
-            if (maxXDiff < 0 || maxYDiff < 0)
+            } else if (tmap.isObstacle(r, b) && (maxXDiff < 0 || maxYDiff < 0)) {
                 scene.physicsEngine.moveSprite(this, scene.tileMap, maxXDiff, maxYDiff);
+            }
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -132,70 +132,37 @@ class Sprite implements SpriteLike {
     setImage(img: Image) {
         if (!img) return; // don't break the sprite
 
-        // Identify bounding box for prior image
+        // Identify old upper left corner
         let oMinX = img.width;
         let oMinY = img.height;
-        let oMaxX = 0;
-        let oMaxY = 0;
 
         for (let i = 0; this._hitboxes && i < this._hitboxes.length; ++i) {
             let box = this._hitboxes[i];
             oMinX = Math.min(oMinX, box.ox);
             oMinY = Math.min(oMinY, box.oy);
-            oMaxX = Math.max(oMaxX, box.ox + box.width - 1);
-            oMaxY = Math.max(oMaxY, box.oy + box.height - 1);
         }
 
         this._image = img;
         this._hitboxes = game.calculateHitBoxes(this);
 
-        // Identify bounding box for new image
+        // Identify new upper left corner
         let nMinX = img.width;
         let nMinY = img.height;
-        let nMaxX = 0;
-        let nMaxY = 0;
 
         for (let i = 0; i < this._hitboxes.length; ++i) {
             let box = this._hitboxes[i];
             nMinX = Math.min(nMinX, box.ox);
             nMinY = Math.min(nMinY, box.oy);
-            nMaxX = Math.max(nMaxX, box.ox + box.width - 1);
-            nMaxY = Math.max(nMaxY, box.oy + box.height - 1);
         }
 
         const minXDiff = oMinX - nMinX;
         const minYDiff = oMinY - nMinY;
-        const maxXDiff = oMaxX - nMaxX;
-        const maxYDiff = oMaxY - nMaxY;
 
-        const tmap = game.currentScene().tileMap;
-        if (!tmap) return;
+        const scene = game.currentScene();
+        const tmap = scene.tileMap;
 
-        // Bump image if collision with surrounding walls due to changed size.
-        if (this.width <= 16 && this.height <= 16 && (~this.flags & SpriteFlag.Ghost)) {
-            const l = nMinX >> 4;
-            const r = nMaxX >> 4;
-            const t = nMinY >> 4;
-            const b = nMaxY >> 4;
-
-            if (tmap.isObstacle(l, t) && (minXDiff > 0 || minYDiff > 0)) {
-                this.x += minXDiff;
-                this.y += minYDiff;
-            }
-            if (tmap.isObstacle(r, t) && (maxXDiff < 0 || minYDiff > 0)) {
-                this.x += maxXDiff;
-                this.y += minYDiff;
-            }
-            if (tmap.isObstacle(l, b) && (minXDiff > 0 || maxYDiff < 0)) {
-                this.x += minXDiff;
-                this.y += maxYDiff;
-            }
-            if (tmap.isObstacle(r, b) && (maxXDiff < 0 || maxYDiff < 0)) {
-                this.x += maxXDiff;
-                this.y += maxYDiff;
-
-            }
-        }
+        if (scene.tileMap)
+            scene.physicsEngine.moveSprite(this, scene.tileMap, minXDiff, minYDiff);
     }
 
     //% group="Properties" blockSetVariable="mySprite"

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -135,11 +135,15 @@ class Sprite implements SpriteLike {
         // Identify old upper left corner
         let oMinX = img.width;
         let oMinY = img.height;
+        let oMaxX = 0;
+        let oMaxY = 0;
 
         for (let i = 0; this._hitboxes && i < this._hitboxes.length; ++i) {
             let box = this._hitboxes[i];
             oMinX = Math.min(oMinX, box.ox);
             oMinY = Math.min(oMinY, box.oy);
+            oMaxX = Math.max(oMaxX, box.ox + box.width - 1);
+            oMaxY = Math.max(oMaxY, box.oy + box.height - 1);
         }
 
         this._image = img;
@@ -148,21 +152,35 @@ class Sprite implements SpriteLike {
         // Identify new upper left corner
         let nMinX = img.width;
         let nMinY = img.height;
+        let nMaxX = 0;
+        let nMaxY = 0;
 
         for (let i = 0; i < this._hitboxes.length; ++i) {
             let box = this._hitboxes[i];
             nMinX = Math.min(nMinX, box.ox);
             nMinY = Math.min(nMinY, box.oy);
+            nMaxX = Math.max(nMaxX, box.ox + box.width - 1);
+            nMaxY = Math.max(nMaxY, box.oy + box.height - 1);
         }
 
         const minXDiff = oMinX - nMinX;
         const minYDiff = oMinY - nMinY;
+        const maxXDiff = oMaxX - nMaxX;
+        const maxYDiff = oMaxY - nMaxY;
 
         const scene = game.currentScene();
         const tmap = scene.tileMap;
 
-        if (scene.tileMap)
-            scene.physicsEngine.moveSprite(this, scene.tileMap, minXDiff, minYDiff);
+        if (scene.tileMap) {
+            if (minXDiff > 0 || minYDiff > 0)
+                scene.physicsEngine.moveSprite(this, scene.tileMap, minXDiff, minYDiff);
+            if (maxXDiff < 0 || minYDiff > 0)
+                scene.physicsEngine.moveSprite(this, scene.tileMap, maxXDiff, minYDiff);
+            if (minXDiff > 0 || maxYDiff < 0) 
+                scene.physicsEngine.moveSprite(this, scene.tileMap, minXDiff, maxYDiff);
+            if (maxXDiff < 0 || maxYDiff < 0)
+                scene.physicsEngine.moveSprite(this, scene.tileMap, maxXDiff, maxYDiff);
+        }
     }
 
     //% group="Properties" blockSetVariable="mySprite"

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -168,7 +168,7 @@ class Sprite implements SpriteLike {
         let maxXDiff = oMaxX - nMaxX;
         let maxYDiff = oMaxY - nMaxY;
 
-        let tmap = game.currentScene().tileMap;
+        const tmap = game.currentScene().tileMap;
         if (!tmap) return;
 
         // bump image if collision with surrounding walls due to changed size
@@ -180,20 +180,21 @@ class Sprite implements SpriteLike {
             let b = nMaxY >> 4;
 
             if (tmap.isObstacle(l, t) && (minXDiff > 0 || minYDiff > 0)) {
-                this.left += minXDiff;
-                this.top += minYDiff;
+                this.x += minXDiff;
+                this.y += minYDiff;
             }
             if (tmap.isObstacle(r, t) && (maxXDiff < 0 || minYDiff > 0)) {
-                this.right += maxXDiff;
-                this.top += minYDiff;
+                this.x += maxXDiff;
+                this.y += minYDiff;
             }
             if (tmap.isObstacle(l, b) && (minXDiff > 0 || maxYDiff < 0)) {
-                this.left += minXDiff;
-                this.bottom += maxYDiff;
+                this.x += minXDiff;
+                this.y += maxYDiff;
             }
             if (tmap.isObstacle(r, b) && (maxXDiff < 0 || maxYDiff < 0)) {
-                this.right += maxXDiff;
-                this.bottom += maxYDiff;
+                this.x += maxXDiff;
+                this.y += maxYDiff;
+
             }
         }
     }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -163,21 +163,20 @@ class Sprite implements SpriteLike {
             nMaxY = Math.max(nMaxY, box.oy + box.height - 1);
         }
 
-        let minXDiff = oMinX - nMinX;
-        let minYDiff = oMinY - nMinY;
-        let maxXDiff = oMaxX - nMaxX;
-        let maxYDiff = oMaxY - nMaxY;
+        const minXDiff = oMinX - nMinX;
+        const minYDiff = oMinY - nMinY;
+        const maxXDiff = oMaxX - nMaxX;
+        const maxYDiff = oMaxY - nMaxY;
 
         const tmap = game.currentScene().tileMap;
         if (!tmap) return;
 
-        // bump image if collision with surrounding walls due to changed size
-        // beyond tile size. Only attempt if new sprite fits within a single tile.
+        // Bump image if collision with surrounding walls due to changed size.
         if (this.width <= 16 && this.height <= 16 && (~this.flags & SpriteFlag.Ghost)) {
-            let l = nMinX >> 4;
-            let r = nMaxX >> 4;
-            let t = nMinY >> 4;
-            let b = nMaxY >> 4;
+            const l = nMinX >> 4;
+            const r = nMaxX >> 4;
+            const t = nMinY >> 4;
+            const b = nMaxY >> 4;
 
             if (tmap.isObstacle(l, t) && (minXDiff > 0 || minYDiff > 0)) {
                 this.x += minXDiff;

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -50,7 +50,7 @@ namespace sprites {
     //% weight=87
     export function allOfKind(kind: number): Sprite[] {
         const spritesByKind = game.currentScene().spritesByKind;
-        if (!(kind >= 0) || spritesByKind[kind] == undefined) return [];
+        if (!(kind >= 0) || !spritesByKind[kind]) return [];
         else return spritesByKind[kind].slice(0, spritesByKind[kind].length);
     }
 

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -151,7 +151,7 @@ namespace tiles {
                     const index = this._map.getPixel(x, y);
                     const tile = this._tileSets[index] || this.generateTile(index);
                     if (tile) {
-                        screen.drawImage(tile.image, ((x - x0) << 4) - offsetX, ((y - y0) << 4) - offsetY)
+                        screen.drawTransparentImage(tile.image, ((x - x0) << 4) - offsetX, ((y - y0) << 4) - offsetY)
                     }
                 }
             }


### PR DESCRIPTION
Fixes Microsoft/pxt-arcade#159, fixes Microsoft/pxt-arcade#218

Tilemap transparency, so background color / image shows through, instead of replacing all transparent portions with black

Issue 218 caused by hitboxes changing when a sprite's image is changed;  attempts to resolve this by bumping sprite back towards a 'safe' area if the sprite now extends into a wall. This implementation only attempts to resolve this in the case of a sprite that fits within a single tile, as otherwise there isn't a guarantee that the sprite actually fits anywhere on the map.