### PR TITLE
Enable some GC checks in normal builds

### DIFF
--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -61,6 +61,10 @@ void *operator new(size_t size);
 #endif
 #endif
 
+#ifndef PXT_IN_ISR
+#define PXT_IN_ISR() (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk)
+#endif
+
 #ifdef POKY
 inline void *operator new(size_t, void *p) {
     return p;
@@ -176,6 +180,7 @@ typedef enum {
     PANIC_SCREEN_ERROR = 911,
     PANIC_MISSING_PROPERTY = 912,
     PANIC_INVALID_IMAGE = 913,
+    PANIC_CALLED_FROM_ISR = 914,
 
     PANIC_CAST_FIRST = 980,
     PANIC_CAST_FROM_UNDEFINED = 980,

--- a/libs/core---linux/platform.h
+++ b/libs/core---linux/platform.h
@@ -32,4 +32,6 @@ namespace pxt
 #define IMAGE_BITS 4
 #define PXT_GC_THREAD_LIST 1
 
+#define PXT_IN_ISR() false
+
 #endif


### PR DESCRIPTION
In particular, added `if (PXT_IN_ISR()) target_panic(PANIC_CALLED_FROM_ISR);`