### PR TITLE
Have the scene register controller handler on init

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -172,7 +172,7 @@ namespace controller {
         return _players.filter(ctrl => !!ctrl);
     }
 
-    interface ControlledSprite {
+    export interface ControlledSprite {
         s: Sprite;
         vx: number;
         vy: number;
@@ -189,7 +189,6 @@ namespace controller {
         playerIndex: number;
         buttons: Button[];
         private _id: number;
-        private _controlledSprites: ControlledSprite[];
         private _connected: boolean;
 
         // array of left,up,right,down,a,b,menu buttons
@@ -209,6 +208,14 @@ namespace controller {
             for (let i = 0; i < this.buttons.length; ++i)
                 this.buttons[i]._owner = this;
             addController(this);
+        }
+
+        get _controlledSprites(): ControlledSprite[] {
+            return game.currentScene().controlledSprites[this.playerIndex];
+        }
+
+        set _controlledSprites(cps: ControlledSprite[]) {
+            game.currentScene().controlledSprites[this.playerIndex] = cps;
         }
 
         get id() {

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -157,7 +157,6 @@ namespace controller {
     function addController(ctrl: Controller) {
         if (!_players) {
             _players = [];
-            game.currentScene().eventContext.registerFrameHandler(19, moveSprites);
         }
         _players[ctrl.playerIndex - 1] = ctrl;
     }
@@ -179,7 +178,7 @@ namespace controller {
         vy: number;
     }
 
-    function moveSprites() {
+    export function _moveSprites() {
         // todo: move to currecnt sceane
         control.enablePerfCounter("controller")
         players().forEach(ctrl => ctrl.__preUpdate());
@@ -326,8 +325,8 @@ namespace controller {
 
         /**
          * Register code run when a controller event occurs
-         * @param event 
-         * @param handler 
+         * @param event
+         * @param handler
          */
         //% weight=99 blockGap=8
         //% blockId=ctrlonevent block="on %controller %event"

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -81,6 +81,8 @@ namespace scene {
                 const dt = this.eventContext.deltaTime;
                 this.physicsEngine.move(dt);
             })
+            // controller update 19
+            this.eventContext.registerFrameHandler(19, controller._moveSprites);
             // user update 20
             // apply collisions 30
             this.eventContext.registerFrameHandler(30, () => {

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -39,6 +39,8 @@ namespace scene {
         overlapHandlers: OverlapHandler[];
         collisionHandlers: CollisionHandler[];
         particleSources: particles.ParticleSource[];
+        controlledSprites: controller.ControlledSprite[][];
+
         private _millis: number;
         private _data: any;
 
@@ -53,6 +55,7 @@ namespace scene {
             this.overlapHandlers = [];
             this.collisionHandlers = [];
             this.spritesByKind = [];
+            this.controlledSprites = [];
             this._data = {};
             this._millis = 0;
         }

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -592,9 +592,9 @@ namespace game {
             const currentState = controller.A.isPressed();
             if (currentState && !pressed) {
                 pressed = true;
-                done = true;
                 scene.setBackgroundImage(null); // GC it
                 game.popScene();
+                done = true;
             }
             else if (pressed && !currentState) {
                 pressed = false;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/686

The scene needs to track the controlled sprites and register the event handlers, but the controllers can stay global.