### PR TITLE
scene time tracking

### DIFF
--- a/libs/base/eventcontext.ts
+++ b/libs/base/eventcontext.ts
@@ -53,8 +53,8 @@ namespace control {
         private frameWorker: number;
         private framesInSample: number;
         private timeInSample: number;
-        public deltaTime: number;
-        private prevTime: number;
+        public deltaTimeMillis: number;
+        private prevTimeMillis: number;
     
         static lastStats: string;
         static onStats: (stats: string) => void;
@@ -63,16 +63,20 @@ namespace control {
             this.handlers = [];
             this.framesInSample = 0;
             this.timeInSample = 0;
-            this.deltaTime = 0;
+            this.deltaTimeMillis = 0;
             this.frameWorker = 0;
+        }
+
+        get deltaTime() {
+            return this.deltaTimeMillis / 1000;
         }
 
         private runCallbacks() {
             control.enablePerfCounter("all frame callbacks")
 
             let loopStart = control.millis()
-            this.deltaTime = (loopStart - this.prevTime) / 1000.0
-            this.prevTime = loopStart;
+            this.deltaTimeMillis = loopStart - this.prevTimeMillis;
+            this.prevTimeMillis = loopStart;
             for (let f of this.frameCallbacks) {
                 f.handler()
             }
@@ -102,8 +106,8 @@ namespace control {
 
             this.framesInSample = 0;
             this.timeInSample = 0;
-            this.deltaTime = 0;
-            this.prevTime = control.millis();
+            this.deltaTimeMillis = 0;
+            this.prevTimeMillis = control.millis();
             const worker = this.frameWorker;
             control.runInParallel(() => {
                 while (worker == this.frameWorker) {

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -202,7 +202,7 @@ namespace game {
         if (!a || period < 0) return;
         let timer = 0;
         game.eventContext().registerFrameHandler(19, () => {
-            const time = control.millis();
+            const time = game.currentScene().millis();
             if (timer <= time) {
                 timer = time + period;
                 a();
@@ -220,5 +220,15 @@ namespace game {
         init();
         if (!a) return;
         game.eventContext().registerFrameHandler(75, a);
+    }
+
+    /**
+     * Returns the time since the game started in milliseconds
+     */
+    //% blockId=arcade_game_runtime block="time since start (ms)"
+    //% group="Gameplay" weight=11
+    //% help=game/runtime
+    export function runtime(): number {
+        return currentScene().millis();
     }
 }

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -66,7 +66,7 @@ namespace info {
             if (_gameEnd !== undefined && _visibilityFlag & Visibility.Countdown) {
                 const scene = game.currentScene();
                 const elapsed = _gameEnd - scene.millis();
-                drawTimer(elapsed)
+                drawTimer(elapsed);
                 let t = elapsed / 1000;
                 if (t <= 0) {
                     t = 0;
@@ -271,6 +271,7 @@ namespace info {
     //% group="Countdown"
     export function startCountdown(duration: number) {
         _gameEnd = game.currentScene().millis() + duration * 1000;
+        console.log(`gameend ` + _gameEnd)
         updateFlag(Visibility.Countdown, true);
         _countdownExpired = false;
     }

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -64,8 +64,10 @@ namespace info {
             }
             // show countdown in both modes
             if (_gameEnd !== undefined && _visibilityFlag & Visibility.Countdown) {
-                drawTimer(_gameEnd - control.millis())
-                let t = Math.max(0, _gameEnd - control.millis()) / 1000;
+                const scene = game.currentScene();
+                const elapsed = _gameEnd - scene.millis();
+                drawTimer(elapsed)
+                let t = elapsed / 1000;
                 if (t <= 0) {
                     t = 0;
                     if (!_countdownExpired) {
@@ -268,7 +270,7 @@ namespace info {
     //% help=info/start-countdown weight=79 blockGap=8
     //% group="Countdown"
     export function startCountdown(duration: number) {
-        _gameEnd = control.millis() + duration * 1000;
+        _gameEnd = game.currentScene().millis() + duration * 1000;
         updateFlag(Visibility.Countdown, true);
         _countdownExpired = false;
     }

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -38,6 +38,7 @@ namespace scene {
         createdHandlers: SpriteHandler[];
         overlapHandlers: OverlapHandler[];
         collisionHandlers: CollisionHandler[];
+        private _millis: number;
         private _data: any;
 
         constructor(eventContext: control.EventContext) {
@@ -52,6 +53,7 @@ namespace scene {
             this.collisionHandlers = [];
             this.spritesByKind = [];
             this._data = {};
+            this._millis = 0;
         }
 
         init() {
@@ -61,8 +63,9 @@ namespace scene {
             this.spriteNextId = 0;
             // update controller state
             this.eventContext.registerFrameHandler(8, () => {
-                control.enablePerfCounter("controller_update")
                 const dt = this.eventContext.deltaTime;
+                this._millis += dt;
+                control.enablePerfCounter("controller_update")
                 controller.__update(dt);
             })
             // update sprites in tilemap
@@ -120,6 +123,13 @@ namespace scene {
 
         get data() {
             return this._data;
+        }
+
+        /**
+         * Gets the elapsed time in the scene
+         */
+        millis(): number {
+            return this._millis;
         }
 
         addSprite(sprite: SpriteLike) {

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -63,10 +63,9 @@ namespace scene {
             this.spriteNextId = 0;
             // update controller state
             this.eventContext.registerFrameHandler(8, () => {
-                const dt = this.eventContext.deltaTime;
-                this._millis += dt;
+                this._millis += this.eventContext.deltaTimeMillis;
                 control.enablePerfCounter("controller_update")
-                controller.__update(dt);
+                controller.__update(this.eventContext.deltaTime);
             })
             // update sprites in tilemap
             this.eventContext.registerFrameHandler(9, () => {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -414,6 +414,7 @@ class Sprite implements SpriteLike {
         let bubbleOffset: number = this._hitbox.oy;
         // sets the defaut scroll speed in pixels per second
         let speed = 45;
+        const currentScene = game.currentScene();
 
         // Calculates the speed of the scroll if scrolling is needed and a time is specified
         if (timeOnScreen && maxOffset > 0) {
@@ -424,7 +425,7 @@ class Sprite implements SpriteLike {
         }
 
         if (timeOnScreen) {
-            timeOnScreen = timeOnScreen + control.millis();
+            timeOnScreen = timeOnScreen + currentScene.millis();
         }
 
         if (bubbleWidth > maxTextWidth + bubblePadding) {
@@ -444,7 +445,7 @@ class Sprite implements SpriteLike {
         this.sayBubbleSprite.setFlag(SpriteFlag.Ghost, true);
         this.updateSay = (dt, camera) => {
             // Update box stuff as long as timeOnScreen doesn't exist or it can still be on the screen
-            if (!timeOnScreen || timeOnScreen > control.millis()) {
+            if (!timeOnScreen || timeOnScreen > currentScene.millis()) {
                 this.sayBubbleSprite.image.fill(textBoxColor);
                 // The minus 2 is how much transparent padding there is under the sayBubbleSprite
                 this.sayBubbleSprite.y = this.top + bubbleOffset - ((font.charHeight + bubblePadding) >> 1) - 2;


### PR DESCRIPTION
The scene keeps track of time spent in the update loop and countdown use this timer instead of the system timer. As a result, when a menu is displayed, the game timer is not incremented.
Fix for https://github.com/Microsoft/pxt-arcade/issues/441