### PR TITLE
Allow dynamic selection of accelerometer used

### DIFF
--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -88,18 +88,18 @@ enum class Gesture {
     //% block="free fall"
     FreeFall = ACCELEROMETER_EVT_FREEFALL,
     /**
-    * Raised when a 3G shock is detected
-    */
+     * Raised when a 3G shock is detected
+     */
     //% block="3g"
     ThreeG = ACCELEROMETER_EVT_3G,
     /**
-    * Raised when a 6G shock is detected
-    */
+     * Raised when a 6G shock is detected
+     */
     //% block="6g"
     SixG = ACCELEROMETER_EVT_6G,
     /**
-    * Raised when a 8G shock is detected
-    */
+     * Raised when a 8G shock is detected
+     */
     //% block="8g"
     EightG = ACCELEROMETER_EVT_8G
 };
@@ -107,7 +107,21 @@ enum class Gesture {
 // defined in accelhw.cpp
 namespace pxt {
 codal::Accelerometer *getAccelerometer();
+
+void initAccelRandom() {
+    auto acc = getAccelerometer();
+    for (int i = 0; i < 10; ++i) {
+        acc->requestUpdate();
+        if (acc->getY())
+            break;
+        fiber_sleep(5);
+    }
+    seedAddRandom(acc->getX());
+    seedAddRandom(acc->getY());
+    seedAddRandom(acc->getZ());
 }
+
+} // namespace pxt
 
 namespace input {
 /**
@@ -198,4 +212,4 @@ void setAccelerometerRange(AcceleratorRange range) {
     getAccelerometer()->setRange((int)range);
 }
 
-}
+} // namespace input

--- a/libs/accelerometer/accelhw.cpp
+++ b/libs/accelerometer/accelhw.cpp
@@ -1,0 +1,119 @@
+// This supports a few different accelerometers.
+// If desired, overrides PXT_SUPPORT_* in platform.h (note that only LIS3DH is on by default).
+// Then accelerometer can be changed with config.ACCELEROMETER_TYPE in TypeScript.
+// This file can be overridden alltogether by a target if a different accelerometer is desired.
+
+#include "pxt.h"
+#include "axis.h"
+#include "Pin.h"
+#include "I2C.h"
+#include "CoordinateSystem.h"
+
+#ifndef PXT_DEFUALT_ACCELEROMETER
+#define PXT_DEFUALT_ACCELEROMETER ACCELEROMETER_TYPE_LIS3DH
+#endif
+
+#ifndef PXT_SUPPORT_LIS3DH
+#define PXT_SUPPORT_LIS3DH 1
+#endif
+#if PXT_SUPPORT_LIS3DH
+#include "LIS3DH.h"
+#endif
+
+#ifndef PXT_SUPPORT_MMA8653
+#define PXT_SUPPORT_MMA8653 0
+#endif
+#if PXT_SUPPORT_MMA8653
+#include "MMA8653.h"
+#endif
+
+#ifndef PXT_SUPPORT_MMA8453
+#define PXT_SUPPORT_MMA8453 0
+#endif
+#if PXT_SUPPORT_MMA8453
+#include "MMA8453.h"
+#endif
+
+#ifndef PXT_SUPPORT_FXOS8700
+#define PXT_SUPPORT_FXOS8700 0
+#endif
+#if PXT_SUPPORT_FXOS8700
+#include "FXOS8700Accelerometer.h"
+#endif
+
+#ifndef PXT_SUPPORT_MSA300
+#define PXT_SUPPORT_MSA300 0
+#endif
+#if PXT_SUPPORT_MSA300
+#include "MSA300.h"
+#endif
+
+#if defined(CODAL_ACCELEROMETER)
+#error "please define PXT_SUPPORT_* and PXT_DEFUALT_ACCELEROMETER"
+#endif
+
+namespace pins {
+CODAL_I2C *getI2C();
+}
+
+namespace pxt {
+
+// Wrapper classes
+class WAccel {
+    CoordinateSpace space;
+
+  public:
+    Accelerometer *acc;
+    WAccel() : space(ACC_SYSTEM, ACC_UPSIDEDOWN, ACC_ROTATION) {
+        CODAL_I2C *i2c;
+        if (PIN(ACCELEROMETER_SDA) == (PinName)-1 || PIN(ACCELEROMETER_SDA) == PIN(SDA)) {
+            i2c = pins::getI2C();
+        } else {
+            i2c = new CODAL_I2C(*LOOKUP_PIN(ACCELEROMETER_SDA), *LOOKUP_PIN(ACCELEROMETER_SCL));
+        }
+
+        auto accType = getConfig(CFG_ACCELEROMETER_TYPE, PXT_DEFUALT_ACCELEROMETER);
+        acc = NULL;
+        switch (accType) {
+#if PXT_SUPPORT_LIS3DH
+        case ACCELEROMETER_TYPE_LIS3DH:
+            acc = new LIS3DH(*i2c, *LOOKUP_PIN(ACCELEROMETER_INT), space);
+            break;
+#endif
+#if PXT_SUPPORT_MSA300
+        case ACCELEROMETER_TYPE_MSA300:
+            acc = new MSA300(*i2c, *LOOKUP_PIN(ACCELEROMETER_INT), space);
+            break;
+#endif
+#if PXT_SUPPORT_FXOS8700
+        case ACCELEROMETER_TYPE_FXOS8700:
+            acc = new FXOS8700Accelerometer(*i2c, *LOOKUP_PIN(ACCELEROMETER_INT), space);
+            break;
+#endif
+#if PXT_SUPPORT_MMA8653
+        case ACCELEROMETER_TYPE_MMA8653:
+            acc = new MMA8653(*i2c, *LOOKUP_PIN(ACCELEROMETER_INT), space);
+            break;
+#endif
+#if PXT_SUPPORT_MMA8453
+        case ACCELEROMETER_TYPE_MMA8453:
+            acc = new MMA8453(*i2c, *LOOKUP_PIN(ACCELEROMETER_INT), space);
+            break;
+#endif
+        }
+
+        if (acc == NULL)
+            target_panic(PANIC_CODAL_HARDWARE_CONFIGURATION_ERROR);
+
+        // acc->init(); - doesn't do anything
+        acc->configure();
+        acc->requestUpdate();
+    }
+};
+SINGLETON(WAccel);
+
+codal::Accelerometer *getAccelerometer() {
+    return getWAccel()->acc;
+}
+
+} // namespace pxt

--- a/libs/accelerometer/accelhw.cpp
+++ b/libs/accelerometer/accelhw.cpp
@@ -9,8 +9,8 @@
 #include "I2C.h"
 #include "CoordinateSystem.h"
 
-#ifndef PXT_DEFUALT_ACCELEROMETER
-#define PXT_DEFUALT_ACCELEROMETER ACCELEROMETER_TYPE_LIS3DH
+#ifndef PXT_DEFAULT_ACCELEROMETER
+#define PXT_DEFAULT_ACCELEROMETER ACCELEROMETER_TYPE_LIS3DH
 #endif
 
 #ifndef PXT_SUPPORT_LIS3DH
@@ -72,7 +72,7 @@ class WAccel {
             i2c = new CODAL_I2C(*LOOKUP_PIN(ACCELEROMETER_SDA), *LOOKUP_PIN(ACCELEROMETER_SCL));
         }
 
-        auto accType = getConfig(CFG_ACCELEROMETER_TYPE, PXT_DEFUALT_ACCELEROMETER);
+        auto accType = getConfig(CFG_ACCELEROMETER_TYPE, PXT_DEFAULT_ACCELEROMETER);
         acc = NULL;
         switch (accType) {
 #if PXT_SUPPORT_LIS3DH

--- a/libs/accelerometer/pxt.json
+++ b/libs/accelerometer/pxt.json
@@ -4,6 +4,7 @@
     "files": [
         "README.md",
         "accelerometer.cpp",
+        "accelhw.cpp",
         "axis.h",
         "shims.d.ts",
         "enums.d.ts",

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -318,6 +318,10 @@ void seedRandom(unsigned seed) {
     random_value = seed;
 }
 
+void seedAddRandom(unsigned seed) {
+    random_value = (random_value * 0x1000193) ^ seed;
+}
+
 unsigned getRandom(unsigned max) {
     unsigned m, result;
 

--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -799,6 +799,7 @@ TNumber getNumberCore(uint8_t *buf, int size, NumberFormat format);
 void setNumberCore(uint8_t *buf, int size, NumberFormat format, TNumber value);
 
 void seedRandom(unsigned seed);
+void seedAddRandom(unsigned seed);
 // max is inclusive
 unsigned getRandom(unsigned max);
 

--- a/libs/core---stm32/platform.cpp
+++ b/libs/core---stm32/platform.cpp
@@ -1,22 +1,18 @@
 #include "pxt.h"
 #include "STMLowLevelTimer.h"
+#include "Accelerometer.h"
 
 namespace pxt {
 
 STMLowLevelTimer tim5(TIM5, TIM5_IRQn);
 CODAL_TIMER devTimer(tim5);
 
+void initAccelRandom();
+
 static void initRandomSeed() {
-    int seed = 0xC0DA1;
-    /*
-    auto pinTemp = LOOKUP_PIN(TEMPERATURE);
-    if (pinTemp)
-        seed *= pinTemp->getAnalogValue();
-    auto pinLight = LOOKUP_PIN(LIGHT);
-    if (pinLight)
-        seed *= pinLight->getAnalogValue();
-    */
-    seedRandom(seed);
+    if (getConfig(CFG_ACCELEROMETER_TYPE, -1) != -1) {
+        initAccelRandom();
+    }
 }
 
 void platformSendSerial(const char *data, int len) {
@@ -80,5 +76,4 @@ void platform_usb_init() {
 
 } // namespace pxt
 
-void cpu_clock_init() {
-}
+void cpu_clock_init() {}

--- a/libs/core---stm32/platform.cpp
+++ b/libs/core---stm32/platform.cpp
@@ -67,6 +67,7 @@ static void writeHex(char *buf, uint32_t n) {
 }
 
 void platform_usb_init() {
+#if CONFIG_ENABLED(DEVICE_USB)
     static char serial_number[25];
 
     writeHex(serial_number, STM32_UUID[0]);
@@ -74,6 +75,7 @@ void platform_usb_init() {
     writeHex(serial_number + 16, STM32_UUID[2]);
 
     usb.stringDescriptors[2] = serial_number;
+#endif
 }
 
 } // namespace pxt

--- a/libs/core/i2c.cpp
+++ b/libs/core/i2c.cpp
@@ -10,6 +10,11 @@ namespace pins {
       }
     }
 
+    CODAL_I2C *getI2C() {
+      initI2C();
+      return i2c;
+    }
+
       /**
      * Read `size` bytes from a 7-bit I2C `address`.
      */

--- a/libs/core/i2c.ts
+++ b/libs/core/i2c.ts
@@ -6,6 +6,8 @@ namespace pins {
     //% blockId=pins_i2c_readnumber block="i2c read number at address %address|of format %format|repeated %repeated"
     export function i2cReadNumber(address: number, format: NumberFormat, repeated?: boolean): number {
         const buf = pins.i2cReadBuffer(address, pins.sizeOf(format), repeated)
+        if (!buf)
+            return undefined
         return buf.getNumber(format, 0)
     }
 


### PR DESCRIPTION
This allows several accelerometer drivers to be compiled in and one to be chosen at runtime using `ACCELEROMETER_TYPE` configuration variable (set in bootloader already).

By default only LIS3DH is compiled in, but this is overridden in Arcade.

Also, add function to use accelerometer as source of randomness.
