### PR TITLE
Game over when life is negative as well

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -51,7 +51,7 @@ namespace info {
             // show life
             if (_life !== null) {
                 drawLives();
-                if (_life == 0) {
+                if (_life <= 0) {
                     if (_lifeOverHandler) {
                         _lifeOverHandler();
                     }


### PR DESCRIPTION
Changed it so that the game considers the player to be out of lives when lives are negative.

Previously, if lives decreased by a number greater than the number of current lives, the game would not recognize this as lives being depleted.