### PR TITLE
add destroy with effect method for particles

### DIFF
--- a/libs/particles/effects.ts
+++ b/libs/particles/effects.ts
@@ -21,12 +21,29 @@ namespace particles {
             if (!this.sourceFactory) return;
             this.sourceFactory(anchor, particlesPerSecond);
         }
+
+        /**
+         * Destroy the provided sprite with
+         * @param sprite
+         * @param particlesPerSecond
+         * @param lifespan how long the sprite will remain on the screen
+         */
+        //% blockId=particlesDestroySpriteWithAnimation block="use %effect effect to destroy %anchor=variables_get(mySprite) at rate %particlesPerSecond p/s || with lifespan %lifespan"
+        //% particlesPerSecond.defl=20
+        //% particlesPerSecond.min=1 particlePerSeconds.max=100
+        //% lifespan.defl=1500
+        //% group="Effects"
+        destroy(anchor: Sprite, particlesPerSecond: number, lifespan: number = 1500) {
+            anchor.setFlag(SpriteFlag.Ghost, true);
+            this.sourceFactory(anchor, particlesPerSecond);
+            anchor.lifespan = lifespan;
+        }
     }
 
     /**
      * Anchor used for effects that occur across the screen.
      */
-    class FullScreenAnchor implements ParticleAnchor {
+    class SceneAnchor implements ParticleAnchor {
         private camera: scene.Camera;
         flags: number; //TODO: remove pending fix for https://github.com/Microsoft/pxt-arcade/issues/504
 
@@ -71,7 +88,7 @@ namespace particles {
         startSceneEffect(particlesPerSecond: number): void {
             if (!this.sourceFactory) return;
             this.endSceneEffect();
-            this.source = this.sourceFactory(new FullScreenAnchor(), particlesPerSecond);
+            this.source = this.sourceFactory(new SceneAnchor(), particlesPerSecond);
         }
 
         /**
@@ -240,7 +257,7 @@ namespace particles {
 
     //% fixedInstance whenUsed block="disintegrate"
     export const disintegrate = new ParticleEffect(function (anchor: ParticleAnchor, particlesPerSecond: number) {
-        const factory = new AshFactory(anchor, true);
+        const factory = new AshFactory(anchor, true, 30);
         factory.minLifespan = 200;
         factory.maxLifespan = 500;
         const src = new ParticleSource(anchor, particlesPerSecond, factory);

--- a/libs/particles/particles.ts
+++ b/libs/particles/particles.ts
@@ -132,7 +132,7 @@ namespace particles {
                     this.destroy();
                 }
             } else if (this.anchor && this.anchor.flags !== undefined && (this.anchor.flags & sprites.Flag.Destroyed)) {
-                this.lifespan = 1000;
+                this.lifespan = 750;
             }
 
             while (this.timer < 0 && this.enabled) {


### PR DESCRIPTION
method to destroy sprite with an effect

Could change wording to something like ``destroy %mySprite with %effect effect at rate %pps ...``, but that would need to be as a separate function which seems like it would be confusing in typescript

![arcade-screenshot 10](https://user-images.githubusercontent.com/5615930/50657217-b595ca00-0f4a-11e9-9c71-5111422ce181.png)

cycling through a handful of the effects (I left the default rate at 20 p/s to match others for now, but this is shown with 60 p/s)

![2019-01-03 11 10 38](https://user-images.githubusercontent.com/5615930/50656635-bc234200-0f48-11e9-880a-b91e3fba07a1.gif)

@pelikhan ~