### PR TITLE
Enable i2c for samd packages

### DIFF
--- a/libs/cable/cable.ts
+++ b/libs/cable/cable.ts
@@ -33,7 +33,7 @@ namespace network {
     export function cableSendNumbers(values: number[]) {
         let buf = msgpack.packNumberArray(values);
         if (buf.length % 2) {
-            const buf2 = pins.createBuffer(buf.length + 1);
+            const buf2 = control.createBuffer(buf.length + 1);
             buf2.write(0, buf);
             buf2[buf2.length - 1] = 0xc1;
             buf = buf2;

--- a/libs/core---samd51/i2c.ts
+++ b/libs/core---samd51/i2c.ts
@@ -1,1 +1,0 @@
-// TS does not like empty files

--- a/libs/core---samd51/platform.h
+++ b/libs/core---samd51/platform.h
@@ -6,7 +6,7 @@
 #include "ZPin.h"
 #include "SAMDTimer.h"
 #include "ZSPI.h"
-//#include "ZI2C.h"
+#include "ZI2C.h"
 #include "ZSingleWireSerial.h"
 
 // cap touch not available on 51 yet

--- a/libs/core---samd51/shims.d.ts
+++ b/libs/core---samd51/shims.d.ts
@@ -17,6 +17,20 @@ declare namespace pins {
     //% weight=19 shim=pins::pulseDuration
     function pulseDuration(): int32;
 }
+declare namespace pins {
+
+    /**
+     * Read `size` bytes from a 7-bit I2C `address`.
+     */
+    //% repeat.defl=0 shim=pins::i2cReadBuffer
+    function i2cReadBuffer(address: int32, size: int32, repeat?: boolean): Buffer;
+
+    /**
+     * Write bytes to a 7-bit I2C `address`.
+     */
+    //% repeat.defl=0 shim=pins::i2cWriteBuffer
+    function i2cWriteBuffer(address: int32, buf: Buffer, repeat?: boolean): int32;
+}
 
 
 declare interface AnalogInPin {

--- a/libs/core/i2c.cpp
+++ b/libs/core/i2c.cpp
@@ -2,7 +2,7 @@
 #include "ErrorNo.h"
 
 namespace pins {
-    static codal::I2C *i2c;
+    static CODAL_I2C *i2c;
 
     static void initI2C() {
       if (NULL == i2c) {

--- a/libs/core/i2c.cpp
+++ b/libs/core/i2c.cpp
@@ -17,7 +17,7 @@ namespace pins {
     Buffer i2cReadBuffer(int address, int size, bool repeat = false)
     {
       initI2C();
-      Buffer buf = createBuffer(size);
+      Buffer buf = mkBuffer(NULL, size);
       int status = i2c->read(address << 1, buf->data, size, repeat);
       if (status != ErrorCode::DEVICE_OK) {
         decrRC(buf);

--- a/libs/core/i2c.ts
+++ b/libs/core/i2c.ts
@@ -5,7 +5,7 @@ namespace pins {
     //% help=pins/i2c-read-number weight=5 group="i2c" inlineInputMode="external"
     //% blockId=pins_i2c_readnumber block="i2c read number at address %address|of format %format|repeated %repeated"
     export function i2cReadNumber(address: number, format: NumberFormat, repeated?: boolean): number {
-        let buf = pins.i2cReadBuffer(address, pins.sizeOf(format), repeated)
+        const buf = pins.i2cReadBuffer(address, pins.sizeOf(format), repeated)
         return buf.getNumber(format, 0)
     }
 
@@ -15,7 +15,7 @@ namespace pins {
     //% help=pins/i2c-write-number weight=4 group="i2c"
     //% blockId=i2c_writenumber block="i2c write number|at address %address|with value %value|of format %format|repeated %repeated"
     export function i2cWriteNumber(address: number, value: number, format: NumberFormat, repeated?: boolean): void {
-        let buf = createBuffer(pins.sizeOf(format))
+        const buf = control.createBuffer(pins.sizeOf(format))
         buf.setNumber(format, 0, value)
         pins.i2cWriteBuffer(address, buf, repeated)
     }

--- a/libs/infrared/ir.ts
+++ b/libs/infrared/ir.ts
@@ -33,7 +33,7 @@ namespace network {
     export function infraredSendNumbers(values: number[]) {
         let buf = msgpack.packNumberArray(values);
         if (buf.length % 2) {
-            const buf2 = pins.createBuffer(buf.length + 1);
+            const buf2 = control.createBuffer(buf.length + 1);
             buf2.write(0, buf);
             buf2[buf2.length - 1] = 0xc1;
             buf = buf2;

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -134,7 +134,7 @@ namespace light {
             if (this._parent) return this._parent.brightnessBuf;
             if (!this._brightnessBuf) {
                 const b = this.buf; // force allocate buffer
-                this._brightnessBuf = pins.createBuffer(this._length);
+                this._brightnessBuf = control.createBuffer(this._length);
                 this._brightnessBuf.fill(this._brightness, 0, this._brightnessBuf.length);
             }
             return this._brightnessBuf;
@@ -313,7 +313,7 @@ namespace light {
                 // bb may be undefined if the brightness
                 // is uniform over the strip and has not been allocated
                 const _bb = this._brightnessBuf;
-                if (!this._sendBuf) this._sendBuf = pins.createBuffer(b.length);
+                if (!this._sendBuf) this._sendBuf = control.createBuffer(b.length);
                 const sb = this._sendBuf;
                 const stride = this.stride();
                 // apply brightness
@@ -742,7 +742,7 @@ namespace light {
 
         private reallocateBuffer(): void {
             const stride = this.stride();
-            this._buf = pins.createBuffer(this._length * stride);
+            this._buf = control.createBuffer(this._length * stride);
             this._brightnessBuf = undefined;
             this._sendBuf = undefined;
         }

--- a/libs/pixel/pixel.ts
+++ b/libs/pixel/pixel.ts
@@ -49,7 +49,7 @@ namespace pixel {
         let green = unpackG(color);
         let blue = unpackB(color);
 
-        const buffer: Buffer = pins.createBuffer(3);
+        const buffer: Buffer = control.createBuffer(3);
         buffer[0] = green;
         buffer[1] = red;
         buffer[2] = blue;


### PR DESCRIPTION
- [x] enable i2c in codal-samd targets
- [x] move all ``pins.createBuffer`` usage to ``control.createBuffer``