### PR TITLE
local multiplayer APIs

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -286,7 +286,7 @@ namespace info {
      * Set whether life should be displayed
      * @param on if true, lives are shown; otherwise, lives are hidden
      */
-    export function ShowLife(on: boolean) {
+    export function showLife(on: boolean) {
         initLife();
         updateFlag(Visibility.Life, on);
     }
@@ -295,7 +295,7 @@ namespace info {
      * Set whether score should be displayed
      * @param on if true, score is shown; otherwise, score is hidden
      */
-    export function ShowScore(on: boolean) {
+    export function showScore(on: boolean) {
         initScore();
         updateFlag(Visibility.Score, on);
     }
@@ -304,7 +304,7 @@ namespace info {
      * Set whether score should be displayed
      * @param on if true, score is shown; otherwise, score is hidden
      */
-    export function ShowCountdown(on: boolean) {
+    export function showCountdown(on: boolean) {
         updateFlag(Visibility.Countdown, on);
     }
 

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -25,7 +25,7 @@ namespace info {
     let _borderColor: number;
     let _fontColor: number;
     let _countdownExpired: boolean;
-    let _visibilityFlag: number;
+    let _visibilityFlag: number = Visibility.None;
 
 
     let _lifeOverHandler: () => void;

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -10,7 +10,7 @@ namespace info {
         None = 0,
         Countdown = 1 << 0,
         Score = 1 << 1,
-        Lives = 1 << 2,
+        Life = 1 << 2,
         All = ~(~0 << 3)
     }
 
@@ -59,7 +59,7 @@ namespace info {
                 drawScore();
             }
             // show life
-            if (_life !== null && _visibilityFlag & Visibility.Lives) {
+            if (_life !== null && _visibilityFlag & Visibility.Life) {
                 drawLives();
                 if (_life <= 0) {
                     if (_lifeOverHandler) {
@@ -125,7 +125,7 @@ namespace info {
     function initLife() {
         if (_life !== null) return
         _life = 3;
-        updateFlag(Visibility.Lives, true);
+        updateFlag(Visibility.Life, true);
         initHUD();
     }
 
@@ -286,8 +286,9 @@ namespace info {
      * Set whether life should be displayed
      * @param on if true, lives are shown; otherwise, lives are hidden
      */
-    export function ShowLives(on: boolean) {
-        updateFlag(Visibility.Lives, on);
+    export function ShowLife(on: boolean) {
+        initLife();
+        updateFlag(Visibility.Life, on);
     }
 
     /**
@@ -295,6 +296,7 @@ namespace info {
      * @param on if true, score is shown; otherwise, score is hidden
      */
     export function ShowScore(on: boolean) {
+        initScore();
         updateFlag(Visibility.Score, on);
     }
 
@@ -304,6 +306,12 @@ namespace info {
      */
     export function ShowCountdown(on: boolean) {
         updateFlag(Visibility.Countdown, on);
+    }
+
+
+    function updateFlag(flag: Visibility, on: boolean) {
+        if (on) _visibilityFlag |= flag;
+        else _visibilityFlag &= Visibility.All ^ flag;
     }
 
     /**
@@ -450,12 +458,6 @@ namespace info {
         }
         return val.toString();
     }
-
-    function updateFlag(flag: Visibility, on: boolean) {
-        if (on) _visibilityFlag |= flag;
-        else _visibilityFlag &= Visibility.All ^ flag;
-    }
-    
 }
 
 declare namespace info {

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -5,6 +5,15 @@
 */
 //% color=#AA5585 weight=80 icon="\uf2bb"
 namespace info {
+
+    enum Visibility {
+        None = 0,
+        Countdown = 1 << 0,
+        Score = 1 << 1,
+        Lives = 1 << 2,
+        All = ~(~0 << 3)
+    }
+
     let _score: number = null;
     let _highScore: number = null;
     let _life: number = null;
@@ -16,6 +25,7 @@ namespace info {
     let _borderColor: number;
     let _fontColor: number;
     let _countdownExpired: boolean;
+    let _visibilityFlag: number;
 
 
     let _lifeOverHandler: () => void;
@@ -45,11 +55,11 @@ namespace info {
         _fontColor = screen.isMono ? 1 : 3;
         game.eventContext().registerFrameHandler(95, () => {
             // show score
-            if (_score !== null) {
+            if (_score !== null && _visibilityFlag & Visibility.Score) {
                 drawScore();
             }
             // show life
-            if (_life !== null) {
+            if (_life !== null && _visibilityFlag & Visibility.Lives) {
                 drawLives();
                 if (_life <= 0) {
                     if (_lifeOverHandler) {
@@ -62,7 +72,7 @@ namespace info {
                 }
             }
             // show countdown
-            if (_gameEnd !== undefined) {
+            if (_gameEnd !== undefined && _visibilityFlag & Visibility.Countdown) {
                 drawTimer(_gameEnd - control.millis())
                 let t = Math.max(0, _gameEnd - control.millis()) / 1000;
                 if (t <= 0) {
@@ -108,12 +118,14 @@ namespace info {
         if (_score !== null) return
         _score = 0;
         _highScore = updateHighScore(_score);
+        updateFlag(Visibility.Score, true);
         initHUD();
     }
 
     function initLife() {
         if (_life !== null) return
         _life = 3;
+        updateFlag(Visibility.Lives, true);
         initHUD();
     }
 
@@ -236,6 +248,7 @@ namespace info {
     export function startCountdown(duration: number) {
         initHUD();
         _gameEnd = control.millis() + duration * 1000;
+        updateFlag(Visibility.Countdown, false);
         _countdownExpired = false;
     }
 
@@ -246,6 +259,7 @@ namespace info {
     //% help=info/stop-countdown
     export function stopCountdown() {
         _gameEnd = undefined;
+        updateFlag(Visibility.Countdown, false);
         _countdownExpired = true;
     }
 
@@ -266,6 +280,30 @@ namespace info {
     //%
     export function setLifeImage(image: Image) {
         _heartImage = image;
+    }
+
+    /**
+     * Set whether life should be displayed
+     * @param on if true, lives are shown; otherwise, lives are hidden
+     */
+    export function ShowLives(on: boolean) {
+        updateFlag(Visibility.Lives, on);
+    }
+
+    /**
+     * Set whether score should be displayed
+     * @param on if true, score is shown; otherwise, score is hidden
+     */
+    export function ShowScore(on: boolean) {
+        updateFlag(Visibility.Score, on);
+    }
+
+    /**
+     * Set whether score should be displayed
+     * @param on if true, score is shown; otherwise, score is hidden
+     */
+    export function ShowCountdown(on: boolean) {
+        updateFlag(Visibility.Countdown, on);
     }
 
     /**
@@ -295,6 +333,30 @@ namespace info {
         _fontColor = Math.min(Math.max(color, 0), 15) | 0;
     }
 
+    /**
+     * Get the current color of the borders around the score, countdown, and life
+     * elements
+     */
+    export function borderColor(): number {
+        return _borderColor ? _borderColor : 3;
+    }
+
+    /**
+     * Get the current color of the background of the score, countdown, and life
+     * elements
+     */
+    export function backgroundColor(): number {
+        return _bgColor ? _bgColor : 1;
+    }
+
+    /**
+     * Get the current color of the text usded in the score, countdown, and life
+     * elements
+     */
+    export function fontColor(): number {
+        return _fontColor ? _fontColor : 3;
+    }
+    
     function drawTimer(millis: number) {
         if (millis < 0) millis = 0;
         millis |= 0;
@@ -388,6 +450,12 @@ namespace info {
         }
         return val.toString();
     }
+
+    function updateFlag(flag: Visibility, on: boolean) {
+        if (on) _visibilityFlag |= flag;
+        else _visibilityFlag &= Visibility.All ^ flag;
+    }
+    
 }
 
 declare namespace info {

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -248,7 +248,7 @@ namespace info {
     export function startCountdown(duration: number) {
         initHUD();
         _gameEnd = control.millis() + duration * 1000;
-        updateFlag(Visibility.Countdown, false);
+        updateFlag(Visibility.Countdown, true);
         _countdownExpired = false;
     }
 

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -1,0 +1,151 @@
+//% groups='["other","Multiplayer"]'
+namespace info {
+
+    /** Only players one and two will have their score and lives displayed on screen
+     * others will only be stored. Only players one and two are defined in the blocks
+     * for  this reason
+     */
+    export enum PlayerNumber {
+        //% block="player one"
+        One = 1,
+        //% block="player two"
+        Two,
+        Three,
+        Four
+    }
+
+    let _scores: number[] = null;
+    let _life: number = null;
+    let _hud: boolean = false;
+    let _gameEnd: number = undefined;
+    let _heartImage: Image;
+    let _multiplierImage: Image;
+    let _bgColor: number;
+    let _borderColor: number;
+    let _fontColor: number;
+
+
+    function initHUD() {
+        if (_hud) return;
+        _hud = true;
+
+        // suppress standard score and life display
+        showScore(false);
+        showLife(false);
+
+        // _heartImage = _heartImage || defaultHeartImage();
+
+        _multiplierImage = _multiplierImage || img`
+            1 . 1
+            . 1 .
+            1 . 1
+        `;
+
+        _bgColor = info.backgroundColor();
+        _borderColor = info.borderColor();;
+        _fontColor = info.fontColor();
+        game.eventContext().registerFrameHandler(95, () => {
+            for (let player = 1; player <= 2; player++) {
+                // show score
+                if (_scores && _scores[player] !== null) {
+                    drawPlayerScore(player);
+                }
+                // show life
+                // if (_life !== null) {
+                //     drawLives();
+                //     if (_life <= 0) {
+                //         if (_lifeOverHandler) {
+                //             _lifeOverHandler();
+                //         }
+                //         else {
+                //             game.over();
+                //         }
+                //         _life = null;
+                //     }
+                // }
+                // show player number
+                // TODO
+            }
+        })
+    }
+
+    function initPlayer(player: PlayerNumber) {
+        // TODO
+    }
+
+    function initPlayerScore(player: PlayerNumber) {
+        if (_scores === null) _scores = [];
+        else if (_scores[player]) return;
+        
+        _scores[player] = 0;
+        saveMultiplayerHighScore();
+        initPlayer(player);
+    }
+
+    /**
+     * Updates the high score based on the scores of all players
+     */
+    export function saveMultiplayerHighScore() {
+        if (_scores) {
+            let oldScore = score();
+            let maxScore = info.highScore();
+            for (let i = 0; i < _scores.length; i++) {
+                if (maxScore && _scores[i]) {
+                    maxScore = Math.max(maxScore, _scores[i]);
+                }
+            }
+            setScore(maxScore);
+            saveHighScore();
+            setScore(oldScore);
+        }
+    }
+
+    /**
+     * Get the current score for the given player if any
+     */
+    //% weight=95 blockGap=8 group="Multiplayer"
+    //% blockId=local_playerScore block="score"
+    export function playerScore(player: PlayerNumber): number {
+        initPlayerScore(player);
+        return _scores[player] || 0;
+    }
+
+    /**
+     * Set the score of a given player
+     * @param player the player
+     * @param value the score to set the player to
+     */
+    //% weight=93 blockGap=8 group="Multiplayer"
+    //% blockId=local_setPlayerScore block="set $player score to $value"
+    export function setPlayerScore(player: PlayerNumber, value: number) {
+        initPlayerScore(player);
+        _scores[player] = value | 0;
+    }
+
+    /**
+     * Change the score of a given player by the given amount
+     * @param player the player
+     * @param value the amount of change, eg: 1
+     */
+    //% weight=92 group="Multiplayer"
+    //% blockId=local_changePlayerScoreBy block="change $player score by $value"
+    export function changePlayerScoreBy(player: PlayerNumber, value: number) {
+        initPlayerScore(player);
+        setScore(_scores[player] + value);
+    }
+
+    function drawPlayerScore(player: PlayerNumber) {
+        const s = score() | 0;
+
+        let font: image.Font;
+        let offsetY = 2;
+        font = image.font5;
+
+        const num = s.toString();
+        const width = num.length * font.charWidth;
+
+        screen.fillRect(screen.width - width - 2, 0, screen.width, image.font5.charHeight + 3, _borderColor)
+        screen.fillRect(screen.width - width - 1, 0, screen.width, image.font5.charHeight + 2, _bgColor)
+        screen.print(num, screen.width - width, offsetY, _fontColor, font);
+    }
+}

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -47,9 +47,9 @@ namespace info {
             // Then run life over events
             for (let player = PlayerNumber.One; player < _players.length; player++) {
                 const p = _players[player];
-                if (p && p._h && p._life !== null && p._life <= 0) {
+                if (p && p._life !== null && p._life <= 0) {
                     p._life = null;
-                    p._h();
+                    if (p._h) p._h();
                 }
             }
         })

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -1,16 +1,16 @@
 //% groups='["other","Multiplayer"]'
 namespace info {
     export interface PlayerInfo {
-        score: number;
-        life: number;
-        player: controller.PlayerNumber;
+        _score: number;
+        _life: number;
+        _player: controller.PlayerNumber;
         bg: number; // background color
         border: number; // border color
         fc: number; // font color
         showScore?: boolean;
         showLife?: boolean;
         showPlayer?: boolean;
-        h?: () => void; // onPlayerLifeOver handler
+        _h?: () => void; // onPlayerLifeOver handler
         x?: number;
         y?: number;
         left?: boolean; // if true banner goes from x to the left, else goes rightward
@@ -47,9 +47,9 @@ namespace info {
             // Then run life over events
             for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
                 const p = _players[player];
-                if (p && p.h && p.life !== null && p.life <= 0) {
-                    p.life = null;
-                    p.h();
+                if (p && p._h && p._life !== null && p._life <= 0) {
+                    p._life = null;
+                    p._h();
                 }
             }
         })
@@ -83,64 +83,64 @@ namespace info {
         if (player === controller.PlayerNumber.One) {
             // Top left, and banner is white on red
             _players[player] = {
-                score: null,
-                life: null,
-                player: player,
+                _score: null,
+                _life: null,
+                _player: player,
                 bg: screen.isMono ? 0 : 2,
                 border: 1,
                 fc: 1,
                 showScore: null,
                 showLife: null,
                 showPlayer: null,
-                x: -1,
-                y: -1
+                x: 0,
+                y: 0
             }
         } else if (player === controller.PlayerNumber.Two) {
             // Top right, and banner is white on blue
             _players[player] = {
-                score: null,
-                life: null,
-                player: player,
+                _score: null,
+                _life: null,
+                _player: player,
                 bg: screen.isMono ? 0 : 8,
                 border: 1,
                 fc: 1,
                 showScore: null,
                 showLife: null,
                 showPlayer: null,
-                x: screen.width + 1,
-                y: -1,
+                x: screen.width,
+                y: 0,
                 left: true
             }
         } else if (player === controller.PlayerNumber.Three) {
             // Not displayed by default, bottom left, banner is white on yellow
             _players[player] = {
-                score: null,
-                life: null,
-                player: player,
-                bg: screen.isMono ? 0 : 5,
+                _score: null,
+                _life: null,
+                _player: player,
+                bg: screen.isMono ? 0 : 4,
                 border: 1,
                 fc: 1,
                 showLife: false,
                 showScore: false,
                 showPlayer: false,
-                x: -1,
-                y: screen.height + 1,
+                x: 0,
+                y: screen.height,
                 up: true
             }
         } else {
             // Not displayed by default, bottom left, banner is white on green
             _players[player] = {
-                score: null,
-                life: null,
-                player: player,
+                _score: null,
+                _life: null,
+                _player: player,
                 bg: screen.isMono ? 0 : 7,
                 border: 1,
                 fc: 1,
                 showLife: false,
                 showScore: false,
                 showPlayer: false,
-                x: screen.width + 1,
-                y: screen.height + 1,
+                x: screen.width,
+                y: screen.height,
                 left: true,
                 up: true
             }
@@ -162,8 +162,8 @@ namespace info {
         if (p.showScore === null) p.showScore = true;
         if (p.showPlayer === null) p.showPlayer = true;
 
-        if (!p.score) {
-            p.score = 0;
+        if (!p._score) {
+            p._score = 0;
             saveMultiplayerHighScore();
         }
     }
@@ -174,8 +174,8 @@ namespace info {
         if (p.showLife === null) p.showLife = true;
         if (p.showPlayer === null) p.showPlayer = true;
 
-        if (p.life === null) {
-            p.life = 3;
+        if (p._life === null) {
+            p._life = 3;
         }
     }
 
@@ -189,8 +189,8 @@ namespace info {
             let maxScore = hS;
             for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
                 const p = _players[player]
-                if (p && p.score) {
-                    maxScore = Math.max(maxScore, p.score);
+                if (p && p._score) {
+                    maxScore = Math.max(maxScore, p._score);
                 }
             }
             if (maxScore > hS) {
@@ -208,7 +208,7 @@ namespace info {
     //% blockId=local_playerScore block="$player score"
     export function playerScore(player: controller.PlayerNumber): number {
         initPlayerScore(player);
-        return _players[player].score;
+        return _players[player]._score;
     }
 
     /**
@@ -220,7 +220,7 @@ namespace info {
     //% blockId=local_setPlayerScore block="set $player score to $value"
     export function setPlayerScore(player: controller.PlayerNumber, value: number) {
         initPlayerScore(player);
-        _players[player].score = value | 0;
+        _players[player]._score = value | 0;
     }
 
     /**
@@ -232,7 +232,7 @@ namespace info {
     //% blockId=local_changePlayerScoreBy block="change $player score by $value"
     export function changePlayerScoreBy(player: controller.PlayerNumber, value: number) {
         initPlayerScore(player);
-        setPlayerScore(player, _players[player].score + value);
+        setPlayerScore(player, _players[player]._score + value);
     }
 
     /**
@@ -243,7 +243,7 @@ namespace info {
     //% blockId=local_life block="$player life"
     export function playerLife(player: controller.PlayerNumber) {
         initPlayerLife(player);
-        return _players[player].life;
+        return _players[player]._life;
     }
 
 
@@ -256,7 +256,7 @@ namespace info {
     //% blockId=local_setLife block="set $player life to %value"
     export function setPlayerLife(player: controller.PlayerNumber, value: number) {
         initPlayerLife(player);
-        _players[player].life = value | 0;
+        _players[player]._life = value | 0;
     }
 
     /**
@@ -268,7 +268,7 @@ namespace info {
     //% blockId=local_changeLifeBy block="change $player life by %value"
     export function changePlayerLifeBy(player: controller.PlayerNumber, value: number) {
         initPlayerLife(player);
-        setPlayerLife(player, _players[player].life + value);
+        setPlayerLife(player, _players[player]._life + value);
     }
 
     /**
@@ -280,7 +280,7 @@ namespace info {
     //% blockId=local_gamelifeevent block="on $player life zero"
     export function onPlayerLifeZero(player: controller.PlayerNumber, handler: () => void) {
         initPlayer(player);
-        _players[player].h = handler;
+        _players[player]._h = handler;
     }
 
     function drawPlayer(player: controller.PlayerNumber) {
@@ -289,73 +289,84 @@ namespace info {
         const font = image.font5;
         const p = _players[player];
         
-        let s: string;
-        let l: string;
-        let h = 4;
-        let sW = 0;
-        let lW = 0;
+        let score: string;
+        let life: string;
+        let height = 4;
+        let scoreWidth = 0;
+        let lifeWidth = 0;
         const offsetX = 1;
         let offsetY = 2;
 
         // TODO maybe w / h should be gotten through exported functions, to making laying stuff out more reasonable?
         if (p.showScore) {
-            s = "" + playerScore(player);
-            sW = s.length * font.charWidth + 3;
-            h += font.charHeight;
+            score = "" + playerScore(player);
+            scoreWidth = score.length * font.charWidth + 3;
+            height += font.charHeight;
             offsetY += font.charHeight + 1;
         }
         if (p.showLife) {
-            l = "" + playerLife(player);
-            lW = _heartImage.width + _multiplierImage.width + l.length * font.charWidth + 3;
-            h += _heartImage.height;
+            life = "" + playerLife(player);
+            lifeWidth = _heartImage.width + _multiplierImage.width + life.length * font.charWidth + 3;
+            height += _heartImage.height;
         }
 
-        const w = Math.max(sW, lW);
+        const width = Math.max(scoreWidth, lifeWidth);
 
         // bump size for space between lines
-        if (p.showScore && p.showLife) h++;
+        if (p.showScore && p.showLife) height++;
 
-        const x = p.x - (p.left ? w : 0);
-        const y = p.y - (p.up ? h : 0);
+        const x = p.x - (p.left ? width : 0);
+        const y = p.y - (p.up ? height : 0);
 
         // Bordered Box
         if (p.showScore || p.showLife) {
-            screen.fillRect(x, y, w, h, p.border);
-            screen.fillRect(x + 1, y + 1, w - 2, h - 2, p.bg);
+            screen.fillRect(x, y, width, height, p.border);
+            screen.fillRect(x + 1, y + 1, width - 2, height - 2, p.bg);
         }
 
         // print score
         if (p.showScore) {
-            const bump = p.left ? w - sW: 0;
-            screen.print(s, x + offsetX + bump + 1, y + 2, p.fc, font);
+            const bump = p.left ? width - scoreWidth: 0;
+            screen.print(score, x + offsetX + bump + 1, y + 2, p.fc, font);
         }
 
         // print life
         if (p.showLife) {
-            const bump = p.left ? w - lW: 0;
+            const xLoc = x + offsetX + (p.left ? width - lifeWidth : 0);
             
             let mult = _multiplierImage.clone();
             mult.replace(1, p.fc);
 
-            screen.drawTransparentImage(_heartImage, x + offsetX + bump, y + offsetY);
-            screen.drawTransparentImage(mult, x + _heartImage.width + offsetX + bump, y + offsetY + font.charHeight - _multiplierImage.height - 1);
-            screen.print(l, x + offsetX + _heartImage.width + _multiplierImage.width + 1 + bump, y + offsetY, p.fc, font);
+            screen.drawTransparentImage(_heartImage,
+                            xLoc,
+                            y + offsetY);
+            screen.drawTransparentImage(mult,
+                            xLoc + _heartImage.width,
+                            y + offsetY + font.charHeight - _multiplierImage.height - 1);
+            screen.print(life,
+                            xLoc + _heartImage.width + _multiplierImage.width + 1,
+                            y + offsetY,
+                            p.fc,
+                            font);
         }
 
-        // print player
+        // print player icon
         if (p.showPlayer) {
-            // TODO make sure this renders in correct position when only showPlayer is on (w/o showLife / showScore)
-            const pNum = "" + p.player;
+            const pNum = "" + p._player;
             
-            let pW = pNum.length * font.charWidth;
-            // characters 4-9 are 1 px wider than 0-3
-            if (player % 10 > 3) pW++;
+            let iconWidth = pNum.length * font.charWidth + 1;
+            const iconHeight = Math.max(height, font.charHeight + 2);
+            let iconX = p.left ? (x - iconWidth + 1) : (x + width - 1);
+            let iconY = y;
 
-            const pH = Math.max(h, font.charHeight + 2);
-            const pX = p.left ? (x - pW + 1) : (x + w - 1);
+            // adjustments when only player icon shown
+            if (!p.showScore && !p.showLife) {
+                iconX += p.left ? -1 : 1;
+                if (p.up) iconY -= 3;
+            }
 
-            screen.fillRect(pX, y, pW, pH, p.border);
-            screen.print(pNum, pX + 1, y + (pH / 2) - (font.charHeight / 2), p.bg, font);
+            screen.fillRect(iconX, iconY, iconWidth, iconHeight, p.border);
+            screen.print(pNum, iconX + 1, iconY + (iconHeight >> 1) - (font.charHeight >> 1), p.bg, font);
         }
     }
 }

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -88,7 +88,7 @@ namespace info {
                 score: null,
                 life: null,
                 player: player,
-                bg: screen.isMono ? 0 : 3,
+                bg: screen.isMono ? 0 : 2,
                 border: 1,
                 fc: 1,
                 showScore: null,
@@ -113,8 +113,24 @@ namespace info {
                 y: -1,
                 left: true
             }
+        } else if (player === controller.PlayerNumber.Three) {
+            // Not displayed by default, bottom left, banner is white on yellow
+            _players[player] = {
+                score: null,
+                life: null,
+                player: player,
+                bg: screen.isMono ? 0 : 5,
+                border: 1,
+                fc: 1,
+                showLife: false,
+                showScore: false,
+                showPlayer: false,
+                x: -1,
+                y: screen.height + 1,
+                up: true
+            }
         } else {
-            // Not displayed by default, standard info color
+            // Not displayed by default, bottom left, banner is white on green
             _players[player + 0] = {
                 // this weird hack is needed to compile the code. Otherwise gets
                 //      non-numeric indexer on Array_::setAt
@@ -123,12 +139,16 @@ namespace info {
                 score: null,
                 life: null,
                 player: player,
-                bg: screen.isMono ? 0 : 1,
-                border: screen.isMono ? 1 : 3,
-                fc: screen.isMono ? 1 : 3,
+                bg: screen.isMono ? 0 : 7,
+                border: 1,
+                fc: 1,
                 showLife: false,
                 showScore: false,
-                showPlayer: false
+                showPlayer: false,
+                x: screen.width + 1,
+                y: screen.height + 1,
+                left: true,
+                up: true
             }
         }
     }
@@ -302,6 +322,7 @@ namespace info {
         // print life
         if (p.showLife) {
             const bump = p.left ? w - lW: 0;
+            
             let mult = _multiplierImage.clone();
             mult.replace(1, p.fc);
 
@@ -313,7 +334,11 @@ namespace info {
         // print player
         if (p.showPlayer) {
             const pNum = "" + p.player;
-            const pW = pNum.length * font.charWidth;
+            
+            let pW = pNum.length * font.charWidth;
+            // characters 4-9 are 1 px wider than 0-3
+            if (player % 10 > 3) pW++;
+
             const pH = Math.max(h, font.charHeight + 2);
             const pX = p.left ? (x - pW + 1) : (x + w - 1);
 

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -283,6 +283,16 @@ namespace info {
         _players[player]._h = handler;
     }
 
+    /**
+     * Returns true if the given player currently has a value set for health,
+     * and false otherwise.
+     * @param player player to check life of
+     */
+    export function playerHasLife(player: PlayerNumber): boolean {
+        initPlayer(player);
+        return _players[player]._life !== null;
+    }
+
     function drawPlayer(player: PlayerNumber) {
         if (!_players || !_players[player]) return;
 

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -3,7 +3,7 @@ namespace info {
     export interface PlayerInfo {
         _score: number;
         _life: number;
-        _player: controller.PlayerNumber;
+        _player: PlayerNumber;
         bg: number; // background color
         border: number; // border color
         fc: number; // font color
@@ -40,12 +40,12 @@ namespace info {
 
         game.eventContext().registerFrameHandler(95, () => {
             // First draw players
-            for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
+            for (let player = PlayerNumber.One; player < _players.length; player++) {
                 drawPlayer(player);
             }
 
             // Then run life over events
-            for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
+            for (let player = PlayerNumber.One; player < _players.length; player++) {
                 const p = _players[player];
                 if (p && p._h && p._life !== null && p._life <= 0) {
                     p._life = null;
@@ -75,12 +75,12 @@ namespace info {
     }
 
 
-    function initPlayer(player: controller.PlayerNumber) {
+    function initPlayer(player: PlayerNumber) {
         if (!_players) _players = [];
         if (_players[player]) return;
         initMultiplayerHUD();
 
-        if (player === controller.PlayerNumber.One) {
+        if (player === PlayerNumber.One) {
             // Top left, and banner is white on red
             _players[player] = {
                 _score: null,
@@ -94,8 +94,8 @@ namespace info {
                 showPlayer: null,
                 x: 0,
                 y: 0
-            }
-        } else if (player === controller.PlayerNumber.Two) {
+            };
+        } else if (player === PlayerNumber.Two) {
             // Top right, and banner is white on blue
             _players[player] = {
                 _score: null,
@@ -110,8 +110,8 @@ namespace info {
                 x: screen.width,
                 y: 0,
                 left: true
-            }
-        } else if (player === controller.PlayerNumber.Three) {
+            };
+        } else if (player === PlayerNumber.Three) {
             // Not displayed by default, bottom left, banner is white on yellow
             _players[player] = {
                 _score: null,
@@ -126,7 +126,7 @@ namespace info {
                 x: 0,
                 y: screen.height,
                 up: true
-            }
+            };
         } else {
             // Not displayed by default, bottom left, banner is white on green
             _players[player] = {
@@ -143,7 +143,7 @@ namespace info {
                 y: screen.height,
                 left: true,
                 up: true
-            }
+            };
         }
     }
 
@@ -151,12 +151,12 @@ namespace info {
      * Get the PlayerInfo object for the given player
      * @param player player to get representation of
      */
-    export function playerInfo(player: controller.PlayerNumber): PlayerInfo {
+    export function playerInfo(player: PlayerNumber): PlayerInfo {
         initPlayer(player);
         return _players[player];
     }
 
-    function initPlayerScore(player: controller.PlayerNumber) {
+    function initPlayerScore(player: PlayerNumber) {
         initPlayer(player);
         const p = _players[player];
         if (p.showScore === null) p.showScore = true;
@@ -168,7 +168,7 @@ namespace info {
         }
     }
 
-    function initPlayerLife(player: controller.PlayerNumber) {
+    function initPlayerLife(player: PlayerNumber) {
         initPlayer(player);
         const p = _players[player];
         if (p.showLife === null) p.showLife = true;
@@ -187,7 +187,7 @@ namespace info {
             const oS = info.score();
             const hS = info.highScore();
             let maxScore = hS;
-            for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
+            for (let player = PlayerNumber.One; player < _players.length; player++) {
                 const p = _players[player]
                 if (p && p._score) {
                     maxScore = Math.max(maxScore, p._score);
@@ -206,7 +206,7 @@ namespace info {
      */
     //% weight=95 blockGap=8 group="Multiplayer"
     //% blockId=local_playerScore block="$player score"
-    export function playerScore(player: controller.PlayerNumber): number {
+    export function playerScore(player: PlayerNumber): number {
         initPlayerScore(player);
         return _players[player]._score;
     }
@@ -218,7 +218,7 @@ namespace info {
      */
     //% weight=93 blockGap=8 group="Multiplayer"
     //% blockId=local_setPlayerScore block="set $player score to $value"
-    export function setPlayerScore(player: controller.PlayerNumber, value: number) {
+    export function setPlayerScore(player: PlayerNumber, value: number) {
         initPlayerScore(player);
         _players[player]._score = value | 0;
     }
@@ -230,7 +230,7 @@ namespace info {
      */
     //% weight=92 group="Multiplayer"
     //% blockId=local_changePlayerScoreBy block="change $player score by $value"
-    export function changePlayerScoreBy(player: controller.PlayerNumber, value: number) {
+    export function changePlayerScoreBy(player: PlayerNumber, value: number) {
         initPlayerScore(player);
         setPlayerScore(player, _players[player]._score + value);
     }
@@ -241,7 +241,7 @@ namespace info {
      */
     //% weight=85 blockGap=8 group="Multiplayer"
     //% blockId=local_life block="$player life"
-    export function playerLife(player: controller.PlayerNumber) {
+    export function playerLife(player: PlayerNumber) {
         initPlayerLife(player);
         return _players[player]._life;
     }
@@ -254,7 +254,7 @@ namespace info {
      */
     //% weight=84 blockGap=8 group="Multiplayer"
     //% blockId=local_setLife block="set $player life to %value"
-    export function setPlayerLife(player: controller.PlayerNumber, value: number) {
+    export function setPlayerLife(player: PlayerNumber, value: number) {
         initPlayerLife(player);
         _players[player]._life = value | 0;
     }
@@ -266,7 +266,7 @@ namespace info {
      */
     //% weight=83 group="Multiplayer"
     //% blockId=local_changeLifeBy block="change $player life by %value"
-    export function changePlayerLifeBy(player: controller.PlayerNumber, value: number) {
+    export function changePlayerLifeBy(player: PlayerNumber, value: number) {
         initPlayerLife(player);
         setPlayerLife(player, _players[player]._life + value);
     }
@@ -278,12 +278,12 @@ namespace info {
      */
     //% weight=82 group="Multiplayer"
     //% blockId=local_gamelifeevent block="on $player life zero"
-    export function onPlayerLifeZero(player: controller.PlayerNumber, handler: () => void) {
+    export function onPlayerLifeZero(player: PlayerNumber, handler: () => void) {
         initPlayer(player);
         _players[player]._h = handler;
     }
 
-    function drawPlayer(player: controller.PlayerNumber) {
+    function drawPlayer(player: PlayerNumber) {
         if (!_players || !_players[player]) return;
 
         const font = image.font5;

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -39,21 +39,19 @@ namespace info {
             `;
 
         game.eventContext().registerFrameHandler(95, () => {
-            // show score
-
+            // First draw players
             for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
                 drawPlayer(player);
             }
 
-            // TODO: add playerLifeOverHandlers
-            // NO DEFAULT BEHAVIOR FOR _lifeOverHandler
-            // if (_life <= 0) {
-            //     if (_lifeOverHandler) {
-            //         _lifeOverHandler();
-            //     }
-            //     _life = 0;
-            //     _isAlive = false
-            // }
+            // Then run life over events
+            for (let player = controller.PlayerNumber.One; player < _players.length; player++) {
+                const p = _players[player];
+                if (p && p.h && p.life !== null && p.life <= 0) {
+                    p.life = null;
+                    p.h();
+                }
+            }
         })
     }
 
@@ -93,7 +91,7 @@ namespace info {
                 fc: 1,
                 showScore: null,
                 showLife: null,
-                showPlayer: true,
+                showPlayer: null,
                 x: -1,
                 y: -1
             }
@@ -108,7 +106,7 @@ namespace info {
                 fc: 1,
                 showScore: null,
                 showLife: null,
-                showPlayer: true,
+                showPlayer: null,
                 x: screen.width + 1,
                 y: -1,
                 left: true
@@ -153,8 +151,11 @@ namespace info {
         }
     }
 
-    //todo comment
-    export function playerInfo(player: controller.PlayerNumber) {
+    /**
+     * Get the PlayerInfo object for the given player
+     * @param player player to get representation of
+     */
+    export function playerInfo(player: controller.PlayerNumber): PlayerInfo {
         initPlayer(player);
         return _players[player];
     }
@@ -163,6 +164,7 @@ namespace info {
         initPlayer(player);
         const p = _players[player];
         if (p.showScore === null) p.showScore = true;
+        if (p.showPlayer === null) p.showPlayer = true;
 
         if (!p.score) {
             p.score = 0;
@@ -174,8 +176,9 @@ namespace info {
         initPlayer(player);
         const p = _players[player];
         if (p.showLife === null) p.showLife = true;
+        if (p.showPlayer === null) p.showPlayer = true;
 
-        if (!p.life) {
+        if (p.life === null) {
             p.life = 3;
         }
     }
@@ -272,6 +275,18 @@ namespace info {
         setPlayerLife(player, _players[player].life + value);
     }
 
+    /**
+     * Run code when the given player's life is at or below 0
+     * @param player Player for the event to apply to
+     * @param handler code to run on life over
+     */
+    //% weight=82 group="Multiplayer"
+    //% blockId=local_gamelifeevent block="on $player life zero"
+    export function onPlayerLifeZero(player: controller.PlayerNumber, handler: () => void) {
+        initPlayer(player);
+        _players[player].h = handler;
+    }
+
     function drawPlayer(player: controller.PlayerNumber) {
         if (!_players || !_players[player]) return;
 
@@ -295,7 +310,7 @@ namespace info {
         }
         if (p.showLife) {
             l = "" + playerLife(player);
-            lW = _heartImage.width + _multiplierImage.width + l.length * font.charWidth + 2;
+            lW = _heartImage.width + _multiplierImage.width + l.length * font.charWidth + 3;
             h += _heartImage.height;
         }
 

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -129,11 +129,7 @@ namespace info {
             }
         } else {
             // Not displayed by default, bottom left, banner is white on green
-            _players[player + 0] = {
-                // this weird hack is needed to compile the code. Otherwise gets
-                //      non-numeric indexer on Array_::setAt
-                //      (property) player: controller.PlayerNumber
-                // Ask someone smart what this is for, seems like an internal bug?
+            _players[player] = {
                 score: null,
                 life: null,
                 player: player,
@@ -301,7 +297,7 @@ namespace info {
         const offsetX = 1;
         let offsetY = 2;
 
-        // maybe w / h should be gotten through exported functions, to making laying stuff out more reasonable?
+        // TODO maybe w / h should be gotten through exported functions, to making laying stuff out more reasonable?
         if (p.showScore) {
             s = "" + playerScore(player);
             sW = s.length * font.charWidth + 3;
@@ -348,6 +344,7 @@ namespace info {
 
         // print player
         if (p.showPlayer) {
+            // TODO make sure this renders in correct position when only showPlayer is on (w/o showLife / showScore)
             const pNum = "" + p.player;
             
             let pW = pNum.length * font.charWidth;

--- a/libs/local-multiplayer/info.ts
+++ b/libs/local-multiplayer/info.ts
@@ -296,15 +296,17 @@ namespace info {
         let lifeWidth = 0;
         const offsetX = 1;
         let offsetY = 2;
+        let showScore = p.showScore && p._score !== null
+        let showLife = p.showLife && p._life !== null;
 
-        // TODO maybe w / h should be gotten through exported functions, to making laying stuff out more reasonable?
-        if (p.showScore) {
+        if (showScore) {
             score = "" + playerScore(player);
             scoreWidth = score.length * font.charWidth + 3;
             height += font.charHeight;
             offsetY += font.charHeight + 1;
         }
-        if (p.showLife) {
+        
+        if (showLife) {
             life = "" + playerLife(player);
             lifeWidth = _heartImage.width + _multiplierImage.width + life.length * font.charWidth + 3;
             height += _heartImage.height;
@@ -313,25 +315,25 @@ namespace info {
         const width = Math.max(scoreWidth, lifeWidth);
 
         // bump size for space between lines
-        if (p.showScore && p.showLife) height++;
+        if (showScore && showLife) height++;
 
         const x = p.x - (p.left ? width : 0);
         const y = p.y - (p.up ? height : 0);
 
         // Bordered Box
-        if (p.showScore || p.showLife) {
+        if (showScore || showLife) {
             screen.fillRect(x, y, width, height, p.border);
             screen.fillRect(x + 1, y + 1, width - 2, height - 2, p.bg);
         }
 
         // print score
-        if (p.showScore) {
+        if (showScore) {
             const bump = p.left ? width - scoreWidth: 0;
             screen.print(score, x + offsetX + bump + 1, y + 2, p.fc, font);
         }
 
         // print life
-        if (p.showLife) {
+        if (showLife) {
             const xLoc = x + offsetX + (p.left ? width - lifeWidth : 0);
             
             let mult = _multiplierImage.clone();
@@ -360,7 +362,7 @@ namespace info {
             let iconY = y;
 
             // adjustments when only player icon shown
-            if (!p.showScore && !p.showLife) {
+            if (!showScore && !showLife) {
                 iconX += p.left ? -1 : 1;
                 if (p.up) iconY -= 3;
             }

--- a/libs/local-multiplayer/local.ts
+++ b/libs/local-multiplayer/local.ts
@@ -1,15 +1,16 @@
+enum PlayerNumber {
+    //% block="player one"
+    One = 1,
+    //% block="player two"
+    Two,
+    //% block="player three"
+    Three,
+    //% block="player four"
+    Four
+}
+
 //% groups='["other","Multiplayer"]'
 namespace controller {
-    export enum PlayerNumber {
-        //% block="player one"
-        One = 1,
-        //% block="player two"
-        Two,
-        //% block="player three"
-        Three,
-        //% block="player four"
-        Four
-    }
 
     enum ButtonOffset {
         Left = 0,

--- a/libs/local-multiplayer/local.ts
+++ b/libs/local-multiplayer/local.ts
@@ -36,6 +36,7 @@ namespace controller {
      */
     //% weight=100 group="Multiplayer"
     //% blockId=local_setplayersprite block="set sprite for $player to $sprite"
+    //% sprite.shadow="spritescreate"
     export function setPlayerSprite(player: PlayerNumber, sprite: Sprite) {
         if (!playerSprites) playerSprites = [];
         playerSprites[player] = sprite;
@@ -43,6 +44,7 @@ namespace controller {
         for (let i = 0; controlledPlayers && i < controlledPlayers.length; i++) {
             if (controlledPlayers[i].p === player) {
                 controlledPlayers[i].s = sprite;
+                break;
             }
         }
 
@@ -59,8 +61,8 @@ namespace controller {
      * Get the sprite for a player
      */
     //% weight=20 group="Multiplayer"
-    //% blockId=local_getplayersprite block="%player sprite"
-    export function getPlayerSprite(player: PlayerNumber): Sprite {
+    //% blockId=local_playersprite block="%player sprite"
+    export function playerSprite(player: PlayerNumber): Sprite {
         if (!playerSprites || !playerSprites[player]) return null;
         return playerSprites[player];
     }
@@ -74,7 +76,7 @@ namespace controller {
      * @param vx The velocity used for horizontal movement when left/right is pressed
      * @param vy The velocity used for vertical movement when up/down is pressed
      */
-    //% blockId="game_control_player" block="control $player with vx $vx vy $vy"
+    //% blockId="local_game_control_player" block="control $player with vx $vx vy $vy"
     //% weight=99 group="Multiplayer"
     //% vx.defl=100 vy.defl=100
     export function controlPlayer(player: PlayerNumber, vx: number, vy: number) {
@@ -119,7 +121,7 @@ namespace controller {
 
         controlledPlayers.push({
             p: player,
-            s: getPlayerSprite(player),
+            s: playerSprite(player),
             vx: vx,
             vy: vy
         });

--- a/libs/local-multiplayer/pxt.json
+++ b/libs/local-multiplayer/pxt.json
@@ -2,7 +2,8 @@
     "name": "local-multiplayer",
     "description": "Local multiplayer",
     "files": [
-        "local.ts"
+        "local.ts",
+        "info.ts"
     ],
     "dependencies": {
         "core": "file:../controller"

--- a/libs/local-multiplayer/pxt.json
+++ b/libs/local-multiplayer/pxt.json
@@ -6,7 +6,8 @@
         "info.ts"
     ],
     "dependencies": {
-        "core": "file:../controller"
+        "core": "file:../controller",
+        "game": "file:../game"
     },
     "public": true
 }


### PR DESCRIPTION
Adding a few APIs for local multiplayer. ~Still in progress for score / lives; I'll finish it up tonight most likely as I have course material to finish during working hours :) (so do not merge for now)~

### local-multiplayer/local

* ``control player {} with vx {} vy {}``
    * Keeps track of player, so that if the player changes sprites movement switches to that sprite
* ``player {} sprite``
    * Returns sprite currently attached to player
* add ``spritescreate``  as a shadow block for ``setPlayerSprite``; feels a bit ambiguous what belongs there to me with just a hole. (Bug with shadow blocks that causes it to be not ideal, though: Microsoft/pxt-arcade#249)

### game/info:

* getters for the colors of the HUD
* functions to turn on / off display of life / score / countdown

### local-multiplayer/info 

* scores and lives for players one and two, as per Richard's beautiful drawing below (& my handwriting). Only players one and two will be displayed (others will be tracked still), with their player number in a colored box with clear text.
* ``info.onPlayerLifeZero`` to set behavior when player runs out of life
* ``info.playerHasLife`` to check if a player is alive or not (js only)
* ``info.playerInfo`` gets the PlayerInfo object which defines the location / colors / behaviors of the player info box (js only)

Standard info api on left, local multiplayer on right; text always smaller, hearts smaller and always using multiplication instead of displaying more than one heart.

![Standard Info vs Multiplayer Info](https://user-images.githubusercontent.com/5615930/46884272-5ae84880-ce09-11e8-87f6-a31f29683864.jpg)

