### PR TITLE
Ability to reset life in `on life zero`

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -62,13 +62,13 @@ namespace info {
             if (_life !== null && _visibilityFlag & Visibility.Life) {
                 drawLives();
                 if (_life <= 0) {
+                    _life = null;
                     if (_lifeOverHandler) {
                         _lifeOverHandler();
                     }
                     else {
                         game.over();
                     }
-                    _life = null;
                 }
             }
             // show countdown


### PR DESCRIPTION
split from #414

_life getting set to null after calling _lifeOverHandler resets any behavior the player intended for resetting the lives; e.g. a continue screen where they want to set the player back to life with only a single life.