### PR TITLE
Add support for status bar on hardware screen

### DIFF
--- a/libs/base/eventcontext.ts
+++ b/libs/base/eventcontext.ts
@@ -85,10 +85,7 @@ namespace control {
             this.framesInSample++
             if (this.timeInSample > 1000 || this.framesInSample > 30) {
                 const fps = this.framesInSample / (this.timeInSample / 1000);
-                if (EventContext.onStats) {
-                    EventContext.lastStats = `fps:${Math.round(fps)}`;
-                    EventContext.onStats(EventContext.lastStats)
-                }
+                EventContext.lastStats = `fps:${Math.round(fps)}`;
                 if (control.profilingEnabled()) {
                     control.dmesg(`${(fps * 100) | 0}/100 fps - ${this.framesInSample} frames`)
                     control.gc()

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -100,14 +100,18 @@ namespace scene {
             this.eventContext.registerFrameHandler(90, () => {
                 control.enablePerfCounter("sprite_draw")
                 if (this.flags & Flag.NeedsSorting)
-                this.allSprites.sort(function (a, b) { return a.z - b.z || a.id - b.id; })
+                    this.allSprites.sort(function (a, b) { return a.z - b.z || a.id - b.id; })
                 for (const s of this.allSprites)
                     s.__draw(this.camera);
             })
             // render diagnostics
             this.eventContext.registerFrameHandler(150, () => {
-                if (game.stats)
-                    screen.print(control.EventContext.lastStats + ` sprites:${this.allSprites.length}`, 2, 2, 0, image.font5);
+                if (game.stats && control.EventContext.onStats) {
+                    control.EventContext.onStats(
+                        control.EventContext.lastStats +
+                        ` sprites:${this.allSprites.length}`
+                    )
+                }
                 if (game.debug)
                     this.physicsEngine.draw();
                 game.consoleOverlay.draw();

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -10,6 +10,7 @@ class WDisplay {
 
     uint32_t currPalette[16];
     bool newPalette;
+    bool inUpdate;
 
     uint8_t *screenBuf;
     Image_ lastStatus;
@@ -62,6 +63,7 @@ class WDisplay {
 
         lastStatus = NULL;
         registerGC((TValue *)&lastStatus);
+        inUpdate = false;
     }
 
     void setAddrStatus() {
@@ -104,6 +106,11 @@ void updateScreenStatusBar(Image_ img) {
 void updateScreen(Image_ img) {
     auto display = getWDisplay();
 
+    if (display->inUpdate)
+        return;
+
+    display->inUpdate = true;
+
     if (img && img->isDirty()) {
         if (img->bpp() != 4 || img->width() != display->width ||
             img->height() != display->displayHeight)
@@ -140,6 +147,8 @@ void updateScreen(Image_ img) {
         display->setAddrMain();
         display->lastStatus = NULL;
     }
+
+    display->inUpdate = false;
 }
 
 //%


### PR DESCRIPTION
This is used to limit hardware screen to 120px and display status data in the bottom 8px.

Also, use `onStats` to display stats.

Also, fix a race in screen update.