### PR TITLE
destroy effects: use default effect lifespan instead of a standard lifespan

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -34,14 +34,14 @@ namespace effects {
         /**
          * Destroy the provided sprite with an effect
          * @param sprite
-         * @param duration how long the sprite will remain on the screen
+         * @param duration how long the sprite will remain on the screen. If set to 0 or undefined,
+         *                  uses the default rate for this effect.
          * @param particlesPerSecond
          */
         destroy(anchor: Sprite, duration?: number, particlesPerSecond?: number) {
             anchor.setFlag(SpriteFlag.Ghost, true);
             this.start(anchor, particlesPerSecond);
-            if (duration)
-                anchor.lifespan = duration;
+            anchor.lifespan = duration ? duration : this.defaultLifespan >> 2;
             effects.dissolve.applyTo(anchor);
         }
     }
@@ -204,6 +204,7 @@ namespace effects {
             . F . F .
             . . F . .
         `);
+
         // if large anchor, increase lifespan
         if (factory.xRange > 50) {
             factory.minLifespan = 1000;


### PR DESCRIPTION
When using the destroy effect, if the duration provided is falsey, use a 1/4 of the default lifespan instead of just an arbitrary standard value. Looks better this way, as different effects really need a different duration to appear properly.

random effect pick on asteroid destroy with optional parameter not supplied:

![2019-01-22 16 25 17](https://user-images.githubusercontent.com/5615930/51574393-6a444c80-1e62-11e9-8b9c-55dc35b6e3fc.gif)

Maybe it would be good to have a time picker with `default` (0) and `forever` (probably just an arbitrarily extra long time ) as options in addition to the current ones for the effects?
