### PR TITLE
Reworked tile map collisions for various bug fixes and performance

### DIFF
--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -19,8 +19,8 @@ namespace scene {
 
             // if sprite, follow sprite
             if (this.sprite) {
-                this.offsetX = Fx.toIntShifted(this.sprite._x, 0) + (this.sprite.width >> 1) - (screen.width >> 1);
-                this.offsetY = Fx.toIntShifted(this.sprite._y, 0) + (this.sprite.height >> 1) - (screen.height >> 1);
+                this.offsetX = this.sprite.x - (screen.width >> 1);
+                this.offsetY = this.sprite.y - (screen.height >> 1);
             }
 
             // don't escape tile map

--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -19,8 +19,8 @@ namespace scene {
 
             // if sprite, follow sprite
             if (this.sprite) {
-                this.offsetX = this.sprite.x - (screen.width >> 1);
-                this.offsetY = this.sprite.y - (screen.height >> 1);
+                this.offsetX = Fx.toIntShifted(this.sprite._x, 0) + (this.sprite.width >> 1) - (screen.width >> 1);
+                this.offsetY = Fx.toIntShifted(this.sprite._y, 0) + (this.sprite.height >> 1) - (screen.height >> 1);
             }
 
             // don't escape tile map

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -32,7 +32,7 @@ namespace game {
     }
 
 
-    export function calculateHitBoxes(s: Sprite): Hitbox[] {
+    export function calculateHitBox(s: Sprite): Hitbox {
         const i = s.image;
         let minX = i.width;
         let minY = i.height;
@@ -52,31 +52,7 @@ namespace game {
 
         const width = maxX - minX + 1;
         const height = maxY - minY + 1;
-        if (width <= 0 || height <= 0) {
-            return [];
-        }
-        else if (width < 16 && height < 16) {
-            return [new Hitbox(s, width, height, minX, minY)]
-        }
-
-        const rows = Math.idiv(height, 15) + 1;
-        const columns = Math.idiv(width, 15) + 1;
-        const boxes: Hitbox[] = [];
-        for (let c = 0; c < columns; c++) {
-            let boxWidth = 15;
-            if (c === columns - 1) {
-                boxWidth = width % 15;
-            }
-
-            for (let r = 0; r < rows; r++) {
-                let boxHeight = 15;
-                if (r === rows - 1) {
-                    boxHeight = height % 15;
-                }
-                if (boxWidth > 0 && boxHeight > 0)
-                    boxes.push(new Hitbox(s, boxWidth, boxHeight, minX + c * 15, minY + r * 15));
-            }
-        }
-        return boxes;
+        
+        return new Hitbox(s, width, height, minX, minY);
     }
 }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -138,7 +138,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
-                                sprite.vx *= -1;
+                                sprite._vx = Fx.neg(sprite._vx);
                             }
                             sprite._x = right ? Fx.sub(Fx8(x0 << 4), Fx8(sprite.width)) : Fx8((x0 + 1) << 4);
                             sprite.registerObstacle(right ? CollisionDirection.Right : CollisionDirection.Left, tm.getObstacle(x0, y0));
@@ -155,7 +155,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
-                                sprite.vy *= -1;
+                                sprite._vy = Fx.neg(sprite._vy);
                             }
                             sprite._y = down ? Fx.sub(Fx8(y0 << 4), Fx8(sprite.height)) : Fx8((y0 + 1) << 4);
                             sprite.registerObstacle(down ? CollisionDirection.Bottom : CollisionDirection.Top, tm.getObstacle(x0, y0));

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -133,14 +133,14 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 if (xDiff !== Fx.zeroFx8) {
                     const right = xDiff > Fx.zeroFx8;
                     const x0 = Fx.toIntShifted(right ? sprite._hitbox.right : sprite._hitbox.left, 4);
-                    for (let y = sprite._hitbox.top; y < Fx.iadd(15, sprite._hitbox.bottom); y = Fx.iadd(16, y)) {
-                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.iadd(-1, sprite._hitbox.bottom)), 4);
+                    for (let y = Fx.sub(sprite._hitbox.top, yDiff); y < Fx.iadd(15, Fx.sub(sprite._hitbox.bottom, yDiff)); y = Fx.iadd(16, y)) {
+                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.iadd(-1, Fx.sub(sprite._hitbox.bottom, yDiff))), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
                                 sprite._vx = Fx.neg(sprite._vx);
                             }
