### PR TITLE
ParticleEffects fixed instance blocks

### DIFF
--- a/libs/game/mathUtil.ts
+++ b/libs/game/mathUtil.ts
@@ -60,7 +60,7 @@ namespace Math {
          * @returns a random value between min and max (inclusive). If min is greater than or equal to max, returns min.
          */
         randomRange(min: number, max: number): number {
-            return min + (max > min ? this.next() % (max - min) : 0);
+            return min + (max > min ? this.next() % (max - min + 1) : 0);
         }
 
         /**

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -24,11 +24,11 @@ namespace tiles {
         }
 
         get x(): number {
-            return this._col << 4;
+            return (this._col << 4) + 8;
         }
 
         get y(): number {
-            return this._row << 4;
+            return (this._row << 4) + 8;
         }
 
         get tileSet(): number {

--- a/libs/particles/effects.ts
+++ b/libs/particles/effects.ts
@@ -80,4 +80,22 @@ namespace particles {
         src.setAcceleration(0, -20)
         return src;
     });
+
+    //% fixedInstance whenUsed block="warm radial"
+    export const warmRadial = createEffect(function () { return new RadialFactory(0, 30, 10) });
+
+    //% fixedInstance whenUsed block="cool radial"
+    export const coolRadial = createEffect(function () { return new RadialFactory(0, 30, 10, [0x6, 0x7, 0x8, 0x9, 0xA]) });
+
+    //% fixedInstance whenUsed block="glow ring"
+    export const glowRing = createEffect(function () {
+        class RingFactory extends RadialFactory {
+            createParticle(anchor: particles.ParticleAnchor) {
+                const p = super.createParticle(anchor);
+                p.lifespan = this.galois.randomRange(200, 350);
+                return p;
+            }
+        }
+        return new RingFactory(30, 40, 10, [0x4, 0x4, 0x5]);
+    });
 }

--- a/libs/particles/effects.ts
+++ b/libs/particles/effects.ts
@@ -73,6 +73,39 @@ namespace particles {
         return factory;
     });
 
+    //% fixedInstance whenUsed block="hearts"
+    export const hearts = createEffect(function () {
+        return new ShapeFactory(16, 16, img`
+            . F . F .
+            F . F . F
+            F . . . F
+            . F . F .
+            . . F . .
+        `);
+    });
+
+    //% fixedInstance whenUsed block="smiles"
+    export const smiles = createEffect(function () {
+        return new ShapeFactory(16, 16, img`
+            . f . f . 
+            . f . f . 
+            . . . . . 
+            f . . . f 
+            . f f f . 
+        `);
+    });
+
+    //% fixedInstance whenUsed block="rings"
+    export const rings = createEffect(function () {
+        return new ShapeFactory(16, 16, img`
+            . F F F . 
+            F . . . F 
+            F . . . F 
+            f . . . f 
+            . f f f . 
+        `);
+    });
+
     //% fixedInstance whenUsed block="fire"
     export const fireEffect = new ParticleEffect(function (anchor: ParticleAnchor, particlesPerSecond: number) {
         const factory = new FireFactory(5);
@@ -87,8 +120,8 @@ namespace particles {
     //% fixedInstance whenUsed block="cool radial"
     export const coolRadial = createEffect(function () { return new RadialFactory(0, 30, 10, [0x6, 0x7, 0x8, 0x9, 0xA]) });
 
-    //% fixedInstance whenUsed block="glow ring"
-    export const glowRing = createEffect(function () {
+    //% fixedInstance whenUsed block="halo"
+    export const halo = createEffect(function () {
         class RingFactory extends RadialFactory {
             createParticle(anchor: particles.ParticleAnchor) {
                 const p = super.createParticle(anchor);

--- a/libs/particles/effects.ts
+++ b/libs/particles/effects.ts
@@ -46,7 +46,7 @@ namespace particles {
             galois: Math.FastRandom;
     
             constructor() {
-                super(40, 180, 90)
+                super(40, 180, 90);
                 this.galois = new Math.FastRandom(1234);
             }
     
@@ -57,11 +57,13 @@ namespace particles {
                 return p;
             }
     
-            drawParticle(p: particles.Particle, x: Fx8, y: Fx8) { screen.setPixel(Fx.toInt(x), Fx.toInt(y), p.data); }
+            drawParticle(p: particles.Particle, x: Fx8, y: Fx8) {
+                screen.setPixel(Fx.toInt(x), Fx.toInt(y), p.data);
+            }
         }
 
         const factory = new FountainFactory();
-        const source = new ParticleSource(anchor, particlesPerSecond, factory) 
+        const source = new ParticleSource(anchor, particlesPerSecond, factory);
         source.setAcceleration(0, 40);
         return source;
     });
@@ -110,7 +112,7 @@ namespace particles {
     export const fireEffect = new ParticleEffect(function (anchor: ParticleAnchor, particlesPerSecond: number) {
         const factory = new FireFactory(5);
         const src = new FireSource(anchor, particlesPerSecond, factory);
-        src.setAcceleration(0, -20)
+        src.setAcceleration(0, -20);
         return src;
     });
 

--- a/libs/particles/effects.ts
+++ b/libs/particles/effects.ts
@@ -1,0 +1,83 @@
+namespace particles {
+    //% fixedInstances
+    export class ParticleEffect {
+        private sourceFactory: (anchor: ParticleAnchor, pps: number) => ParticleSource;
+
+        constructor(sourceFactory: (anchor: ParticleAnchor, particlesPerSecond: number) => ParticleSource) {
+            this.sourceFactory = sourceFactory;
+        }
+
+        /**
+         * Attaches a new particle animation to the sprite or anchor
+         * @param anchor 
+         * @param particlesPerSecond 
+         */
+        //% blockId=particlesstartanimation block="start %effect effect on %anchor=variables_get(mySprite) at rate %particlesPerSecond p/s"
+        //% particlesPerSecond.defl=20
+        //% particlesPerSecond.min=1 particlePerSeconds.max=100
+        //% group="Effects"
+        start(anchor: ParticleAnchor, particlesPerSecond: number): void {
+            if (!this.sourceFactory) return;
+            this.sourceFactory(anchor, particlesPerSecond);
+        }
+    }
+
+    function createEffect(factoryFactory: () => ParticleFactory): ParticleEffect {
+        const factory = factoryFactory();
+        if (!factory) return undefined;
+        return new ParticleEffect((anchor: ParticleAnchor, pps: number) => new ParticleSource(anchor, pps, factory));
+    }
+
+    //% whenUsed
+    export const defaultFactory = new SprayFactory(20, 0, 60);
+
+    //% fixedInstance whenUsed block="spray"
+    export const sprayEffect = createEffect(function () { return new SprayFactory(100, 0, 120) });
+
+    //% fixedInstance whenUsed block="trail"
+    export const trailEffect = new ParticleEffect(function (anchor: ParticleAnchor, particlesPerSecond: number) {
+        const factory = new TrailFactory(anchor, 250, 1000);
+        return new ParticleSource(anchor, particlesPerSecond, factory);
+    });
+
+    //% fixedInstance whenUsed block="fountain"
+    export const fountainEffect = new ParticleEffect(function (anchor: ParticleAnchor, particlesPerSecond: number) {
+        class FountainFactory extends particles.SprayFactory {
+            galois: Math.FastRandom;
+    
+            constructor() {
+                super(40, 180, 90)
+                this.galois = new Math.FastRandom(1234);
+            }
+    
+            createParticle(anchor: particles.ParticleAnchor) {
+                const p = super.createParticle(anchor);
+                p.data = this.galois.randomBool() ? 8 : 9;
+                p.lifespan = 1500;
+                return p;
+            }
+    
+            drawParticle(p: particles.Particle, x: Fx8, y: Fx8) { screen.setPixel(Fx.toInt(x), Fx.toInt(y), p.data); }
+        }
+
+        const factory = new FountainFactory();
+        const source = new ParticleSource(anchor, particlesPerSecond, factory) 
+        source.setAcceleration(0, 40);
+        return source;
+    });
+
+    //% fixedInstance whenUsed block="confetti"
+    export const confettiEffect = createEffect(function () {
+        const factory = new ConfettiFactory(16, 16);
+        factory.setSpeed(30);
+        return factory;
+    });
+
+    //% fixedInstance whenUsed block="fire"
+    export const fireEffect = new ParticleEffect(function (anchor: ParticleAnchor, particlesPerSecond: number) {
+        const factory = new FireFactory(5);
+        const src = new FireSource(anchor, particlesPerSecond, factory);
+        src.setAcceleration(0, -20)
+        return src;
+    });
+}

