### PR TITLE
Fixes issues with detecting if a sprite is colliding with a wall

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -78,11 +78,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     collisions() {
         control.enablePerfCounter("phys_collisions")
 
-        // 1: clear obstacles
-        for (let i = 0; i < this.sprites.length; ++i)
-            this.sprites[i].clearObstacles();
-
-        // 2: refresh non-ghost collision map
+        // 1: refresh non-ghost collision map
         const colliders = this.sprites.filter(sprite => !(sprite.flags & sprites.Flag.Ghost));
 
         if (colliders.length < 10) {
@@ -93,7 +89,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             this.map.update(colliders);
         }
 
-        // 3: go through sprite and handle collisions
+        // 2: go through sprite and handle collisions
         const scene = game.currentScene();
         const tm = scene.tileMap;
 
@@ -165,6 +161,8 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     }
 
     public moveSprite(s: Sprite, tm: tiles.TileMap, dx: Fx8, dy: Fx8) {
+        s.clearObstacles();
+
         if (dx === Fx.zeroFx8 && dy === Fx.zeroFx8) {
             s._lastX = s._x;
             s._lastY = s._y;


### PR DESCRIPTION
Moved obstacle clearing to moveSprite where obstacles are set

This fixes Microsoft/pxt-arcade#375

Previously, the obstacles impacting a sprite where getting registered in [moveSprite during the application of physics on frame 10](https://github.com/Microsoft/pxt-common-packages/blob/108dff9777462c7cb22fceec8406b054e6241e79/libs/game/physics.ts#L167) and [then cleared when collisions were applied on frame 30](https://github.com/Microsoft/pxt-common-packages/blob/108dff9777462c7cb22fceec8406b054e6241e79/libs/game/physics.ts#L83).

This meant that the obstacles where only set between those frames and really could only be used inside on update loops.

This is just a quick fix so that there are not bugs in the lessons (e.g. [Barrel Dodger](https://arcade.makecode.com/lessons/barrel-dodger#step-9)). Ideally, in my opinion, obstacles should be cleared and registered during the collisions phase, but that would take a lot more work.