### PR TITLE
Scale the fonts dynamically

### DIFF
--- a/libs/base/gc.cpp
+++ b/libs/base/gc.cpp
@@ -529,7 +529,7 @@ void *gcAllocate(int numbytes) {
     size_t numwords = (numbytes + 3) >> 2;
 
     if (numbytes > GC_MAX_ALLOC_SIZE)
-        oops(45);
+        target_panic(PANIC_GC_TOO_BIG_ALLOCATION);
 
     if (PXT_IN_ISR() || (inGC & IN_GC_ALLOC))
         target_panic(PANIC_CALLED_FROM_ISR);

--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -175,6 +175,7 @@ inline bool canBeTagged(int v) {
 typedef enum {
     PANIC_CODAL_OOM = 20,
     PANIC_GC_OOM = 21,
+    PANIC_GC_TOO_BIG_ALLOCATION = 22,
     PANIC_CODAL_HEAP_ERROR = 30,
     PANIC_CODAL_NULL_DEREFERENCE = 40,
     PANIC_CODAL_USB_ERROR = 50,


### PR DESCRIPTION
Instead of allocating scaled bitmap data for entire font, do it dynamically while printing. While this is slower, it saves memory and allows for  arbitrary size for fonts, not only powers of two.

Fixes https://github.com/Microsoft/pxt-arcade/issues/596

Also, change "too big allocation" error code from 845 to 022 (to fit with 020 and 021).

@abchatra your call if you want this in, but seems low risk

![arcade-stm](https://user-images.githubusercontent.com/10673976/51247266-80469e80-1984-11e9-9b60-062e53a49c06.png)
