### PR TITLE
Default to mySprite in createFromSprite

### DIFF
--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -74,7 +74,7 @@ namespace sprites {
      * The sprite auto-destroys when it leaves the screen. You can modify position after it's created.
      */
     //% group="Projectiles"
-    //% blockId=spritescreateprojectilefromsprite block="projectile %img=screen_image_picker from %mySprite=variables_get with vx %vx vy %vy"
+    //% blockId=spritescreateprojectilefromsprite block="projectile %img=screen_image_picker from %sprite=variables_get(mySprite) with vx %vx vy %vy"
     //% weight=99 help=sprites/create-projectile-from-sprite
     //% blockSetVariable=projectile
     //% inlineInputMode=inline


### PR DESCRIPTION
default for ``variables_get`` is ``item``, which is not used for sprites