### PR TITLE
pause on game.ask so it isn't missed

### DIFF
--- a/libs/game/ask.ts
+++ b/libs/game/ask.ts
@@ -13,11 +13,11 @@ namespace game {
         control.pushEventContext();
         game.showDialog(title, subtitle, "A = OK, B = CANCEL");
         let answer: boolean = null;
-        controller.A.onEvent(ControllerButtonEvent.Pressed, () => answer = true);
-        controller.B.onEvent(ControllerButtonEvent.Pressed, () => answer = false);
-
         // short pause so that players don't skip through prompt
         pause(500);
+
+        controller.A.onEvent(ControllerButtonEvent.Pressed, () => answer = true);
+        controller.B.onEvent(ControllerButtonEvent.Pressed, () => answer = false);
         pauseUntil(() => answer !== null);
         control.popEventContext();
         return answer;

--- a/libs/game/ask.ts
+++ b/libs/game/ask.ts
@@ -15,6 +15,9 @@ namespace game {
         let answer: boolean = null;
         controller.A.onEvent(ControllerButtonEvent.Pressed, () => answer = true);
         controller.B.onEvent(ControllerButtonEvent.Pressed, () => answer = false);
+
+        // short pause so that players don't skip through prompt
+        pause(500);
         pauseUntil(() => answer !== null);
         control.popEventContext();
         return answer;


### PR DESCRIPTION
It's a bit too easy to skip through the ``game.ask`` dialogue when you're playing the game (/ mashing A or B) and completely miss it, so this adds a short pause between the prompt appearing and the player being able to make a decision, similar to the behavior in game over. https://github.com/Microsoft/pxt-common-packages/blob/1735068d37288dae04eeb0de30f86ff0a0c8b275/libs/game/game.ts#L190-L192

The 500ms pause is pretty arbitrary, but it's enough that the prompt will at least give them a chance to respond; 1000ms feels alright too, but 2000ms feels sluggish to me

### Current

(notice that the first few tries where I'm pressing a to fire the laser cause the prompt to never appear, with the game just appearing to be laggy for a second then the score going down)

![2019-01-23 11 15 18](https://user-images.githubusercontent.com/5615930/51630971-43d4ee80-1f00-11e9-902c-5f9a23a8bbfc.gif)

### with 500 pause

![2019-01-23 11 17 42](https://user-images.githubusercontent.com/5615930/51631061-8dbdd480-1f00-11e9-9e79-426684f50d45.gif)

### alternate 1000ms pause

![2019-01-23 11 23 08](https://user-images.githubusercontent.com/5615930/51631349-54d22f80-1f01-11e9-8ea2-400e2f7b4a05.gif)
