### PR TITLE
Battery service over JACDAC

### DIFF
--- a/libs/jacdac/batterydriver.ts
+++ b/libs/jacdac/batterydriver.ts
@@ -31,9 +31,8 @@ namespace jacdac {
 
         public handleControlPacket(pkt: Buffer): boolean {
             const cp = new ControlPacket(pkt);
-            console.log(pkt.toHex())
             const level = cp.data.getNumber(NumberFormat.UInt8LE, 0);
-            this.log(`lvl ${cp.serialNumber}: ${level}`)
+            this.log(`${cp.serialNumber}: ${level}`)
             return true;
         }
     }

--- a/libs/jacdac/batterydriver.ts
+++ b/libs/jacdac/batterydriver.ts
@@ -31,8 +31,9 @@ namespace jacdac {
 
         public handleControlPacket(pkt: Buffer): boolean {
             const cp = new ControlPacket(pkt);
+            console.log(pkt.toHex())
             const level = cp.data.getNumber(NumberFormat.UInt8LE, 0);
-            this.log(`$level ${cp.serialNumber}: ${level}`)
+            this.log(`lvl ${cp.serialNumber}: ${level}`)
             return true;
         }
     }

--- a/libs/jacdac/batterydriver.ts
+++ b/libs/jacdac/batterydriver.ts
@@ -1,0 +1,38 @@
+namespace jacdac {
+    class BatteryDriver extends Driver {
+        private level: () => number;
+        constructor(level: () => number) {
+            super("bat", DriverType.HostDriver, jacdac.BATTERY_DRIVER_CLASS, 1);
+            this.level = level;
+            jacdac.addDriver(this);
+        }
+
+        protected updateControlPacket() {
+            const batteryLevel = this.level();
+            this.log(`level ${this.level}`);
+            this.controlData.setNumber(NumberFormat.UInt8LE, 0, batteryLevel);
+        }
+    }
+
+    /**
+     * Send battery level over jacdac
+     * @param level 
+     */
+    //%
+    export function broadcastBatteryLevel(level: () => number) {
+        new BatteryDriver(level);
+    }
+
+    class BatterySniffer extends Driver {
+        constructor() {
+            super("bat", DriverType.SnifferDriver, jacdac.BATTERY_DRIVER_CLASS);
+            jacdac.addDriver(this);
+        }
+    }
+
+    let _batterSniffer: BatterySniffer;
+    export function monitorBatteryLevels() {
+        if (!_batterSniffer)
+            _batterSniffer = new BatterySniffer();
+    }
+}

--- a/libs/jacdac/batterydriver.ts
+++ b/libs/jacdac/batterydriver.ts
@@ -28,6 +28,13 @@ namespace jacdac {
             super("bat", DriverType.SnifferDriver, jacdac.BATTERY_DRIVER_CLASS);
             jacdac.addDriver(this);
         }
+
+        public handleControlPacket(pkt: Buffer): boolean {
+            const cp = new ControlPacket(pkt);
+            const level = cp.data.getNumber(NumberFormat.UInt8LE, 0);
+            this.log(`$level ${cp.serialNumber}: ${level}`)
+            return true;
+        }
     }
 
     let _batterSniffer: BatterySniffer;

--- a/libs/jacdac/batterydriver.ts
+++ b/libs/jacdac/batterydriver.ts
@@ -9,7 +9,7 @@ namespace jacdac {
 
         protected updateControlPacket() {
             const batteryLevel = this.level();
-            this.log(`level ${this.level}`);
+            this.log(`level ${batteryLevel}`);
             this.controlData.setNumber(NumberFormat.UInt8LE, 0, batteryLevel);
         }
     }
