### PR TITLE
Fix move sprite docs

### DIFF
--- a/libs/controller/docs/reference/controller.md
+++ b/libs/controller/docs/reference/controller.md
@@ -8,7 +8,7 @@ controller.anyButton.onEvent(ControllerButtonEvent.Pressed, function () {
 })
 controller.anyButton.isPressed()
 controller.anyButton.pauseUntil(ControllerButtonEvent.Pressed)
-controller.controlSprite(null, 0, 0)
+controller.moveSprite(null, 0, 0)
 controller.dx(100)
 controller.dy(100)
 ```
@@ -18,6 +18,6 @@ controller.dy(100)
 [on event](/reference/controller/button/on-event),
 [is pressed](/reference/controller/button/is-pressed),
 [pause until](/reference/controller/button/pause-until),
-[control sprite](/reference/controller/control-sprite),
+[move sprite](/reference/controller/move-sprite),
 [dx](/reference/controller/dx),
 [dy](/reference/controller/dy)

--- a/libs/controller/docs/reference/controller/move-sprite.md
+++ b/libs/controller/docs/reference/controller/move-sprite.md
@@ -1,9 +1,9 @@
-# control Sprite
+# move Sprite
 
 Control the motion of a sprite with the direction buttons.
 
 ```sig
-controller.controlSprite(null, 0, 0)
+controller.moveSprite(null, 0, 0)
 ```
 
 Instead of tracking the direction buttons in a game update function and then updating a sprite's position, you can set a sprite to move automatically when the buttons are pressed. You just decide how fast the sprite will move in both the horizontal and vertical directions when the related buttons are pressed.
@@ -42,7 +42,7 @@ mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
 . . . . . . . . . . . . . . . . 
 `, SpriteKind.Player)
-controller.controlSprite(mySprite, 100, 100)
+controller.moveSprite(mySprite, 100, 100)
 ```
 
 ## See also #seealso

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -19,7 +19,7 @@ namespace controller {
     //% blockId="game_control_sprite" block="move $sprite=variables_get(mySprite) with buttons||vx $vx vy $vy"
     //% weight=100
     //% vx.defl=100 vy.defl=100
-    //% help=controller/control-sprite
+    //% help=controller/move-sprite
     export function moveSprite(sprite: Sprite, vx: number = 100, vy: number = 100) {
         if (!sprite) return;
         if (!controlledSprites) {


### PR DESCRIPTION
broken due to move from ``controlSprite`` to ``moveSprite`` with https://github.com/Microsoft/pxt-common-packages/pull/481.

Will need a bump to 5.1.7 to make everything match in arcade as well