### PR TITLE
don't include pxt.json in files of pxt.json

### DIFF
--- a/libs/jacdac/pxt.json
+++ b/libs/jacdac/pxt.json
@@ -10,7 +10,6 @@
         "sensordriver.ts",
         "jacdac.svg",
         "pxtparts.json",
-        "pxt.json",
         "shims.d.ts",
         "actuator.ts",
         "messagebus.ts",


### PR DESCRIPTION
Don't explicitely add "pxt.json" in project.