### PR TITLE
implement for unicode display

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -406,7 +406,7 @@ class Sprite implements SpriteLike {
         let holdTextSeconds = 1.5;
         let bubblePadding = 4;
         let maxTextWidth = 100;
-        let font = image.font8;
+        let font = game.dialogFont || image.font8;
         let startX = 2;
         let startY = 2;
         let bubbleWidth = text.length * font.charWidth + bubblePadding;

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -13,10 +13,17 @@ enum DialogLayout {
     Full
 }
 
+enum FontType {
+    //% block=8px
+    font8,
+    //% block=12px
+    font12
+}
+
 namespace game {
     let dialogFrame: Image;
     let dialogCursor: Image;
-    let dialogFont: image.Font;
+    export let dialogFont: image.Font;
     let dialogTextColor: number;
 
     export class BaseDialog {
@@ -40,7 +47,7 @@ namespace game {
 
             this.frame = frame || dialogFrame || (dialogFrame = defaultFrame());
 
-            this.font = font || dialogFont || (dialogFont = image.font8);
+            this.font = dialogFont || font || (dialogFont = image.font8);
 
             this.cursor = cursor || dialogCursor || (dialogCursor = defaultCursorImage());
 
@@ -287,7 +294,7 @@ namespace game {
         maxSubOffset: number;
 
         constructor(width: number, height: number) {
-            super(width, height, defaultSplashFrame(), image.font8)
+            super(width, height, defaultSplashFrame())
             this.maxOffset = -1;
             this.maxSubOffset = -1;
             this.textColor = 1;
@@ -561,8 +568,20 @@ namespace game {
         dialogTextColor = Math.floor(Math.min(15, Math.max(0, color)));
     }
 
-    export function setDialogFont(font: image.Font) {
-        dialogFont = font;
+    /**
+     * Set font size, 12px will support unicode characters
+     *
+     * @param font the font type
+     */
+    //% blockId=game_dialog_set_dialog_font group="Dialogs"
+    //% block="set dialog font to %font"
+    export function setDialogFont(font: FontType) {
+        if (font === FontType.font8){
+            dialogFont = image.font8;
+        } else {
+            dialogFont = image.font12;
+        }
+        
     }
 
     /**

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -155,4 +155,25 @@ void updateScreen(Image_ img) {
 void updateStats(String msg) {
     // ignore...
 }
+
+
+//%
+void getUnicode(int ch, Buffer buf) {
+	// this function is target dependent
+    auto display = getWDisplay();
+    display->lcd.waitForSendDone();
+	/*
+    if (!display->fsMounted){
+        int ret = display->fs.mount();
+        if (ret == 0){
+            display->fp = display->fs.open("/unicode12.bin", 0x1);
+            display->fsMounted = true;
+        }
+    }
+    DMESG("show unicode %x", ch);
+    uint32_t bias = ch*24;
+    display->fp->seek(bias);
+    display->fp->read(buf->data, 24);
+	*/
+}
 } // namespace pxt

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -131,7 +131,7 @@ bool isValidImage(Buffer buf) {
 
     return true;
 }
-
+void getUnicode(int ch, Buffer buf);
 } // namespace pxt
 
 namespace ImageMethods {
@@ -869,6 +869,30 @@ void _drawIcon(Image_ img, Buffer icon, int xy, int c) {
     drawImageCore(img, ii, XX(xy), YY(xy), c);
     decrRC(ii);
 }
+
+//%
+void _drawUnicode(Image_ img, int ch, int xy, int c){
+    int x = XX(xy);
+    int y = YY(xy);
+    Buffer buf = mkBuffer(NULL, 32);
+    uint8_t * b = buf->data;
+    getUnicode(ch, buf);
+    for (int i=0;i<24;i+=2){
+        for (int j=7;j>-1;j--){
+            if ((b[i]>>j) & 0x1){
+                setPixel(img, x+7-j, y, c);
+            }
+        }
+        for (int j=7;j>-1;j--){
+            if ((b[i+1]>>j) & 0x1){
+                setPixel(img, x+8+7-j, y, c);
+            }
+        }
+        y+=1;
+    }
+
+}
+
 
 static void drawLineLow(Image_ img, int x0, int y0, int x1, int y1, int c) {
     int dx = x1 - x0;

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -58,6 +58,12 @@ interface Image {
      */
     //% helper=imageRotated
     rotated(deg: number): Image;
+
+    /**
+     * Draw unicode character using given color
+     */
+    //% helper=drawUnicode
+    drawUnicode(ch: number, x: number, y: number, c: color): void;
 }
 
 namespace helpers {
@@ -72,6 +78,9 @@ namespace helpers {
 
     //% shim=ImageMethods::_drawIcon
     function _drawIcon(img: Image, icon: Buffer, xy: number, c: color): void { }
+
+    //% shim=ImageMethods::_drawUnicode
+    function _drawUnicode(img: Image, ch: number, xy: number, c: color): void { }
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
@@ -88,6 +97,9 @@ namespace helpers {
     }
     export function imageDrawLine(img: Image, x: number, y: number, w: number, h: number, c: color): void {
         _drawLine(img, pack(x, y), pack(w, h), c)
+    }
+    export function drawUnicode(img: Image, ch: number, x: number, y: number, c: color): void {
+        _drawUnicode(img, ch, pack(x, y), c)
     }
     export function imageDrawRect(img: Image, x: number, y: number, w: number, h: number, c: color): void {
         if (w == 0 || h == 0) return

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -486,6 +486,31 @@ namespace pxsim.ImageMethods {
         }
     }
 
+    export function drawUnicode(img: RefImage, ch: number, x: number, y: number, color: number) {
+        img.makeWritable()
+        const canvas = document.createElement("canvas")
+        const ctx = canvas.getContext("2d");
+        ctx.font = "12px WenQuanYi";
+        ctx.fillStyle = "white";
+        canvas.width = 12;
+        canvas.height = 12;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillText(String.fromCharCode(ch), 0, 11);
+        let data32 = new Uint32Array(ctx.getImageData(0, 0, canvas.width, canvas.height).data.buffer);
+        for (let i = 0; i < data32.length; i++) {
+            if (data32[i] & 0xE0000000) {
+                let px = (i % canvas.width);
+                let py = ((i / canvas.width) | 0);
+                img.data[img.pix(x+px, y+py)] = img.color(color)
+            }
+        }
+        // console.log("draw unicode", ch, x, y);
+    }
+
+    export function _drawUnicode(img: RefImage, ch: number, xy: number, color: number) {
+        drawUnicode(img, ch, XX(xy), YY(xy), color)
+    }
+
     export function drawIcon(img: RefImage, icon: RefBuffer, x: number, y: number, color: number) {
         const img2 = icon.data
         if (!img2 || img2.length < 5 || img2[0] != 0xe1)

--- a/libs/screen/text.ts
+++ b/libs/screen/text.ts
@@ -169,6 +169,13 @@ f3000c12130d0000 04010e05051e1000 05010609191f0800 06010c1213131200 07010c121313
 19010e151d1a0000 41011f1412100000 4201100f14120000 43011f0205081f00 44011e03031c0000 5a0110140b030200
 5b0110140b030000 7901121a17130000 7a01121a17130000 7b01121b17120000 7c01121b17120000`,
     }
+
+    //% whenUsed
+    export const font12: Font = {
+        charWidth: 12,
+        charHeight: 12,
+        data: hex``
+    }
 }
 
 interface Image {
@@ -218,6 +225,13 @@ namespace helpers {
 
             if (ch < 32)
                 continue // skip control chars
+
+            // draw unicode, font load from somewhere elese
+            if (font == image.font12){
+                img.drawUnicode(ch, x, y, color);
+                x += font.charWidth
+                continue
+            }
 
             // decompose Korean characters
             let arr = [ch]


### PR DESCRIPTION
A new 12x12 font added for displaying unicode, use `set dialog font to 12px` to enable the feature.
Regarding the hardware implement, just modify `getUnicode` in `screen.cpp`. For me, I load the font.bin from a read-only spiflash fat fs.
here is some screenshoots:
![image](https://user-images.githubusercontent.com/3390845/52158546-50153480-26d4-11e9-8db8-42d22b1dfee9.png)

![image](https://user-images.githubusercontent.com/3390845/52158602-d6317b00-26d4-11e9-9dfb-666b9cc2ef43.png)

