### PR TITLE
Fixes pxt-arcade/#620

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -297,6 +297,12 @@ namespace controller {
                 cp = { s: sprite, vx: vx, vy: vy }
                 this._controlledSprites.push(cp);
             }
+            if (cp.vx && vx == 0) {
+                cp.s.vx = 0
+            }
+            if (cp.vy && vy == 0) {
+                cp.s.vy = 0
+            }
             cp.vx = vx;
             cp.vy = vy;
         }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -366,7 +366,7 @@ class Sprite implements SpriteLike {
     }
 
     /**
-     * Sets the sprite velocity in pixel / sec²
+     * Sets the sprite velocity in pixel / sec
      * @param vx 
      * @param vy 
      */


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/620
When changing a controlled sprite velocity to 0, override its sprite velocity so that it gets updated.