### PR TITLE
durations for particle effects consistency

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -34,13 +34,14 @@ namespace effects {
         /**
          * Destroy the provided sprite with an effect
          * @param sprite
+         * @param duration how long the sprite will remain on the screen
          * @param particlesPerSecond
-         * @param lifespan how long the sprite will remain on the screen
          */
-        destroy(anchor: Sprite, particlesPerSecond?: number, duration: number = 500) {
+        destroy(anchor: Sprite, duration?: number, particlesPerSecond?: number) {
             anchor.setFlag(SpriteFlag.Ghost, true);
             this.start(anchor, particlesPerSecond);
-            anchor.lifespan = duration;
+            if (duration)
+                anchor.lifespan = duration;
             effects.dissolve.applyTo(anchor);
         }
     }
@@ -88,17 +89,27 @@ namespace effects {
         /**
          * Creates a new effect that occurs over the entire screen
          * @param particlesPerSecond 
+         * @param duration
          */
-        //% blockId=particlesStartScreenAnimation block="start screen %effect effect"
+        //% blockId=particlesStartScreenAnimation block="start screen %effect effect || for %duration ms"
+        //% duration.shadow=timePicker
         //% blockNamespace=scene
         //% group="Effects" blockGap=8
         //% weight=90
-        startScreenEffect(particlesPerSecond?: number): void {
-            if (!this.sourceFactory || (this.source && this.source.enabled))
+        startScreenEffect(duration?: number, particlesPerSecond?: number): void {
+            if (!this.sourceFactory)
                 return;
+
+            if (this.source && this.source.enabled) {
+                if (duration)
+                    this.source.lifespan = duration;
+                return;
+            }
 
             this.endScreenEffect();
             this.source = this.sourceFactory(new SceneAnchor(), particlesPerSecond ? particlesPerSecond : this.sceneDefaultRate);
+            if (duration)
+                this.source.lifespan = duration;
         }
 
         /**

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -718,14 +718,16 @@ class Sprite implements SpriteLike {
      */
     //% group="Effects"
     //% weight=80
-    //% blockId=spritedestroy block="destroy %sprite(mySprite) || with %effect effect"
+    //% blockId=spritedestroy block="destroy %sprite(mySprite) || with %effect effect for %duration ms"
+    //% duration.shadow=timePicker
+    //% expandableArgumentMode="toggle"
     //% help=sprites/sprite/destroy
-    destroy(effect?: effects.ParticleEffect) {
+    destroy(effect?: effects.ParticleEffect, duration?: number) {
         if (this.flags & sprites.Flag.Destroyed)
             return;
         
         if (effect) {
-            effect.destroy(this);
+            effect.destroy(this, duration);
             return;
         }
 


### PR DESCRIPTION
expose durations for all the sprite effects to match the normal `sprite.startEffect` ones, as that is really useful and pretty intuitive.

<img width="578" alt="screen shot 2019-01-17 at 11 43 15 pm" src="https://user-images.githubusercontent.com/5615930/51372376-eda41d80-1ab1-11e9-9295-d4176119c632.png">

@pelikhan 