### PR TITLE
Fix onGesture jsdoc description

### DIFF
--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -138,7 +138,7 @@ SINGLETON(WAccel);
 
 namespace input {
 /**
- * Do something when when a gesture is done (like shaking the board).
+ * Do something when a gesture occurs (like shaking the board).
  * @param gesture the type of gesture to track, eg: Gesture.Shake
  * @param body code to run when gesture is raised
  */


### PR DESCRIPTION
Too many "when"s in the description.

RE: https://github.com/Microsoft/pxt-adafruit/issues/849