### PR TITLE
jsdoc parse error for onswitchmoved

### DIFF
--- a/libs/switch/switch.cpp
+++ b/libs/switch/switch.cpp
@@ -27,7 +27,6 @@ SINGLETON(WSwitch);
 namespace input {
 /**
 * Do something when the slide switch is moved left or right.
-*
 * @param direction the direction the switch must be moved to trigget the event
 */
 //% help=input/on-switch-moved

--- a/libs/switch/switch.cpp
+++ b/libs/switch/switch.cpp
@@ -27,7 +27,7 @@ SINGLETON(WSwitch);
 namespace input {
 /**
 * Do something when the slide switch is moved left or right.
-* @param direction the direction the switch must be moved to trigget the event
+* @param direction the direction the switch must be moved to trigger the event
 */
 //% help=input/on-switch-moved
 //% blockId=device_on_switch_moved block="on switch moved %direction"


### PR DESCRIPTION
The method description also includes the stuff from the ``@param`` line when there is a 'blank' line in between, an additional ``*`` as an empty line. Go figure.

![image](https://user-images.githubusercontent.com/27789908/48654991-a53f8500-e9c6-11e8-8ccf-3c44effad64f.png)

```typescript
/**
* Do something when the slide switch is moved left or right.
*
* @param direction the direction the switch must be moved to trigget the event
*/
```
versus:

![image](https://user-images.githubusercontent.com/27789908/48655015-e9cb2080-e9c6-11e8-8fda-9d17c720b693.png)

```typescript
/**
* Do something when the slide switch is moved left or right.
* @param direction the direction the switch must be moved to trigget the event
*/
```

RE: https://github.com/Microsoft/pxt-adafruit/issues/852#