### PR TITLE
enable deviceusb for storage project

### DIFF
--- a/libs/core---samd51/platform.h
+++ b/libs/core---samd51/platform.h
@@ -8,6 +8,7 @@
 #include "ZSPI.h"
 #include "ZI2C.h"
 #include "ZSingleWireSerial.h"
+#include "SAMDSerial.h"
 
 // cap touch not available on 51 yet
 #ifdef SAMD21
@@ -35,6 +36,7 @@ typedef int PinName;
 #define CODAL_SPI ZSPI
 #define CODAL_I2C ZI2C
 #define CODAL_JACDAC_WIRE_SERIAL codal::ZSingleWireSerial
+#define CODAL_SERIAL codal::SAMDSerial
 
 #define PXT_BOOTLOADER_CFG_ADDR (0x4000 - 4*4)
 #define PXT_BOOTLOADER_CFG_MAGIC 0xbe3fd5ce

--- a/libs/serial/serial.cpp
+++ b/libs/serial/serial.cpp
@@ -34,7 +34,7 @@ namespace pxt {
       WSerial()
         : serial(*LOOKUP_PIN(TX), *LOOKUP_PIN(RX))
         {
-          serial.baud((int)BaudRate::BaudRate115200);
+          serial.setBaud((int)BaudRate::BaudRate115200);
         }
   };
 
@@ -98,7 +98,7 @@ namespace serial {
     */
     //% help=serial/set-baud-rate
     void setBaudRate(BaudRate rate) {
-      getWSerial()->serial.baud((int)rate);
+      getWSerial()->serial.setBaud((int)rate);
     }
 
     /**
@@ -116,7 +116,9 @@ namespace serial {
     //% rx.fieldOptions.tooltips="false"
     //% blockGap=8 inlineInputMode=inline
     void redirect(DigitalInOutPin tx, DigitalInOutPin rx, BaudRate rate) {
-      getWSerial()->serial.redirect( (PinName)tx->name, (PinName)rx->name);
+      if (NULL == tx || NULL == rx)
+        return;
+      getWSerial()->serial.redirect(*tx, *rx);
       setBaudRate(rate);
     }
 }

--- a/libs/storage/GhostSNORFS.cpp
+++ b/libs/storage/GhostSNORFS.cpp
@@ -1,7 +1,5 @@
 #include "GhostSNORFS.h"
 
-#if CONFIG_ENABLED(DEVICE_USB)
-
 #include "CodalCompat.h"
 #include "CodalDmesg.h"
 #include "CodalDevice.h"
@@ -64,4 +62,3 @@ void GhostSNORFS::addFiles()
 }
 
 }
-#endif

--- a/libs/storage/GhostSNORFS.h
+++ b/libs/storage/GhostSNORFS.h
@@ -4,8 +4,6 @@
 #include "GhostFAT.h"
 #include "SNORFS.h"
 
-#if CONFIG_ENABLED(DEVICE_USB)
-
 namespace codal
 {
     
@@ -28,4 +26,3 @@ public:
 
 #endif
 
-#endif

--- a/libs/storage/pxt.json
+++ b/libs/storage/pxt.json
@@ -13,5 +13,10 @@
     "public": true,
     "dependencies": {
         "core": "file:../core"
+    },
+    "yotta": {
+        "config": {
+            "DEVICE_USB": 1
+        }
     }
 }

--- a/libs/storage/storage.cpp
+++ b/libs/storage/storage.cpp
@@ -1,9 +1,6 @@
 #include "pxt.h"
 #include "SPI.h"
 
-#if CONFIG_ENABLED(DEVICE_USB)
-
-#include "MbedSPI.h"
 #include "GhostSNORFS.h"
 #include "StandardSPIFlash.h"
 
@@ -203,4 +200,3 @@ Buffer readAsBuffer(String filename) {
 }
 
 } // namespace storage
-#endif


### PR DESCRIPTION
``strogae`` requires DEVICE_USB so adding it at the project level and removing devices. (Might make LEGO unhappy, we'll see).