### PR TITLE
Removing the ability to interrupt playTone in mixer

### DIFF
--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -60,34 +60,9 @@ namespace music {
     //% weight=76 blockGap=8
     //% group="Tone"
     export function playTone(frequency: number, ms: number): void {
-        if (playToneFreq == null) {
-            let buf = control.createBuffer(10 + 1)
-            control.runInParallel(() => {
-                while (true) {
-                    if (playToneFreq && playToneEnd) {
-                        if (control.millis() > playToneEnd) {
-                            playToneFreq = 0
-                            playToneSeq++
-                        }
-                    }
-                    if (playToneFreq == 0) {
-                        pause(3)
-                    } else {
-                        addNote(buf, 0, 60, 255, 255, 1, playToneFreq, globalVolume)
-                        playInstructions(buf)
-                    }
-                }
-            })
-        }
-        playToneFreq = frequency
-        if (ms) {
-            let seq = ++playToneSeq
-            playToneEnd = control.millis() + ms
-            while (seq == playToneSeq)
-                pause(3)
-        } else {
-            playToneEnd = 0
-        }
+        let buf = control.createBuffer(10 + 1)
+        addNote(buf, 0, ms, 255, 255, 1, frequency, globalVolume)
+        playInstructions(buf)
     }
 
 
@@ -199,7 +174,7 @@ namespace music {
         play(volume: number) {
             if (!this.melody)
                 return
-            
+
             volume = Math.clamp(0, 255, (volume * globalVolume) >> 8)
 
             let notes = this.melody._text


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/489

In our old editors (i.e. micro:bit), this code:

```typescript
control.runInParallel(function () {
    music.playTone(Note.C, 1000)
})
pause(500)
music.playTone(Note.C5, 1000)
``` 

Would result in `C` playing for 500 ms and `C5` playing for 1000 ms (the second `playTone` interrupts the first).

With this change, both notes play for 1000 ms (with 500 ms of overlap).

This is a break from our old behavior, but I talked it over with @Jaqster and we think that this is a better model anyhow. Plus, it lets you do chords!