### PR TITLE
fix for https://github.com/Microsoft/pxt-maker/issues/12

### DIFF
--- a/libs/keyboard/keyboard.cpp
+++ b/libs/keyboard/keyboard.cpp
@@ -109,6 +109,7 @@ namespace keyboard {
     */
     //% blockId=keyboardType block="keyboard type %text"
     //% blockGap=8 weight=100
+    //% text.shadowOptions.toString=true
     void type(String text) {
         if (NULL != text)
             pxt::keyboard.type(text->data, text->length);


### PR DESCRIPTION
Automatic tostring on keyboard type.