### PR TITLE
Fixed the docs for lifespan to reflect that it is measured in ms

### DIFF
--- a/libs/game/docs/reference/sprites/sprite/lifespan.md
+++ b/libs/game/docs/reference/sprites/sprite/lifespan.md
@@ -1,6 +1,6 @@
 # lifespan (property)
 
-Get or set the lifespan of sprite in update units.
+Get or set the lifespan of sprite in milliseconds.
 
 ## Get
 
@@ -18,7 +18,7 @@ let lifetime = mySprite.lifespan
 
 ### Returns
 
-* a [number](/types/number) that is the current lifespan of the sprite.
+* a [number](/types/number) that is the current lifespan of the sprite in milliseconds.
 
 ## Set
 
@@ -38,15 +38,13 @@ mySprite.lifespan = 0
 
 ## Sprite lifespan
 
-Sprites that aren't set to auto destroy will remain in the game until they are destroyed by calling their **destroy** function or until their lifespan expires. You must set the lifespan to give a sprite a limited amount of time live. You set the lifespan of sprite to make it leave the game after some amount of time in update units.
-
-The game has it's own internal update interval similar to your program's **onUpdate** function. During this interval the lifespan of the sprite, if it was set, will decrease by `1` unit. When the lifespan becomes `0`, the sprite is destroyed.
+Sprites that aren't set to auto destroy will remain in the game until they are destroyed by calling their **destroy** function or until their lifespan expires. You must set the lifespan to give a sprite a limited amount of time live. You set the lifespan of sprite to make it leave the game after some amount of time.
 
 The lifespan of a sprite is infinite when it's created and stays that way until you actually set it to a number. Once you set it, the lifespan begins to count down to `0`. You can reset the lifespan value to keep a sprite alive longer as a bonus to your player.
 
 ## Example #example
 
-Make a ``Player`` sprite and set its ``lifespan`` to `100` units.
+Make a ``Player`` sprite and set its ``lifespan`` to `1000` milliseconds (or `1` second).
 
 ```blocks
 enum SpriteKind {
@@ -57,7 +55,7 @@ let orangeBlock = image.create(16, 16)
 orangeBlock.fill(4)
 orangeBlock.drawRect(0, 0, 16, 16, 1)
 let player = sprites.create(orangeBlock, SpriteKind.Player)
-player.lifespan = 100
+player.lifespan = 1000
 ```
 
 ## See also #seealso

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -84,7 +84,7 @@ class Sprite implements SpriteLike {
     _action: number; //Used with animation library
 
     /**
-     * Time to live in game ticks. The lifespan decreases by 1 on each game update
+     * Time to live in milliseconds. The lifespan decreases by 1 on each millisecond
      * and the sprite gets destroyed when it reaches 0.
      */
     //% group="Properties" blockSetVariable="mySprite"


### PR DESCRIPTION
In Microsoft/pxt-common-packages#384, sprite lifespan was changed to measure in milliseconds. This updates the docs for lifespan to reflect this change.