### PR TITLE
showLongText tweaks

### DIFF
--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -197,9 +197,9 @@ namespace game {
             let current = "";
 
             while (strIndex < str.length) {
-                const lastIndex = strIndex + charactersPerRow - 1;
                 const currRowCharacters = rowIndex < rowsOfCharacters - rowsWithCursor - 1 ?
                                             charactersPerRow : charactersPerCursorRow;
+                const lastIndex = strIndex + currRowCharacters - 1;
 
                 if (str.charAt(lastIndex) === " " || lastIndex >= str.length - 1) {
                     current += str.substr(strIndex, currRowCharacters);

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -522,7 +522,8 @@ namespace game {
      * @param frame A square image with a width and height divisible by three
      */
     //% blockId=game_dialog_set_frame group="Dialogs"
-    //% block="set dialog frame to %frame=long_text_image_picker"
+    //% sprite.fieldEditor="long_text_image_picker"
+    //% block="set dialog frame to %frame=screen_image_picker"
     export function setDialogFrame(frame: Image) {
         dialogFrame = frame;
     }

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -347,8 +347,9 @@ namespace game {
 
     /**
      * Shows a long piece of text in a dialog box that can be advanced
-     * using the "A" button. This function halts execution until the
-     * last page of text is dismissed.
+     * using the "A" or "down" buttons. The previous section of the
+     * text can be returned to using the "up" button. This function
+     * halts execution until the last page of text is dismissed.
      *
      * @param str The text to display
      * @param layout The layout to use for the dialog box

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -174,8 +174,8 @@ namespace game {
         }
 
         chunkText(str: string): string[] {
-            const charactersPerRow = Math.floor(this.textAreaWidth() / this.font.charWidth);
-            const rowsOfCharacters = Math.floor(this.textAreaHeight() / this.rowHeight());
+            const charactersPerRow = Math.floor((this.textAreaWidth() - this.cursor.width) / this.font.charWidth);
+            const rowsOfCharacters = Math.floor((this.image.height - ((this.innerTop + this.unit) << 1) - 1) / this.rowHeight());
 
             const screens: string[] = [];
 
@@ -235,8 +235,8 @@ namespace game {
         drawTextCore() {
             if (!this.chunks || this.chunks.length === 0) return;
             const str = this.chunks[this.chunkIndex];
-            const availableWidth = this.textAreaWidth();
-            const availableHeight = this.textAreaHeight();
+            const availableWidth = this.textAreaWidth() - this.cursor.width;
+            const availableHeight = this.image.height - ((this.innerTop + this.unit) << 1) - 1;
 
             const charactersPerRow = Math.floor(availableWidth / this.font.charWidth);
             const rowsOfCharacters = Math.floor(availableHeight / this.rowHeight());
@@ -489,7 +489,7 @@ namespace game {
      * @param frame A square image with a width and height divisible by three
      */
     //% blockId=game_dialog_set_frame group="Dialogs"
-    //% block="set dialog frame to %frame=screen_image_picker"
+    //% block="set dialog frame to %frame=long_text_image_picker"
     export function setDialogFrame(frame: Image) {
         dialogFrame = frame;
     }

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -522,7 +522,6 @@ namespace game {
      * @param frame A square image with a width and height divisible by three
      */
     //% blockId=game_dialog_set_frame group="Dialogs"
-    //% sprite.fieldEditor="long_text_image_picker"
     //% block="set dialog frame to %frame=screen_image_picker"
     export function setDialogFrame(frame: Image) {
         dialogFrame = frame;

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -186,9 +186,9 @@ namespace game {
 
         chunkText(str: string): string[] {
             const charactersPerRow = Math.floor(this.textAreaWidth() / this.font.charWidth);
-            const rowsOfCharacters = Math.floor(this.textAreaHeight() / this.rowHeight());
-            const rowsWithCursor = Math.floor(this.cursor.height / this.rowHeight());
             const charactersPerCursorRow = Math.floor(charactersPerRow - (this.cursor.width / this.font.charWidth));
+            const rowsOfCharacters = Math.floor(this.textAreaHeight() / this.rowHeight());
+            const rowsWithCursor = Math.ceil(this.cursor.height / this.rowHeight());
 
             const screens: string[] = [];
 
@@ -197,8 +197,8 @@ namespace game {
             let current = "";
 
             while (strIndex < str.length) {
-                const currRowCharacters = rowIndex < rowsOfCharacters - rowsWithCursor - 1 ?
-                                            charactersPerRow : charactersPerCursorRow;
+                const currRowCharacters = rowIndex < rowsOfCharacters - rowsWithCursor ?
+                                                                    charactersPerRow : charactersPerCursorRow;
                 const lastIndex = strIndex + currRowCharacters - 1;
 
                 if (str.charAt(lastIndex) === " " || lastIndex >= str.length - 1) {
@@ -254,18 +254,17 @@ namespace game {
             const availableHeight = this.textAreaHeight();
 
             const charactersPerRow = Math.floor(availableWidth / this.font.charWidth);
-            const rowsOfCharacters = Math.floor(availableHeight / this.rowHeight());
-
-            const rowsWithCursor = Math.floor(this.cursor.height / this.rowHeight());
             const charactersPerCursorRow = Math.floor(charactersPerRow - (this.cursor.width / this.font.charWidth));
+            const rowsOfCharacters = Math.floor(availableHeight / this.rowHeight());
+            const rowsWithCursor = Math.ceil(this.cursor.height / this.rowHeight());
 
             const textLeft = 1 + this.innerLeft + this.unit + ((availableWidth - charactersPerRow * this.font.charWidth) >> 1);
             const textTop = 1 + this.innerTop + this.unit + ((availableHeight - rowsOfCharacters * this.rowHeight()) >> 1);
 
             let current = 0;
             for (let row = 0; row < rowsOfCharacters; row++) {
-                const currRowCharacters = row % rowsOfCharacters < rowsOfCharacters - rowsWithCursor - 1 ?
-                                            charactersPerRow : charactersPerCursorRow;
+                const currRowCharacters = row % rowsOfCharacters < rowsOfCharacters - rowsWithCursor ?
+                                                                    charactersPerRow : charactersPerCursorRow;
 
                 this.image.print(
                     str.substr(current, currRowCharacters),

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -84,7 +84,7 @@ namespace game {
             this.image.drawTransparentImage(
                 this.cursor,
                 this.innerLeft + this.textAreaWidth() + this.unit + offset - this.cursor.width,
-                this.innerTop + this.unit + this.textAreaHeight() + 1
+                this.innerTop + this.unit + this.textAreaHeight() + 1 - this.cursorRowHeight()
             )
         }
 
@@ -148,7 +148,7 @@ namespace game {
         }
 
         protected textAreaHeight() {
-            return this.image.height - ((this.innerTop + this.unit) << 1) - 1 - this.cursorRowHeight();
+            return this.image.height - ((this.innerTop + this.unit) << 1) - 1;
         }
     }
 
@@ -185,8 +185,8 @@ namespace game {
         }
 
         chunkText(str: string): string[] {
-            const charactersPerRow = Math.floor((this.textAreaWidth()) / this.font.charWidth);
-            const rowsOfCharacters = Math.floor((this.image.height - ((this.innerTop + this.unit) << 1) - 1) / (this.rowHeight()));
+            const charactersPerRow = Math.floor(this.textAreaWidth() / this.font.charWidth);
+            const rowsOfCharacters = Math.floor(this.textAreaHeight() / this.rowHeight());
             const rowsWithCursor = Math.floor(this.cursor.height / this.rowHeight());
             const charactersPerCursorRow = Math.floor(charactersPerRow - (this.cursor.width / this.font.charWidth));
 
@@ -251,7 +251,7 @@ namespace game {
             if (!this.chunks || this.chunks.length === 0) return;
             const str = this.chunks[this.chunkIndex];
             const availableWidth = this.textAreaWidth();
-            const availableHeight = this.image.height - ((this.innerTop + this.unit) << 1) - 1;
+            const availableHeight = this.textAreaHeight();
 
             const charactersPerRow = Math.floor(availableWidth / this.font.charWidth);
             const rowsOfCharacters = Math.floor(availableHeight / this.rowHeight());

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -167,15 +167,28 @@ namespace game {
             return this.chunkIndex < this.chunks.length - 1;
         }
 
+        hasPrev() {
+            if (!this.chunks || this.chunks.length === 0) return false;
+            return this.chunkIndex > 0;
+        }
+
         nextPage() {
             if (this.hasNext()) {
                 this.chunkIndex++;
             }
         }
 
+        prevPage() {
+            if (this.hasPrev()) {
+                this.chunkIndex--;
+            }
+        }
+
         chunkText(str: string): string[] {
-            const charactersPerRow = Math.floor((this.textAreaWidth() - this.cursor.width) / this.font.charWidth);
-            const rowsOfCharacters = Math.floor((this.image.height - ((this.innerTop + this.unit) << 1) - 1) / this.rowHeight());
+            const charactersPerRow = Math.floor((this.textAreaWidth()) / this.font.charWidth);
+            const rowsOfCharacters = Math.floor((this.image.height - ((this.innerTop + this.unit) << 1) - 1) / (this.rowHeight()));
+            const rowsWithCursor = Math.floor(this.cursor.height / this.rowHeight());
+            const charactersPerCursorRow = Math.floor(charactersPerRow - (this.cursor.width / this.font.charWidth));
 
             const screens: string[] = [];
 
@@ -185,30 +198,32 @@ namespace game {
 
             while (strIndex < str.length) {
                 const lastIndex = strIndex + charactersPerRow - 1;
+                const currRowCharacters = rowIndex < rowsOfCharacters - rowsWithCursor - 1 ?
+                                            charactersPerRow : charactersPerCursorRow;
 
                 if (str.charAt(lastIndex) === " " || lastIndex >= str.length - 1) {
-                    current += str.substr(strIndex, charactersPerRow);
-                    strIndex += charactersPerRow;
+                    current += str.substr(strIndex, currRowCharacters);
+                    strIndex += currRowCharacters;
                 }
                 else if (str.charAt(lastIndex + 1) === " ") {
                     // No need to break, but consume the space
-                    current += str.substr(strIndex, charactersPerRow);
-                    strIndex += charactersPerRow + 1;
+                    current += str.substr(strIndex, currRowCharacters);
+                    strIndex += currRowCharacters + 1;
                 }
                 else if (str.charAt(lastIndex - 1) === " ") {
                     // Move the whole word down to the next row
-                    current += str.substr(strIndex, charactersPerRow - 1) + " ";
-                    strIndex += charactersPerRow - 1;
+                    current += str.substr(strIndex, currRowCharacters - 1) + " ";
+                    strIndex += currRowCharacters - 1;
                 }
                 else if (str.charAt(lastIndex - 2) === " ") {
                     // Move the whole word down to the next row
-                    current += str.substr(strIndex, charactersPerRow - 2) + "  ";
-                    strIndex += charactersPerRow - 2;
+                    current += str.substr(strIndex, currRowCharacters - 2) + "  ";
+                    strIndex += currRowCharacters - 2;
                 }
                 else {
                     // Insert a break
-                    current += str.substr(strIndex, charactersPerRow - 1) + "-";
-                    strIndex += charactersPerRow - 1;
+                    current += str.substr(strIndex, currRowCharacters - 1) + "-";
+                    strIndex += currRowCharacters - 1;
                 }
 
                 rowIndex++;
@@ -235,24 +250,30 @@ namespace game {
         drawTextCore() {
             if (!this.chunks || this.chunks.length === 0) return;
             const str = this.chunks[this.chunkIndex];
-            const availableWidth = this.textAreaWidth() - this.cursor.width;
+            const availableWidth = this.textAreaWidth();
             const availableHeight = this.image.height - ((this.innerTop + this.unit) << 1) - 1;
 
             const charactersPerRow = Math.floor(availableWidth / this.font.charWidth);
             const rowsOfCharacters = Math.floor(availableHeight / this.rowHeight());
+
+            const rowsWithCursor = Math.floor(this.cursor.height / this.rowHeight());
+            const charactersPerCursorRow = Math.floor(charactersPerRow - (this.cursor.width / this.font.charWidth));
 
             const textLeft = 1 + this.innerLeft + this.unit + ((availableWidth - charactersPerRow * this.font.charWidth) >> 1);
             const textTop = 1 + this.innerTop + this.unit + ((availableHeight - rowsOfCharacters * this.rowHeight()) >> 1);
 
             let current = 0;
             for (let row = 0; row < rowsOfCharacters; row++) {
+                const currRowCharacters = row % rowsOfCharacters < rowsOfCharacters - rowsWithCursor - 1 ?
+                                            charactersPerRow : charactersPerCursorRow;
+
                 this.image.print(
-                    str.substr(current, charactersPerRow),
+                    str.substr(current, currRowCharacters),
                     textLeft,
                     textTop + row * this.rowHeight(),
                     this.textColor, this.font
                 )
-                current += charactersPerRow;
+                current += currRowCharacters;
             }
         }
     }
@@ -395,9 +416,11 @@ namespace game {
         let pressed = true;
         let done = false;
 
+        let upPressed = true;
+
         game.onUpdate(() => {
             dialog.update();
-            const currentState = controller.A.isPressed();
+            const currentState = controller.A.isPressed() || controller.down.isPressed();
             if (currentState && !pressed) {
                 pressed = true;
                 if (dialog.hasNext()) {
@@ -410,6 +433,17 @@ namespace game {
             }
             else if (pressed && !currentState) {
                 pressed = false;
+            }
+
+            const moveBack = controller.up.isPressed();
+            if (moveBack && !upPressed) {
+                upPressed = true;
+                if (dialog.hasPrev()) {
+                    dialog.prevPage();
+                }
+            }
+            else if (upPressed && !moveBack) {
+                upPressed = false;
             }
         })
 

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -38,18 +38,6 @@ namespace images {
         return img
     }
 
-    //% blockId=long_text_image_picker block="%img"
-    //% shim=TD_ID
-    //% img.fieldEditor="sprite"
-    //% img.fieldOptions.taggedTemplate="img"
-    //% img.fieldOptions.decompileIndirectFixedInstances="true"
-    //% img.fieldOptions.sizes="9,9;12,12;15,15;18,18;3,3;6,6"
-    //% weight=100 group="Create"
-    //% blockHidden=1
-    export function _longTextImage(img: Image) {
-        return img
-    }
-
     /**
      * An image
      * @param image the image

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -38,6 +38,18 @@ namespace images {
         return img
     }
 
+    //% blockId=long_text_image_picker block="%img"
+    //% shim=TD_ID
+    //% img.fieldEditor="sprite"
+    //% img.fieldOptions.taggedTemplate="img"
+    //% img.fieldOptions.decompileIndirectFixedInstances="true"
+    //% img.fieldOptions.sizes="9,9;12,12;15,15;18,18;3,3;6,6"
+    //% weight=100 group="Create"
+    //% blockHidden=1
+    export function _longTextImage(img: Image) {
+        return img
+    }
+
     /**
      * An image
      * @param image the image


### PR DESCRIPTION
* Resolves Microsoft/pxt-arcade#254; up and down arrow keys can be used to scroll through the pages of the text (down arrow key acting as an alternative to A to move to the next chunk, up arrow key going back a screen / page (if possible))
* Allow more of the dialog box to be used to display text

### Current

![Current Full Screen](https://user-images.githubusercontent.com/5615930/44830629-7ab80a00-abd7-11e8-8776-fe6bbd6764d3.gif)

![Current Bottom Screen](https://user-images.githubusercontent.com/5615930/44830700-e8643600-abd7-11e8-85fe-18bffd7fa379.gif)

![Current Right Screen](https://user-images.githubusercontent.com/5615930/44830767-35e0a300-abd8-11e8-97cf-02f00bd54201.gif)

### New

![New Full Screen](https://user-images.githubusercontent.com/5615930/44830622-755abf80-abd7-11e8-8e4d-6b2ad2dd7f37.gif)

![New Bottom Screen](https://user-images.githubusercontent.com/5615930/44830656-aaffa880-abd7-11e8-9ad3-def6c0e0a968.gif)

![New Right Screen](https://user-images.githubusercontent.com/5615930/44830777-4002a180-abd8-11e8-96e9-e6fede24ae7d.gif)
