### PR TITLE
Particles: export cached sin and cos functions

### DIFF
--- a/libs/particles/factories.ts
+++ b/libs/particles/factories.ts
@@ -11,13 +11,35 @@ namespace particles {
      */
     function initTrig() {
         if (!cachedSin) {
-            cachedSin = [];
-            cachedCos = [];
-            for (let i = 0; i < NUM_SLICES; i++) {
-                cachedSin.push(Fx8(Math.sin(i * angleSlice)));
-                cachedCos.push(Fx8(Math.cos(i * angleSlice)));
-            }
+            cachedSin = cacheSin(NUM_SLICES);
+            cachedCos = cacheCos(NUM_SLICES);
         }
+    }
+
+    /**
+     * @param slices number of cached sin values to make
+     * @returns array of cached sin values between 0 and 360 degrees
+     */
+    export function cacheSin(slices: number): Fx8[] {
+        let sin: Fx8[] = [];
+        let anglePerSlice = 2 * Math.PI / slices;
+        for (let i = 0; i < slices; i++) {
+            sin.push(Fx8(Math.sin(i * anglePerSlice)));
+        }
+        return sin;
+    }
+
+    /**
+     * @param slices number of cached cos values to make
+     * @returns array of cached cos values between 0 and 360 degrees
+     */
+    export function cacheCos(slices: number): Fx8[] {
+        let cos: Fx8[] = [];
+        let anglePerSlice = 2 * Math.PI / slices;
+        for (let i = 0; i < slices; i++) {
+            cos.push(Fx8(Math.cos(i * anglePerSlice)));
+        }
+        return cos;
     }
 
     const ratio = Math.PI / 180;


### PR DESCRIPTION
It's very common to use these in particle effects, so avoid duplication.

(first commit is actual change, second one is just adding examples to tests)

Bonus: fire! and spiral

![2018-12-17 13 51 20](https://user-images.githubusercontent.com/5615930/50117864-f2e82100-0202-11e9-9f20-95163c1cf46c.gif)

![2018-12-17 13 58 48](https://user-images.githubusercontent.com/5615930/50118230-e9ab8400-0203-11e9-8e11-0d50331e3e36.gif)
