### PR TITLE
Fixed issue with tile maps not being ID'ed correctly

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -68,8 +68,7 @@ namespace tiles {
             this.z = -1;
 
             const sc = game.currentScene();
-            sc.allSprites.push(this);
-            this.id = sc.spriteNextId++;
+            sc.addSprite(this);
             sc.flags |= scene.Flag.NeedsSorting;
         }
 


### PR DESCRIPTION
Fixed issue that @riknoll brought up in Microsoft/pxt-common-packages#452