### PR TITLE
Reword controlSprite and reorder toolbox

### DIFF
--- a/libs/controller/controller.ts
+++ b/libs/controller/controller.ts
@@ -10,7 +10,7 @@ enum ControllerButtonEvent {
 /**
  * Access to game controls
  */
-//% weight=97 color="#e15f41" icon="\uf11b"
+//% weight=98 color="#e15f41" icon="\uf11b"
 namespace controller {
     let _userEventsEnabled = true;
     let _activeButtons: Button[];

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -20,7 +20,7 @@ namespace controller {
     //% weight=100
     //% vx.defl=100 vy.defl=100
     //% help=controller/control-sprite
-    export function controlSprite(sprite: Sprite, vx: number = 100, vy: number = 100) {
+    export function moveSprite(sprite: Sprite, vx: number = 100, vy: number = 100) {
         if (!sprite) return;
         if (!controlledSprites) {
             controlledSprites = [];

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -16,11 +16,11 @@ namespace controller {
      * @param vx The velocity used for horizontal movement when left/right is pressed
      * @param vy The velocity used for vertical movement when up/down is pressed
      */
-    //% blockId="game_control_sprite" block="control sprite $sprite=variables_get(mySprite) with vx $vx vy $vy"
+    //% blockId="game_control_sprite" block="move $sprite=variables_get(mySprite) with buttons||vx $vx vy $vy"
     //% weight=100
     //% vx.defl=100 vy.defl=100
     //% help=controller/control-sprite
-    export function controlSprite(sprite: Sprite, vx: number, vy: number) {
+    export function controlSprite(sprite: Sprite, vx: number = 100, vy: number = 100) {
         if (!sprite) return;
         if (!controlledSprites) {
             controlledSprites = [];

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -1,7 +1,7 @@
 /**
  * Game transitions and dialog
  **/
-//% color=#008272 weight=98 icon="\uf111"
+//% color=#008272 weight=97 icon="\uf111"
 //% groups='["Gameplay", "Prompt"]'
 namespace game {
     /**

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -1,7 +1,7 @@
 /**
  * Game transitions and dialog
  **/
-//% color=#008272 weight=99 icon="\uf111"
+//% color=#008272 weight=98 icon="\uf111"
 //% groups='["Gameplay", "Prompt"]'
 namespace game {
     /**

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -12,7 +12,7 @@ Frame handlers:
 /**
  * Sprites on screen
  */
-//% weight=98 color="#4B7BEC" icon="\uf1d8"
+//% weight=99 color="#4B7BEC" icon="\uf1d8"
 //% groups='["Create", "Properties", "Overlaps", "Collisions", "Lifecycle"]'
 namespace sprites {
 

--- a/libs/local-multiplayer/local.ts
+++ b/libs/local-multiplayer/local.ts
@@ -77,10 +77,10 @@ namespace controller {
      * @param vx The velocity used for horizontal movement when left/right is pressed
      * @param vy The velocity used for vertical movement when up/down is pressed
      */
-    //% blockId="local_game_control_player" block="control $player with vx $vx vy $vy"
+    //% blockId="local_game_control_player" block="move $player with buttons||vx $vx vy $vy"
     //% weight=99 group="Multiplayer"
     //% vx.defl=100 vy.defl=100
-    export function controlPlayer(player: PlayerNumber, vx: number, vy: number) {        
+    export function controlPlayer(player: PlayerNumber, vx: number = 100, vy: number = 100) {        
         if (!controlledPlayers) {
             controlledPlayers = [];
             game.currentScene().eventContext.registerFrameHandler(19, () => {

--- a/libs/local-multiplayer/local.ts
+++ b/libs/local-multiplayer/local.ts
@@ -80,7 +80,7 @@ namespace controller {
     //% blockId="local_game_control_player" block="move $player with buttons||vx $vx vy $vy"
     //% weight=99 group="Multiplayer"
     //% vx.defl=100 vy.defl=100
-    export function controlPlayer(player: PlayerNumber, vx: number = 100, vy: number = 100) {        
+    export function movePlayer(player: PlayerNumber, vx: number = 100, vy: number = 100) {        
         if (!controlledPlayers) {
             controlledPlayers = [];
             game.currentScene().eventContext.registerFrameHandler(19, () => {


### PR DESCRIPTION
Reword sprites.controlSprite so that it's a bit easier to understand for new developers; ``move {mySprite} with buttons`` and give vx / vy default values so they can be suppressed.

Reorder toolbox so that game is below controller ( closes Microsoft/pxt-arcade#349 )

Todo:

* [ ] authoring so that ``vx`` and ``vy`` pop out with the ``+`` at the same time, like ``motors.largeA.run`` in lego
* [ ] upgrade path from controlSprite -> moveSprite to avoid breaking everyone who's used it so far with ts change (should be this I think: https://github.com/jwunderl/pxt-arcade/commit/b96d56128265b5771f5816036a560561427ace20)

Also, since this will require an upgrade path already, I can add in the changes to tilemap apis here if we can agree on something ( https://github.com/Microsoft/pxt-arcade/issues/334 )