--- a/libs/particles/factories.ts
+++ b/libs/particles/factories.ts
@@ -219,7 +219,7 @@ namespace particles {
             const pImage = this.galois.pickRandom(this.sources).clone();
             pImage.replace(0xF, p.data);
 
-            screen.drawImage(pImage,
+            screen.drawTransparentImage(pImage,
                 Fx.toInt(Fx.sub(x, this.ox)),
                 Fx.toInt(Fx.sub(y, this.oy))
             );

--- a/libs/particles/factories.ts
+++ b/libs/particles/factories.ts
@@ -191,7 +191,10 @@ namespace particles {
     }
 
     /**
-     * A factory for creating particles with the provided shapes fall down the screen
+     * A factory for creating particles with the provided shapes fall down the screen.
+     * 
+     * Any pixels assigned to 0xF (black) in the provided shape will be replaced with a
+     * random color for each particle.
      */
     export class ShapeFactory extends AreaFactory {
         protected sources: Image[];
@@ -208,7 +211,7 @@ namespace particles {
         }
 
         /**
-         * Add another possible shape for a particle to display
+         * Add another possible shape for a particle to display as
          * @param shape 
          */
         addShape(shape: Image) {
@@ -256,7 +259,7 @@ namespace particles {
                     F F
                     . F
             `];
-            super(xRange, yRange, confetti[0])
+            super(xRange, yRange, confetti[0]);
             for (let i = 1; i < confetti.length; i++) {
                 this.addShape(confetti[i]);
             }
@@ -286,14 +289,14 @@ namespace particles {
             const p = super.createParticle(anchor);
             p.data = this.galois.randomBool() ?
                 2 : this.galois.randomBool() ?
-                    4 : 5 // 50% 2, otherwise 50% 4 or 5
+                    4 : 5;
     
             const i = this.galois.randomRange(0, cachedCos.length);
             const r = this.galois.randomRange(this.minRadius, this.maxRadius);
             p._x = Fx.iadd(anchor.x, Fx.mul(Fx8(r), cachedCos[i]));
             p._y = Fx.iadd(anchor.y, Fx.mul(Fx8(r), cachedSin[i]));
             p.vy = Fx8(Math.randomRange(0, 10));
-            p.vx = Fx8(Math.randomRange(-5, 5))
+            p.vx = Fx8(Math.randomRange(-5, 5));
             p.lifespan = 1500;
     
             return p;

--- a/libs/particles/factories.ts
+++ b/libs/particles/factories.ts
@@ -303,4 +303,61 @@ namespace particles {
             screen.setPixel(Fx.toInt(p._x), Fx.toInt(p._y), p.data);
         }
     }
+
+    export class RadialFactory extends particles.ParticleFactory {
+        protected r: Fx8;
+        protected speed: Fx8;
+        protected t: number;
+        protected spread: number;
+        protected galois: Math.FastRandom;
+        protected colors: number[];
+
+        constructor(radius: number, speed: number, spread: number, colors?: number[]) {
+            super();
+            initTrig();
+
+            if (colors && colors.length != 0)
+                this.colors = colors;
+            else
+                this.colors = [0x2, 0x3, 0x4, 0x5];
+
+            this.setRadius(radius)
+            this.speed = Fx8(-speed);
+            this.spread = spread;
+            this.t = 0;
+            this.galois = new Math.FastRandom();
+        }
+
+        createParticle(anchor: particles.ParticleAnchor) {
+            const p = super.createParticle(anchor);
+            const time = ++this.t % cachedCos.length;
+            const offsetTime = (time + this.galois.randomRange(0, this.spread)) % cachedCos.length;
+
+            p._x = Fx.iadd(anchor.x, Fx.mul(this.r, cachedCos[time]));
+            p._y = Fx.iadd(anchor.y, Fx.mul(this.r, cachedSin[time]));
+            p.vx = Fx.mul(this.speed, Fx.neg(cachedSin[offsetTime]));
+            p.vy = Fx.mul(this.speed, cachedCos[offsetTime]);
+
+            p.lifespan = this.galois.randomRange(200, 1500);
+            p.data = this.galois.pickRandom(this.colors);
+
+            return p;
+        }
+
+        drawParticle(p: particles.Particle, x: Fx8, y: Fx8) {
+            screen.setPixel(Fx.toInt(p._x), Fx.toInt(p._y), p.data);
+        }
+
+        setRadius(r: number) {
+            this.r = Fx8(r >> 1);
+        }
+
+        setSpeed(s: number) {
+            this.speed = Fx8(-s);
+        }
+
+        setSpread(s: number) {
+            this.spread = s;
+        }
+    }
 }

--- a/libs/particles/particles.ts
+++ b/libs/particles/particles.ts
@@ -28,6 +28,8 @@ namespace particles {
     export interface ParticleAnchor {
         x: number;
         y: number;
+        width?: number;
+        height?: number;
     }
 
     /**
@@ -266,30 +268,23 @@ namespace particles {
         }
     }
 
-    //% fixedInstances
-    export class ParticleEffect {
-        private factoryFactory: () => ParticleFactory;
-        constructor(factoryFactory: () => ParticleFactory) {
-            this.factoryFactory = factoryFactory;
+    /**
+     * A source of particles, where 
+     */
+    export class FireSource extends particles.ParticleSource {
+        private galois: Math.FastRandom;
+        constructor(anchor: particles.ParticleAnchor, particlesPerSecond: number, factory?: particles.ParticleFactory) {
+            super(anchor, particlesPerSecond, factory);
+            this.galois = new Math.FastRandom();
+            this.z = 20;
         }
 
-        createFactory(): ParticleFactory {
-            return this.factoryFactory();
-        }
-
-        /**
-         * Attaches a new particle animation to the sprite or anchor
-         * @param anchor 
-         * @param particlesPerSecond 
-         */
-        //% blockId=particlesstartanimation block="start %effect effect on %anchor=variables_get(mySprite) at rate %particlesPerSecond p/s"
-        //% particlesPerSecond.defl=20
-        //% particlesPerSecond.min=1 particlePerSeconds.max=100
-        //% group="Effects"
-        start(anchor: ParticleAnchor, particlesPerSecond: number): void {
-            const factory = this.createFactory();
-            if (!factory) return;
-            const source = new ParticleSource(anchor, particlesPerSecond, factory);
+        updateParticle(p: particles.Particle, fixedDt: Fx8) {
+            super.updateParticle(p, fixedDt);
+            if (p.next && this.galois.percentChance(30)) {
+                p.vx = p.next.vx;
+                p.vy = p.next.vy;
+            }
         }
     }
 }

--- a/libs/particles/particles.ts
+++ b/libs/particles/particles.ts
@@ -1,7 +1,7 @@
 /**
  * Small particles
  */
-//% color="#03AA74" weight=78 icon="\uf021"
+//% color="#382561" weight=78 icon="\uf06d"
 //% groups='["Create", "Properties"]'
 namespace particles {
     const TIME_PRECISION = 10; // time goes down to down to the 1<<10 seconds

--- a/libs/particles/pxt.json
+++ b/libs/particles/pxt.json
@@ -3,7 +3,8 @@
     "description": "Particle rendering - beta",
     "files": [
         "particles.ts",
-        "factories.ts"
+        "factories.ts",
+        "effects.ts"
     ],
     "testFiles": [
         "test.ts"


### PR DESCRIPTION
(this is a bit long as I made a lot of gifs)

gifs of effects: all at 20 particles per second to start

spray
![2018-12-18 00 08 36](https://user-images.githubusercontent.com/5615930/50140406-7896bb80-0259-11e9-90a5-704364802595.gif)

trail
![2018-12-18 00 08 47](https://user-images.githubusercontent.com/5615930/50140405-7896bb80-0259-11e9-9770-ac4949d4a7ff.gif)

fountain
![2018-12-18 00 09 00](https://user-images.githubusercontent.com/5615930/50140403-7896bb80-0259-11e9-9932-95c4201aab64.gif)

confetti
![2018-12-18 00 09 13](https://user-images.githubusercontent.com/5615930/50140402-77fe2500-0259-11e9-985c-ec91694292e7.gif)

hearts
![2018-12-18 00 09 24](https://user-images.githubusercontent.com/5615930/50140401-77fe2500-0259-11e9-9840-fd2a85ee146a.gif)

smiles
![2018-12-18 00 09 34](https://user-images.githubusercontent.com/5615930/50140400-77fe2500-0259-11e9-8b19-751995e4d24a.gif)

rings
![2018-12-18 00 09 45](https://user-images.githubusercontent.com/5615930/50140399-77fe2500-0259-11e9-923a-b62388af403e.gif)

fire
![2018-12-18 00 09 55](https://user-images.githubusercontent.com/5615930/50140398-77fe2500-0259-11e9-9cee-1d52866e1735.gif)

warm radial
![2018-12-18 00 10 17](https://user-images.githubusercontent.com/5615930/50140397-77fe2500-0259-11e9-873c-f243bd6a3106.gif)

cool radial
![2018-12-18 00 10 29](https://user-images.githubusercontent.com/5615930/50140396-77fe2500-0259-11e9-99a6-48ada614abfc.gif)

halo (also shows at 1000pps, as it needs to be about >300 to look like I want it to :) )
![2018-12-18 00 10 41](https://user-images.githubusercontent.com/5615930/50140395-77658e80-0259-11e9-974b-c38ba81afaff.gif)

<img width="497" alt="screen shot 2018-12-18 at 12 22 48 am" src="https://user-images.githubusercontent.com/5615930/50140966-248cd680-025b-11e9-939f-bbedacee5830.png">

Some notes:

* changes icon to fontawesome fire, and a dark purple color
* fixed off by one bug in FastRandom (oops)
* using a tile as an anchor works fine, but you have to store it in a variable first and pass that to get the blocks to work without getTile bouncing off
* Tile.x and Tile.y now return center instead of top left corner; makes the particle effects center in the middle of the tile, and match sprites positioning


with tiles

![arcade-screenshot 2](https://user-images.githubusercontent.com/5615930/50141091-7170ad00-025b-11e9-8bd4-bd2fd5cfaa7f.png)

![2018-12-18 00 26 06](https://user-images.githubusercontent.com/5615930/50141201-bd235680-025b-11e9-97a2-8732fb686222.gif)

and 

![2018-12-18 00 27 14](https://user-images.githubusercontent.com/5615930/50141214-c7ddeb80-025b-11e9-808d-b80e200985fb.gif)
