### PR TITLE
Fix controller button repeat

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -125,10 +125,10 @@ namespace controller {
                 if (this._owner)
                     this._owner.connected = true;
                 this._pressed = pressed;
-                if (this._pressed)
-                    this.raiseButtonDown();
-                else {
+                if (this._pressed) {
                     this._pressedElasped = 0;
+                    this.raiseButtonDown();
+                } else {
                     this._repeatCount = 0;
                     this.raiseButtonUp();
                 }
@@ -137,12 +137,13 @@ namespace controller {
 
         __update(dtms: number) {
             if (!this._pressed) return;
-            this._pressedElasped += dtms;
+            this._pressedElasped += dtms / 1000;
+
             // inital delay
             if (this._pressedElasped < this.repeatDelay)
                 return;
 
-            // do we have enough time to repeat
+            // repeat count for this step
             const count = Math.floor((this._pressedElasped - this.repeatDelay) / this.repeatInterval);
             if (count != this._repeatCount) {
                 this.raiseButtonRepeat();

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -135,9 +135,9 @@ namespace controller {
             }
         }
 
-        __update(dtmus: number) {
+        __update(dtms: number) {
             if (!this._pressed) return;
-            this._pressedElasped += dtmus / 1000;
+            this._pressedElasped += dtms;
 
             // inital delay
             if (this._pressedElasped < this.repeatDelay)
@@ -436,8 +436,8 @@ namespace controller {
                     .filter(s => !(s.s.flags & sprites.Flag.Destroyed));
         }
 
-        __update(dt: number) {
-            const dtms = (dt * 1000) | 0
+        __update(dtms: number) {
+            dtms = dtms | 0;
             this.buttons.forEach(btn => btn.__update(dtms));
         }
 

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -135,9 +135,9 @@ namespace controller {
             }
         }
 
-        __update(dtms: number) {
+        __update(dtmus: number) {
             if (!this._pressed) return;
-            this._pressedElasped += dtms / 1000;
+            this._pressedElasped += dtmus / 1000;
 
             // inital delay
             if (this._pressedElasped < this.repeatDelay)


### PR DESCRIPTION
Had two issues:

* this._pressedElapsed wasn't set until after the button was first released, so `+=`ing to it was resulting in NaN. any comparison with NaN results in false besides `!=`, so it always failed the first if in `__update`, and `NaN != NaN` is true so it repeated on each step no matter the `repeatDelay` and `repeatInterval` that was set

* the value being passed to `Controller.__update` was in ms, but was being multiplied by 1000 resulting in each button getting a value in μs instead of ms and updating 1000* too fast