@@ -25,7 +25,7 @@ namespace jacdac {
 
     class BatterySniffer extends Driver {
         constructor() {
-            super("bat", DriverType.SnifferDriver, jacdac.BATTERY_DRIVER_CLASS);
+            super("batmon", DriverType.SnifferDriver, jacdac.BATTERY_DRIVER_CLASS);
             jacdac.addDriver(this);
         }
 

--- a/libs/jacdac/jacdac.cpp
+++ b/libs/jacdac/jacdac.cpp
@@ -102,9 +102,6 @@ class JDProxyDriver : public JDDriver {
     RefCollection *methods;
     Buffer _controlData; // may be NULL
 
-    /**
-        methods = [handlePacket, handleControlPacket]
-    */
     JDProxyDriver(JDDevice d, RefCollection *m, Buffer controlData) 
         : JDDriver(d)
         , methods(m)

--- a/libs/jacdac/jacdac.cpp
+++ b/libs/jacdac/jacdac.cpp
@@ -118,10 +118,10 @@ class JDProxyDriver : public JDDriver {
     }
 
     virtual int fillControlPacket(JDPkt* p) {
-        if (NULL != _controlData) {
+        if (NULL != _controlData && _controlData->length) {
             ControlPacket* cp = (ControlPacket*)p->data;
-            uint8_t* controlData = cp->data;
-            memcpy(controlData, this->_controlData->data, min(CONTROL_PACKET_PAYLOAD_SIZE, this->_controlData->length));
+            auto n = min(CONTROL_PACKET_PAYLOAD_SIZE, this->_controlData->length);
+            memcpy(cp->data, this->_controlData->data, n);
             Event(this->id, JD_DRIVER_EVT_FILL_CONTROL_PACKET);
         }
         return DEVICE_OK;

--- a/libs/jacdac/jacdac.cpp
+++ b/libs/jacdac/jacdac.cpp
@@ -2,7 +2,7 @@
 #include "JDProtocol.h"
 #include "JackRouter.h"
 
-# JD_DRIVER_EVT_FILL_CONTROL_PACKET 50
+#define JD_DRIVER_EVT_FILL_CONTROL_PACKET 50
 
 namespace jacdac {
 
@@ -122,7 +122,7 @@ class JDProxyDriver : public JDDriver {
             ControlPacket* cp = (ControlPacket*)p->data;
             uint8_t* controlData = cp->data;
             memcpy(controlData, this->_controlData->data, min(CONTROL_PACKET_PAYLOAD_SIZE, this->_controlData->length));
-            Event(this->device.id, JD_DRIVER_EVT_FILL_CONTROL_PACKET);
+            Event(this->id, JD_DRIVER_EVT_FILL_CONTROL_PACKET);
         }
         return DEVICE_OK;
     }

--- a/libs/jacdac/jacdac.cpp
+++ b/libs/jacdac/jacdac.cpp
@@ -139,7 +139,7 @@ class JDProxyDriver : public JDDriver {
             }
         }
 
-        auto buf = pxt::mkBuffer((const uint8_t *)&p->crc, p->size + 4);
+        auto buf = pxt::mkBuffer((const uint8_t *)cp, sizeof(ControlPacket));
         auto r = pxt::runAction1(methods->getAt(1), (TValue)buf);
         auto retVal = numops::toBool(r) ? DEVICE_OK : DEVICE_CANCELLED;
         decr(r);

--- a/libs/jacdac/jacdac.ts
+++ b/libs/jacdac/jacdac.ts
@@ -7,62 +7,18 @@ enum JacDacDriverEvent {
     PairingResponse = DAL.JD_DRIVER_EVT_PAIRING_RESPONSE
 }
 
-class JacDacDriver {
-    public name: string;
-    public status: JacDacDriverStatus;
-    public driverType: jacdac.DriverType;
-    public deviceClass: number;
-    protected supressLog: boolean;
-
-    constructor(name: string, driverType: jacdac.DriverType, deviceClass: number, suppressLog: boolean = false) {
-        this.name = name;
-        this.driverType = driverType;
-        this.deviceClass = deviceClass || jacdac.programHash();
-        this.supressLog = suppressLog;
-    }
-
-    get isConnected(): boolean {
-        return this.status && this.status.isConnected;
-    }
-
-    protected get device(): jacdac.JDDevice {
-        return new jacdac.JDDevice(this.status.device);
-    }
-
-    public log(text: string) {
-        if (!this.supressLog)
-            console.add(jacdac.consolePriority, `jd>${this.name}>${text}`);
-    }
-
-    /**
-     * Registers code to run a on a particular event
-     * @param event 
-     * @param handler 
-     */
-    public onDriverEvent(event: JacDacDriverEvent, handler: () => void) {
-        control.onEvent(this.status.id, event, handler);
-    }
-
-    /**
-     * Called by the logic driver when a data packet is addressed to this driver
-     * Return false when the packet wasn't handled here.
-     */
-    public handlePacket(pkt: Buffer): boolean {
-        return false
-    }
-
-    protected sendPacket(pkt: Buffer) {
-        // this.log(`send pkt ${this.device.driverAddress}`)
-        jacdac.sendPacket(pkt, this.device.driverAddress);
-    }
-}
-
 /**
  * JACDAC protocol support
  */
 namespace jacdac {
     // TODO allocate ID in DAL
     export const LOGGER_DRIVER_CLASS = 4220;
+    // TODO allocate ID in DAL
+    export const BATTERY_DRIVER_CLASS = 4221;
+    // move to codal
+    export const JD_MESSAGE_BUS_ID = 2500;
+    export const JD_DRIVER_EVT_FILL_CONTROL_PACKET = 50;
+
 
     // common logging level for jacdac services
     export let consolePriority = ConsolePriority.Silent;
@@ -78,10 +34,83 @@ namespace jacdac {
         SnifferDriver = DAL.JD_DEVICE_FLAGS_REMOTE | DAL.JD_DEVICE_FLAGS_BROADCAST, // the driver is not enumerated, and receives all packets of the same class (including control packets)
     };
 
+    export class Driver {
+        public name: string;
+        private _status: JacDacDriverStatus;
+        public driverType: jacdac.DriverType;
+        public deviceClass: number;
+        protected supressLog: boolean;
+        private _controlData: Buffer;
+
+        constructor(name: string, driverType: jacdac.DriverType, deviceClass: number, controlDataLength = 0) {
+            this.name = name;
+            this.driverType = driverType;
+            this.deviceClass = deviceClass || jacdac.programHash();
+            if (controlDataLength > 0) {
+                this._controlData = control.createBuffer(controlDataLength);
+            }
+        }
+
+        get status(): JacDacDriverStatus {
+            return this._status;
+        }
+
+        set status(value: JacDacDriverStatus) {
+            this._status = value;
+            if (this._controlData)
+                control.onEvent(this._status.id, JD_DRIVER_EVT_FILL_CONTROL_PACKET, () => this.updateControlPacket());
+        }
+
+        /**
+         * Update the controlData buffer
+         */
+        protected updateControlPacket() {            
+        }
+
+        get controlData(): Buffer {
+            return this._controlData;
+        }
+
+        get isConnected(): boolean {
+            return this.status && this.status.isConnected;
+        }
+
+        protected get device(): jacdac.JDDevice {
+            return new jacdac.JDDevice(this.status.device);
+        }
+
+        public log(text: string) {
+            if (!this.supressLog)
+                console.add(jacdac.consolePriority, `jd>${this.name}>${text}`);
+        }
+
+        /**
+         * Registers code to run a on a particular event
+         * @param event 
+         * @param handler 
+         */
+        public onDriverEvent(event: JacDacDriverEvent, handler: () => void) {
+            control.onEvent(this.status.id, event, handler);
+        }
+
+        /**
+         * Called by the logic driver when a data packet is addressed to this driver
+         * Return false when the packet wasn't handled here.
+         */
+        public handlePacket(pkt: Buffer): boolean {
+            return false
+        }
+
+        protected sendPacket(pkt: Buffer) {
+            // this.log(`send pkt ${this.device.driverAddress}`)
+            jacdac.sendPacket(pkt, this.device.driverAddress);
+        }
+    }
+
     /**
      * base class for pairable drivers
     */
-    export class PairableDriver extends JacDacDriver {
+    export class PairableDriver extends Driver {
         constructor(name: string, isHost: boolean, deviceClass: number) {
             super(name, isHost ? DriverType.PairableHostDriver : DriverType.PairedDriver, deviceClass);
         }
@@ -129,7 +158,7 @@ namespace jacdac {
     export function programHash(): number { return 0 }
 
     //% shim=jacdac::__internalAddDriver
-    function __internalAddDriver(driverType: number, deviceClass: number, methods: ((p: Buffer) => void)[]): JacDacDriverStatus {
+    function __internalAddDriver(driverType: number, deviceClass: number, methods: ((p: Buffer) => void)[], controlData: Buffer): JacDacDriverStatus {
         return null
     }
 
@@ -137,16 +166,17 @@ namespace jacdac {
      * Adds a JacDac device driver
      * @param n driver
      */
-    export function addDriver(n: JacDacDriver) {
+    export function addDriver(n: Driver) {
         if (n.status) { // don't add twice
             n.log(`already added`);
             return;
         }
 
         n.log(`add t${n.driverType} c${n.deviceClass}`)
-        n.status = __internalAddDriver(n.driverType, n.deviceClass, [
-            (p: Buffer) => n.handlePacket(p)
-        ]);
+        n.status = __internalAddDriver(n.driverType, n.deviceClass, 
+            [(p: Buffer) => n.handlePacket(p)],
+            n.controlData
+        );
     }
 
     /**
@@ -250,7 +280,7 @@ namespace jacdac {
         get driverClass(): number {
             return this.buf.getNumber(NumberFormat.UInt32LE, 8);
         }
-        
+
         /**
          * Used to determine what mode the driver is currently in.
          *
@@ -258,8 +288,7 @@ namespace jacdac {
          *
          * @returns true if in VirtualDriver mode.
          **/
-        get isVirtualDriver(): boolean
-        {
+        get isVirtualDriver(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_REMOTE) && !(this.flags & DAL.JD_DEVICE_FLAGS_BROADCAST);
         }
 
@@ -270,8 +299,7 @@ namespace jacdac {
          *
          * @returns true if in PairedDriver mode.
          **/
-        get isPairedDriver(): boolean
-        {
+        get isPairedDriver(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_BROADCAST) && !!(this.flags & DAL.JD_DEVICE_FLAGS_PAIR);
         }
 
@@ -282,8 +310,7 @@ namespace jacdac {
          *
          * @returns true if in SnifferDriver mode.
          **/
-        get isHostDriver(): boolean
-        {
+        get isHostDriver(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_LOCAL) && !(this.flags & DAL.JD_DEVICE_FLAGS_BROADCAST);
         }
 
@@ -294,8 +321,7 @@ namespace jacdac {
          *
          * @returns true if in BroadcastDriver mode.
          **/
-        get isBroadcastDriver(): boolean
-        {
+        get isBroadcastDriver(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_LOCAL) && !!(this.flags & DAL.JD_DEVICE_FLAGS_BROADCAST);
         }
 
@@ -306,8 +332,7 @@ namespace jacdac {
          *
          * @returns true if in SnifferDriver mode.
          **/
-        get isSnifferDriver(): boolean
-        {
+        get isSnifferDriver(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_REMOTE) && !!(this.flags & DAL.JD_DEVICE_FLAGS_BROADCAST);
         }
 
@@ -316,8 +341,7 @@ namespace jacdac {
          *
          * @returns true if paired
          **/
-        get isPaired(): boolean
-        {
+        get isPaired(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_PAIRED);
         }
 
@@ -326,8 +350,7 @@ namespace jacdac {
          *
          * @returns true if pairable
          **/
-        get isPairable(): boolean
-        {
+        get isPairable(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_PAIRABLE);
         }
 
@@ -336,8 +359,7 @@ namespace jacdac {
          *
          * @returns true if pairing
          **/
-        get isPairing(): boolean
-        {
+        get isPairing(): boolean {
             return !!(this.flags & DAL.JD_DEVICE_FLAGS_PAIRING);
         }
     }

--- a/libs/jacdac/jacdac.ts
+++ b/libs/jacdac/jacdac.ts
@@ -101,6 +101,14 @@ namespace jacdac {
             return false
         }
 
+        /**
+         * Called by the logic driver when a control packet is received
+         * @param pkt 
+         */
+        public handleControlPacket(pkt: Buffer): boolean {
+            return false;
+        }
+
         protected sendPacket(pkt: Buffer) {
             // this.log(`send pkt ${this.device.driverAddress}`)
             jacdac.sendPacket(pkt, this.device.driverAddress);
@@ -174,7 +182,8 @@ namespace jacdac {
 
         n.log(`add t${n.driverType} c${n.deviceClass}`)
         n.status = __internalAddDriver(n.driverType, n.deviceClass, 
-            [(p: Buffer) => n.handlePacket(p)],
+            [(p: Buffer) => n.handlePacket(p),
+             (p: Buffer) => n.handleControlPacket(p)],
             n.controlData
         );
     }

--- a/libs/jacdac/loggerdriver.ts
+++ b/libs/jacdac/loggerdriver.ts
@@ -9,11 +9,11 @@ namespace jacdac {
             _logBroadcastDriver = new LoggerBroadcastDriver();
     }
 
-    class LoggerBroadcastDriver extends JacDacDriver {
+    class LoggerBroadcastDriver extends Driver {
         public suppressForwading: boolean;
         constructor() {
-            super("log", DriverType.VirtualDriver, jacdac.LOGGER_DRIVER_CLASS, true); // TODO pickup type from DAL
-            // send to other devices
+            super("log", DriverType.VirtualDriver, jacdac.LOGGER_DRIVER_CLASS);
+            this.supressLog = true;
             this.suppressForwading = false;
             jacdac.addDriver(this);
             console.addListener((priority, text) => this.broadcastLog(priority, text));
@@ -51,7 +51,7 @@ namespace jacdac {
             _logListenerDriver = new LoggerListenDriver();
     }
 
-    class LoggerListenDriver extends JacDacDriver {
+    class LoggerListenDriver extends Driver {
         constructor() {
             super("log", DriverType.HostDriver, jacdac.LOGGER_DRIVER_CLASS); // TODO pickup type from DAL
             jacdac.addDriver(this);

--- a/libs/jacdac/messagebusdriver.ts
+++ b/libs/jacdac/messagebusdriver.ts
@@ -1,11 +1,9 @@
 namespace jacdac {
-    // move to codal
-    const JD_MESSAGE_BUS_ID = 2500;
 
     /**
      * A driver that listens for message bus events
      */
-    export class MessageBusDriver extends JacDacDriver {
+    export class MessageBusDriver extends Driver {
         suppressForwarding: boolean;
 
         constructor() {

--- a/libs/jacdac/pxt.json
+++ b/libs/jacdac/pxt.json
@@ -9,6 +9,7 @@
         "messagebusdriver.ts",
         "pindriver.ts",
         "sensordriver.ts",
+        "batterydriver.ts",
         "ns.ts",
         "shims.d.ts"
     ],

--- a/libs/jacdac/sensordriver.ts
+++ b/libs/jacdac/sensordriver.ts
@@ -27,7 +27,7 @@ namespace jacdac {
     /**
      * JacDac service running on sensor and streaming data out
      */
-    export class StreamingHostDriver extends JacDacDriver {
+    export class StreamingHostDriver extends Driver {
         private stateSerializer: () => Buffer;
         private streamingState: StreamingState;
         private _sendTime: number;
@@ -121,7 +121,7 @@ namespace jacdac {
         }
     }
 
-    export class StreamingVirtualDriver extends JacDacDriver {
+    export class StreamingVirtualDriver extends Driver {
         // virtual mode only
         protected _localTime: number;
         protected _lastHostTime: number;

--- a/libs/jacdac/sensordriver.ts
+++ b/libs/jacdac/sensordriver.ts
@@ -160,7 +160,7 @@ namespace jacdac {
                     return r;
                 case StreamingCommand.Event:
                     const value = packet.data.getNumber(NumberFormat.UInt16LE, 1);
-                    control.raiseEvent(this.status.id, value);
+                    control.raiseEvent(this.id, value);
                     return true;
                 default:
                     return this.handleCustomCommand(command, packet);

--- a/libs/jacdac/sim/jacdac.ts
+++ b/libs/jacdac/sim/jacdac.ts
@@ -24,15 +24,14 @@ namespace pxsim.jacdac {
         deviceClass: number,
         methods: ((p: pxsim.RefBuffer) => void)[],
         controlData: Buffer
-    ):
-        JacDacDriverStatus {
+    ): JacDacDriverStatus {
         // TODO keep track        
-        return new JacDacDriverStatus(driverType, deviceClass, methods);
+        return new JacDacDriverStatus(driverType, deviceClass, methods, controlData);
     }
 }
 
 class JacDacDriverStatus {
-    constructor(private driverType: number, private deviceClass: number, private methods: ((p: pxsim.RefBuffer) => void)[]) {
+    constructor(private driverType: number, private deviceClass: number, private methods: ((p: pxsim.RefBuffer) => void)[], private controlData: Buffer) {
         this.id = pxsim.control.allocateNotifyEvent();
     }
 

--- a/libs/jacdac/sim/jacdac.ts
+++ b/libs/jacdac/sim/jacdac.ts
@@ -22,7 +22,9 @@ namespace pxsim.jacdac {
     export function __internalAddDriver(
         driverType: number,
         deviceClass: number,
-        methods: ((p: pxsim.RefBuffer) => void)[]):
+        methods: ((p: pxsim.RefBuffer) => void)[],
+        controlData: Buffer
+    ):
         JacDacDriverStatus {
         // TODO keep track        
         return new JacDacDriverStatus(driverType, deviceClass, methods);

--- a/libs/jacdac/sim/jacdac.ts
+++ b/libs/jacdac/sim/jacdac.ts
@@ -22,8 +22,8 @@ namespace pxsim.jacdac {
     export function __internalAddDriver(
         driverType: number,
         deviceClass: number,
-        methods: ((p: pxsim.RefBuffer) => void)[],
-        controlData: Buffer
+        methods: ((p: pxsim.RefBuffer) => boolean)[],
+        controlData: pxsim.RefBuffer
     ): JacDacDriverStatus {
         // TODO keep track        
         return new JacDacDriverStatus(driverType, deviceClass, methods, controlData);
@@ -31,7 +31,7 @@ namespace pxsim.jacdac {
 }
 
 class JacDacDriverStatus {
-    constructor(private driverType: number, private deviceClass: number, private methods: ((p: pxsim.RefBuffer) => void)[], private controlData: Buffer) {
+    constructor(private driverType: number, private deviceClass: number, private methods: ((p: pxsim.RefBuffer) => boolean)[], private controlData: pxsim.RefBuffer) {
         this.id = pxsim.control.allocateNotifyEvent();
     }
 


### PR DESCRIPTION
Uses control packets to broadcast a battery level byte. Also brings back handleControlPacket, and basic support for fillControlpacket.