### PR TITLE
fix place on tile to properly center sprite

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -46,8 +46,8 @@ namespace tiles {
         place(mySprite: Sprite): void {
             if (!mySprite) return;
 
-            mySprite.x = this.x + 8;
-            mySprite.y = this.y + 8;
+            mySprite.x = this.x;
+            mySprite.y = this.y;
         }
     }
 


### PR DESCRIPTION
Must have gotten out of sync with a change of x and y to give the center, part of cleaning up https://github.com/Microsoft/pxt-arcade/issues/478