### PR TITLE
Interaction between scenes.setTileAt and getTile / getTilesByType

### DIFF
--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -106,19 +106,18 @@ namespace scene {
 
     /**
      * Set the given tile to be of the given index
-     * @param col
-     * @param row
+     * @param tile
      * @param index
      */
-    //% blockId=gamesettileat block="set tile at col %col row %row to %index=colorindexpicker"
+    //% blockId=gamesettileat block="set %tile=variables_get(myTile) to %index=colorindexpicker"
     //% group="Tiles"
     //% weight=30
     //% help=scene/set-tile-at
-    export function setTileAt(col: number, row: number, index: number) {
+    export function setTileAt(tile: tiles.Tile, index: number) {
         const scene = game.currentScene();
         if (!scene.tileMap)
             scene.tileMap = new tiles.TileMap();
-        scene.tileMap.setTileAt(col, row, index);
+        scene.tileMap.setTileAt(tile.x >> 4, tile.y >> 4, index);
     }
 
     /**

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -109,7 +109,7 @@ namespace scene {
      * @param tile
      * @param index
      */
-    //% blockId=gamesettileat block="set %tile=variables_get(myTile) to %index=colorindexpicker"
+    //% blockId=gamesettileat block="set %tile=gamegettile to %index=colorindexpicker"
     //% group="Tiles"
     //% weight=30
     //% help=scene/set-tile-at


### PR DESCRIPTION
After writing up a lesson focusing on the new tiles implementation, setTileAt feels a bit clunky within blocks. I didn't add a way (exposed in the blocks) to get a tile's row and column, so they'd have to switch to TypeScript to get those properties from the tile, which feels a bit unnecessary.

Ways in which it might be improved:
- Add in row / column getters to tile that are exposed in blocks
- Make setTileAt accept a tile instead of a column and row (implemented)
- Make another function that takes in a tile, and leave setTileAt as is

@riknoll 