### PR TITLE
Fixes Sprite ID collision issues

### DIFF
--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -29,6 +29,7 @@ namespace scene {
         background: Background;
         tileMap: tiles.TileMap;
         allSprites: SpriteLike[];
+        spriteCount: number;
         spritesByKind: Sprite[][];
         physicsEngine: PhysicsEngine;
         camera: scene.Camera;
@@ -55,6 +56,7 @@ namespace scene {
             if (this.allSprites) return;
 
             this.allSprites = [];
+            this.spriteCount = 0;
             scene.setBackgroundColor(0)
             // update controller state
             this.eventContext.registerFrameHandler(8, () => {
@@ -112,6 +114,13 @@ namespace scene {
             });
             // update screen
             this.eventContext.registerFrameHandler(200, control.__screen.update);
+        }
+
+        addSprite(sprite: SpriteLike) {
+            if (!this.allSprites) return;
+            
+            this.allSprites.push(sprite);
+            this.spriteCount++;
         }
     }
 }

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -29,8 +29,8 @@ namespace sprites {
         const scene = game.currentScene();
         const sprite = new Sprite(img)
         sprite.type = kind;
-        scene.allSprites.push(sprite)
-        sprite.id = scene.allSprites.length
+        sprite.id = scene.spriteCount;
+        scene.addSprite(sprite)
         scene.physicsEngine.addSprite(sprite);
 
         // run on created handlers

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -68,9 +68,9 @@ namespace tiles {
             this.z = -1;
 
             const sc = game.currentScene();
-            sc.allSprites.push(this);
+            this.id = sc.spriteCount;
+            sc.addSprite(this);
             sc.flags |= scene.Flag.NeedsSorting;
-            this.id = sc.allSprites.length;
         }
 
         offsetX(value: number) {


### PR DESCRIPTION
Added a sprite counter to distribute unique sprite IDs.

Previously, two sprites can have the same ID since their ID is based on how many sprites were in the scene when they were created.

Fixes Microsoft/pxt-arcade#333