-                            sprite._x = right ? Fx.sub(Fx8(x0 << 4), Fx8(sprite.width)) : Fx8((x0 + 1) << 4);
+                            sprite._x = Fx.iadd(-sprite._hitbox.ox, right ? Fx.sub(Fx8(x0 << 4), Fx8(sprite._hitbox.width)) : Fx8((x0 + 1) << 4));
                             sprite.registerObstacle(right ? CollisionDirection.Right : CollisionDirection.Left, tm.getObstacle(x0, y0));
                             break;
                         }
@@ -149,15 +149,15 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 
                 if (yDiff !== Fx.zeroFx8) {
                     const down = yDiff > Fx.zeroFx8;
-                    const y0 = Fx.toIntShifted(down ? Fx.iadd(sprite.height, sprite._y) : sprite._y, 4);
-                    for (let x = sprite._x; x < Fx.iadd(sprite.width + 15, sprite._x); x = Fx.iadd(16, x)) {
-                        const x0 = Fx.toIntShifted(Fx.min(x, Fx.iadd(sprite.width - 1, sprite._x)), 4);
+                    const y0 = Fx.toIntShifted(down ? sprite._hitbox.bottom : sprite._hitbox.top, 4);
+                    for (let x = sprite._hitbox.left; x < Fx.iadd(15, sprite._hitbox.right); x = Fx.iadd(16, x)) {
+                        const x0 = Fx.toIntShifted(Fx.min(x, Fx.iadd(-1, sprite._hitbox.right)), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
                                 sprite._vy = Fx.neg(sprite._vy);
                             }
-                            sprite._y = down ? Fx.sub(Fx8(y0 << 4), Fx8(sprite.height)) : Fx8((y0 + 1) << 4);
+                            sprite._y = Fx.iadd(-sprite._hitbox.oy, down ? Fx.sub(Fx8(y0 << 4), Fx8(sprite._hitbox.height)) : Fx8((y0 + 1) << 4));
                             sprite.registerObstacle(down ? CollisionDirection.Bottom : CollisionDirection.Top, tm.getObstacle(x0, y0));
                             break;
                         }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -132,9 +132,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
                 if (xDiff !== Fx.zeroFx8) {
                     const right = xDiff > Fx.zeroFx8;
-                    const x0 = Fx.toIntShifted(right ? Fx.iadd(1, sprite._hitbox.right) : sprite._hitbox.left, 4);
+                    const x0 = Fx.toIntShifted(Fx.add(right ? Fx.iadd(1, sprite._hitbox.right) : sprite._hitbox.left, Fx8(0.5)), 4);
                     for (let y = Fx.sub(sprite._hitbox.top, yDiff); y < Fx.iadd(16, Fx.sub(sprite._hitbox.bottom, yDiff)); y = Fx.iadd(16, y)) {
-                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.sub(sprite._hitbox.bottom, yDiff)), 4);
+                        const y0 = Fx.toIntShifted(Fx.add(Fx.min(y, Fx.sub(sprite._hitbox.bottom, yDiff)), Fx8(0.5)), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
@@ -148,9 +148,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 }
                 if (yDiff !== Fx.zeroFx8) {
                     const down = yDiff > Fx.zeroFx8;
-                    const y0 = Fx.toIntShifted(down ? Fx.iadd(1, sprite._hitbox.bottom) : sprite._hitbox.top, 4);
+                    const y0 = Fx.toIntShifted(Fx.add(down ? Fx.iadd(1, sprite._hitbox.bottom) : sprite._hitbox.top, Fx8(0.5)), 4);
                     for (let x = sprite._hitbox.left; x < Fx.iadd(16, sprite._hitbox.right); x = Fx.iadd(16, x)) {
-                        const x0 = Fx.toIntShifted(Fx.min(x, sprite._hitbox.right), 4);
+                        const x0 = Fx.toIntShifted(Fx.add(Fx.min(x, sprite._hitbox.right), Fx8(0.5)), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -132,9 +132,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
                 if (xDiff !== Fx.zeroFx8) {
                     const right = xDiff > Fx.zeroFx8;
-                    const x0 = Fx.toIntShifted(right ? sprite._hitbox.right : sprite._hitbox.left, 4);
-                    for (let y = Fx.sub(sprite._hitbox.top, yDiff); y < Fx.iadd(15, Fx.sub(sprite._hitbox.bottom, yDiff)); y = Fx.iadd(16, y)) {
-                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.iadd(-1, Fx.sub(sprite._hitbox.bottom, yDiff))), 4);
+                    const x0 = Fx.toIntShifted(right ? Fx.iadd(1, sprite._hitbox.right) : sprite._hitbox.left, 4);
+                    for (let y = Fx.sub(sprite._hitbox.top, yDiff); y < Fx.iadd(16, Fx.sub(sprite._hitbox.bottom, yDiff)); y = Fx.iadd(16, y)) {
+                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.sub(sprite._hitbox.bottom, yDiff)), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
@@ -146,12 +146,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         }
                     }
                 }
-                
                 if (yDiff !== Fx.zeroFx8) {
                     const down = yDiff > Fx.zeroFx8;
-                    const y0 = Fx.toIntShifted(down ? sprite._hitbox.bottom : sprite._hitbox.top, 4);
-                    for (let x = sprite._hitbox.left; x < Fx.iadd(15, sprite._hitbox.right); x = Fx.iadd(16, x)) {
-                        const x0 = Fx.toIntShifted(Fx.min(x, Fx.iadd(-1, sprite._hitbox.right)), 4);
+                    const y0 = Fx.toIntShifted(down ? Fx.iadd(1, sprite._hitbox.bottom) : sprite._hitbox.top, 4);
+                    for (let x = sprite._hitbox.left; x < Fx.iadd(16, sprite._hitbox.right); x = Fx.iadd(16, x)) {
+                        const x0 = Fx.toIntShifted(Fx.min(x, sprite._hitbox.right), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {
@@ -193,13 +192,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     }
 
     public moveSprite(s: Sprite, tm: tiles.TileMap, dx: Fx8, dy: Fx8) {
-
-        if (dx === Fx.zeroFx8 && dy === Fx.zeroFx8) {
-            s._lastX = s._x;
-            s._lastY = s._y;
-            return;
-        }
-
         s._lastX = s._x;
         s._lastY = s._y;
         s._x = Fx.add(s._x, dx);

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -132,9 +132,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
                 if (xDiff !== Fx.zeroFx8) {
                     const right = xDiff > Fx.zeroFx8;
-                    const x0 = Fx.toIntShifted(right ? Fx.iadd(sprite.width, sprite._x) : sprite._x, 4);
-                    for (let y = sprite._lastY; y < Fx.iadd(sprite.height + 15, sprite._lastY); y = Fx.iadd(16, y)) {
-                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.iadd(sprite.height - 1, sprite._lastY)), 4);
+                    const x0 = Fx.toIntShifted(right ? sprite._hitbox.right : sprite._hitbox.left, 4);
+                    for (let y = sprite._hitbox.top; y < Fx.iadd(15, sprite._hitbox.bottom); y = Fx.iadd(16, y)) {
+                        const y0 = Fx.toIntShifted(Fx.min(y, Fx.iadd(-1, sprite._hitbox.bottom)), 4);
                         if (tm.isObstacle(x0, y0)) {
                             hitWall = true;
                             if (bounce) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -551,7 +551,7 @@ class Sprite implements SpriteLike {
 
         // debug info
         if (game.debug) {
-            this._image.drawRect(this._hitbox.ox, this._hitbox.oy, this._hitbox.width, this._hitbox.height, 1);
+            screen.drawRect(Fx.toInt(this._hitbox.left), Fx.toInt(this._hitbox.top), this._hitbox.width, this._hitbox.height, 1);
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -530,8 +530,8 @@ class Sprite implements SpriteLike {
     __draw(camera: scene.Camera) {
         if (this.isOutOfScreen(camera)) return;
 
-        const l = this.left - camera.offsetX;
-        const t = this.top - camera.offsetY;
+        const l = Fx.toIntShifted(this._x, 0) - camera.offsetX;
+        const t = Fx.toIntShifted(this._y, 0) - camera.offsetY;
         screen.drawTransparentImage(this._image, l, t)
 
         if (this.flags & SpriteFlag.ShowPhysics) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -530,8 +530,8 @@ class Sprite implements SpriteLike {
     __draw(camera: scene.Camera) {
         if (this.isOutOfScreen(camera)) return;
 
-        const l = Fx.toIntShifted(this._x, 0) - camera.offsetX;
-        const t = Fx.toIntShifted(this._y, 0) - camera.offsetY;
+        const l = this.left - camera.offsetX;
+        const t = this.top - camera.offsetY;
         screen.drawTransparentImage(this._image, l, t)
 
         if (this.flags & SpriteFlag.ShowPhysics) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -64,6 +64,7 @@ class Sprite implements SpriteLike {
     //% group="Properties" blockSetVariable="mySprite"
     //% blockCombine block="x"
     set x(v: number) {
+        this._lastX = this._x;
         this._x = Fx8(v - (this._image.width >> 1))
     }
 
@@ -75,6 +76,7 @@ class Sprite implements SpriteLike {
     //% group="Properties" blockSetVariable="mySprite"
     //% blockCombine block="y"
     set y(v: number) {
+        this._lastY = this._y;
         this._y = Fx8(v - (this._image.height >> 1))
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -241,24 +241,15 @@ class Sprite implements SpriteLike {
         const maxXDiff = oMaxX - nMaxX;
         const maxYDiff = oMaxY - nMaxY;
 
-        const scene = game.currentScene();
-        const tmap = scene.tileMap;
-
-        if (tmap && tmap.enabled && this.width <= 16 && this.height <= 16) {
-            const l = (nMinX + this.left) >> 4;
-            const r = (nMaxX + this.left) >> 4;
-            const t = (nMinY + this.top) >> 4;
-            const b = (nMaxY + this.top) >> 4;
-
-            if (tmap.isObstacle(l, t) && (minXDiff > 0 || minYDiff > 0)) {
-                scene.physicsEngine.moveSprite(this, scene.tileMap, Fx8(minXDiff), Fx8(minYDiff));
-            } else if (tmap.isObstacle(r, t) && (maxXDiff < 0 || minYDiff > 0)) {
-                scene.physicsEngine.moveSprite(this, scene.tileMap, Fx8(maxXDiff), Fx8(minYDiff));
-            } else if (tmap.isObstacle(l, b) && (minXDiff > 0 || maxYDiff < 0)) {
-                scene.physicsEngine.moveSprite(this, scene.tileMap, Fx8(minXDiff), Fx8(maxYDiff));
-            } else if (tmap.isObstacle(r, b) && (maxXDiff < 0 || maxYDiff < 0)) {
-                scene.physicsEngine.moveSprite(this, scene.tileMap, Fx8(maxXDiff), Fx8(maxYDiff));
-            }
+        // If just a small change to the hitbox, don't change the hitbox
+        // Used for things like walking animations
+        if (Math.abs(minXDiff) + Math.abs(maxXDiff) <= 2) {
+            this._hitbox.ox = oMinX;
+            this._hitbox.width = oMaxX - oMinX;
+        }
+        if (Math.abs(minYDiff) + Math.abs(maxYDiff) <= 2) {
+            this._hitbox.oy = oMinY;
+            this._hitbox.height = oMaxY - oMinY;
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -243,11 +243,11 @@ class Sprite implements SpriteLike {
 
         // If just a small change to the hitbox, don't change the hitbox
         // Used for things like walking animations
-        if (Math.abs(minXDiff) + Math.abs(maxXDiff) <= 2) {
+        if (oMaxX != oMinX && Math.abs(minXDiff) + Math.abs(maxXDiff) <= 2) {
             this._hitbox.ox = oMinX;
             this._hitbox.width = oMaxX - oMinX;
         }
-        if (Math.abs(minYDiff) + Math.abs(maxYDiff) <= 2) {
+        if (oMaxY != oMinY && Math.abs(minYDiff) + Math.abs(maxYDiff) <= 2) {
             this._hitbox.oy = oMinY;
             this._hitbox.height = oMaxY - oMinY;
         }


### PR DESCRIPTION
**Fixes the following bugs**
Fixes Microsoft/pxt-arcade#375
Fixes Microsoft/pxt-arcade#448
Fixes Microsoft/pxt-arcade#517

Also fixes some issues with sprites clipping into walls when they should be bouncing. See [here](https://makecode.com/_FkP2g8eqcDHR). Sometimes the white block will bounce like it should, but sometimes it will clip into the bottom wall and get stuck. Thanks Joey for they example!

Moves code that deals with sprites interacting with tile maps to collisions section of the physics. So it 
now moves the sprites relative to the tile map collisions after it as moved the sprites their respective dxdt and dydt.

Reworks the collisions to be more efficient. Instead of checking every corner of every hitbox, only checking the points necessary. 
For example, if a sprite is moving up, it will check the points starting from the top left and moving right 16 pixels until the right side and then checks the top right corner.
Also stops checking points if a collision is already been detected.

