### PR TITLE
Lowlevelimg

### DIFF
--- a/libs/base/eventcontext.ts
+++ b/libs/base/eventcontext.ts
@@ -55,7 +55,7 @@ namespace control {
         private timeInSample: number;
         public deltaTimeMillis: number;
         private prevTimeMillis: number;
-    
+
         static lastStats: string;
         static onStats: (stats: string) => void;
 
@@ -86,6 +86,8 @@ namespace control {
             if (this.timeInSample > 1000 || this.framesInSample > 30) {
                 const fps = this.framesInSample / (this.timeInSample / 1000);
                 EventContext.lastStats = `fps:${Math.round(fps)}`;
+                if (fps < 99)
+                    EventContext.lastStats += "." + (Math.round(fps * 10) % 10)
                 if (control.profilingEnabled()) {
                     control.dmesg(`${(fps * 100) | 0}/100 fps - ${this.framesInSample} frames`)
                     control.gc()

--- a/libs/core/i2c.ts
+++ b/libs/core/i2c.ts
@@ -6,6 +6,8 @@ namespace pins {
     //% blockId=pins_i2c_readnumber block="i2c read number at address %address|of format %format|repeated %repeated"
     export function i2cReadNumber(address: number, format: NumberFormat, repeated?: boolean): number {
         const buf = pins.i2cReadBuffer(address, pins.sizeOf(format), repeated)
+        if (!buf)
+            return undefined
         return buf.getNumber(format, 0)
     }
 

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -9,6 +9,12 @@ interface Image {
     fillRect(x: number, y: number, w: number, h: number, c: color): void;
 
     /**
+     * Replace colors in a rectangle
+     */
+    //% helper=imageMapRect
+    mapRect(x: number, y: number, w: number, h: number, colorMap: Buffer): void;
+
+    /**
      * Draw a line
      */
     //% helper=imageDrawLine blockNamespace="images" inlineInputMode="inline" group="Drawing"

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -67,6 +67,9 @@ namespace helpers {
     //% shim=ImageMethods::_fillRect
     function _fillRect(img: Image, xy: number, wh: number, c: color): void { }
 
+    //% shim=ImageMethods::_mapRect
+    function _mapRect(img: Image, xy: number, wh: number, m: Buffer): void { }
+
     //% shim=ImageMethods::_drawIcon
     function _drawIcon(img: Image, icon: Buffer, xy: number, c: color): void { }
 
@@ -79,6 +82,9 @@ namespace helpers {
     }
     export function imageFillRect(img: Image, x: number, y: number, w: number, h: number, c: color): void {
         _fillRect(img, pack(x, y), pack(w, h), c)
+    }
+    export function imageMapRect(img: Image, x: number, y: number, w: number, h: number, m: Buffer): void {
+        _mapRect(img, pack(x, y), pack(w, h), m)
     }
     export function imageDrawLine(img: Image, x: number, y: number, w: number, h: number, c: color): void {
         _drawLine(img, pack(x, y), pack(w, h), c)

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -94,6 +94,68 @@ namespace pxsim.ImageMethods {
         fillRect(img, XX(xy), YY(xy), XX(wh), YY(wh), c)
     }
 
+    export function mapRect(img: RefImage, x: number, y: number, w: number, h: number, c: RefBuffer) {
+        if (c.data.length < 16)
+            return
+        img.makeWritable()
+        let [x2, y2] = img.clamp(x + w - 1, y + h - 1);
+        [x, y] = img.clamp(x, y)
+        let p = img.pix(x, y)
+        w = x2 - x + 1
+        h = y2 - y + 1
+        let d = img._width - w
+
+        while (h-- > 0) {
+            for (let i = 0; i < w; ++i) {
+                img.data[p] = c.data[img.data[p]]
+                p++
+            }
+            p += d
+        }
+    }
+
+    export function _mapRect(img: RefImage, xy: number, wh: number, c: RefBuffer) {
+        mapRect(img, XX(xy), YY(xy), XX(wh), YY(wh), c)
+    }
+
+    export function getRows(img: RefImage, x: number, dst: RefBuffer) {
+        x |= 0
+        if (!img.inRange(x, 0))
+            return
+
+        let dp = 0
+        let len = Math.min(dst.data.length, (img._width - x) * img._height)
+        let sp = x
+        let hh = 0
+        while (len--) {
+            if (hh++ >= img._height) {
+                hh = 0
+                sp = ++x
+            }
+            dst.data[dp++] = img.data[sp]
+            sp += img._width
+        }
+    }
+
+    export function setRows(img: RefImage, x: number, src: RefBuffer) {
+        x |= 0
+        if (!img.inRange(x, 0))
+            return
+
+        let sp = 0
+        let len = Math.min(src.data.length, (img._width - x) * img._height)
+        let dp = x
+        let hh = 0
+        while (len--) {
+            if (hh++ >= img._height) {
+                hh = 0
+                dp = ++x
+            }
+            img.data[dp] = src.data[sp++]
+            dp += img._width
+        }
+    }
+
     export function clone(img: RefImage) {
         let r = new RefImage(img._width, img._height, img._bpp)
         r.data.set(img.data)


### PR DESCRIPTION
This adds:
* methods on image to extract row(s) into a buffer and store them back
* mapRect() method, which remaps (according to 16 byte buffer) pixels colors in a given rectangle

Example:
```typescript
function mapScreen2() {
    let mapA = hex`000102030405060708090a0b0c0d0e0f`
    let mapB = hex`0102030405060708090a0b0c0d0e0f00`
    let h = screen.height
    let rowBuf = control.createBuffer(h)
    let w = screen.width
    for (let x = 0; x < w; ++x) {
        let m = x % 10 < 5 ? mapA : mapB
        screen.getRows(x, rowBuf)
        for (let y = 0; y < h; ++y) {
            rowBuf[y] = m[rowBuf[y]]
        }
        screen.setRows(x, rowBuf)
    }
}
```

This, however, takes around 150-200 cycles per loop iteration, giving about 15fps, so not quite good enough. The get/setRows will be useful for other effects though (eg melt could be much more efficient with that).

`mapRect` example, running at around 25fps:
```typescript
function mapScreen3() {
    let mapA = hex`000102030405060708090a0b0c0d0e0f`
    let mapB = hex`0102030405060708090a0b0c0d0e0f00`
    let h = screen.height
    let rowBuf = control.createBuffer(h)
    let w = screen.width
    for (let x = 0; x < w; ++x) {
        screen.mapRect(x, 0, 1, 10, mapA)
        screen.mapRect(x, 11, 1, 30, mapA)
        screen.mapRect(x, 32, 1, 30, mapB)
        screen.mapRect(x, 62, 1, 30, mapA)
        screen.mapRect(x, 92, 1, 30, mapB)
    }
}
```

This can be further sped-up by going two or three rows at a time. Note, that it's fastest to do it row by row, not column by column.