### PR TITLE
expand `moveSprite` velocities at same time

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -286,6 +286,7 @@ namespace controller {
          */
         //% blockId="ctrlgame_control_sprite" block="%controller move $sprite=variables_get(mySprite) with buttons||vx $vx vy $vy"
         //% weight=100
+        //% expandableArgumentMode="toggle"
         //% vx.defl=100 vy.defl=100
         //% help=controller/move-sprite
         //% group="Multiplayer"
@@ -464,6 +465,7 @@ namespace controller {
      */
     //% blockId="game_control_sprite" block="move $sprite=variables_get(mySprite) with buttons||vx $vx vy $vy"
     //% weight=100
+    //% expandableArgumentMode="toggle"
     //% vx.defl=100 vy.defl=100
     //% help=controller/move-sprite
     //% group="Single Player"


### PR DESCRIPTION
Expand both `vx` and `vy` at once, rather than one at a time

![2019-01-16 10 38 27](https://user-images.githubusercontent.com/5615930/51270927-0fe74f80-197b-11e9-85bf-75e00628db1c.gif)