### PR TITLE
printCenter center of image instead of screen

### DIFF
--- a/libs/screen/text.ts
+++ b/libs/screen/text.ts
@@ -195,7 +195,7 @@ namespace helpers {
     export function imagePrintCenter(img: Image, text: string, y: number, color?: number, font?: image.Font) {
         if (!font) font = image.font8
         let w = text.length * font.charWidth
-        let x = (screen.width - w) / 2
+        let x = (img.width - w) / 2
         imagePrint(img, text, x, y, color, font)
     }
 


### PR DESCRIPTION
Fixed printCenter to print in the center of the image instead of the screen.