### PR TITLE
Use TC4 not TCC0 on SAMD21

### DIFF
--- a/libs/core---samd/platform.cpp
+++ b/libs/core---samd/platform.cpp
@@ -6,7 +6,7 @@
 namespace pxt {
 
 #ifdef SAMD21
-SAMDTCCTimer lowTimer(TCC0, TCC0_IRQn);
+SAMDTCTimer lowTimer(TC4, TC4_IRQn);
 #endif
 #ifdef SAMD51
 SAMDTCTimer lowTimer(TC0, TC0_IRQn);


### PR DESCRIPTION
I guess we should check if this fixes I2C?