### PR TITLE
fix timer spacing

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -423,12 +423,11 @@ namespace info {
 
 
         if (seconds < 60) {
-            left += 3
             const top = 1;
             const remainder = Math.idiv(millis % 1000, 10);
 
             screen.print(formatDecimal(seconds) + ".", left, top, color1, font)
-            const decimalLeft = left + 3 * font.charWidth - 2;
+            const decimalLeft = left + 3 * font.charWidth;
             screen.print(formatDecimal(remainder), decimalLeft, top + 2, color1, smallFont)
         }
         else {


### PR DESCRIPTION
The positioning of the timer for countdowns got messed up when the font changed and / or when local-multiplayer got pulled in, and it was incredibly distracting while looking at old scripts :)

current:

![2019-01-15 23 57 36](https://user-images.githubusercontent.com/5615930/51236564-51e6a600-1927-11e9-8e0e-f975ed726975.gif)

this:

![2019-01-16 00 37 06](https://user-images.githubusercontent.com/5615930/51236563-51e6a600-1927-11e9-8ad5-6af32115c57a.gif)