### PR TITLE
allow standalone accelerometer

### DIFF
--- a/libs/accelerometer/accelerometer.cpp
+++ b/libs/accelerometer/accelerometer.cpp
@@ -110,6 +110,8 @@ codal::Accelerometer *getAccelerometer();
 
 void initAccelRandom() {
     auto acc = getAccelerometer();
+    if (!acc) return;
+
     for (int i = 0; i < 10; ++i) {
         acc->requestUpdate();
         if (acc->getY())
@@ -138,6 +140,8 @@ namespace input {
 //% weight=92 blockGap=12
 void onGesture(Gesture gesture, Action body) {
     auto acc = getAccelerometer();
+    if (!acc) return;
+
     acc->requestUpdate();
     int gi = (int)gesture;
     if (gi == ACCELEROMETER_EVT_3G && acc->getRange() < 3)
@@ -149,6 +153,8 @@ void onGesture(Gesture gesture, Action body) {
 
 int getAccelerationStrength() {
     auto acc = getAccelerometer();
+    if (!acc) return 0;
+
     float x = acc->getX();
     float y = acc->getY();
     float z = acc->getZ();
@@ -168,13 +174,16 @@ int getAccelerationStrength() {
 //% dimension.fieldOptions.columns=2
 //% weight=42 blockGap=8
 int acceleration(Dimension dimension) {
+    auto acc = getAccelerometer();
+    if (!acc) return 0;
+
     switch (dimension) {
     case Dimension::X:
-        return getAccelerometer()->getX();
+        return acc->getX();
     case Dimension::Y:
-        return getAccelerometer()->getY();
+        return acc->getY();
     case Dimension::Z:
-        return getAccelerometer()->getZ();
+        return acc->getZ();
     case Dimension::Strength:
         return getAccelerationStrength();
     }
@@ -190,11 +199,14 @@ int acceleration(Dimension dimension) {
 //% parts="accelerometer"
 //% group="More" weight=38
 int rotation(Rotation kind) {
+    auto acc = getAccelerometer();
+    if (!acc) return 0;
+
     switch (kind) {
     case Rotation::Pitch:
-        return getAccelerometer()->getPitch();
+        return acc->getPitch();
     case Rotation::Roll:
-        return getAccelerometer()->getRoll();
+        return acc->getRoll();
     }
     return 0;
 }
@@ -209,7 +221,10 @@ int rotation(Rotation kind) {
 //% parts="accelerometer"
 //% group="More" weight=15 blockGap=8
 void setAccelerometerRange(AcceleratorRange range) {
-    getAccelerometer()->setRange((int)range);
+    auto acc = getAccelerometer();
+    if (!acc) return;
+
+    acc->setRange((int)range);
 }
 
 } // namespace input

--- a/libs/accelerometer/accelhw.cpp
+++ b/libs/accelerometer/accelhw.cpp
@@ -61,7 +61,7 @@ class WAccel {
 
   public:
     Accelerometer *acc;
-    WAccel() : space(ACC_SYSTEM, ACC_UPSIDEDOWN, ACC_ROTATION) {
+    WAccel() : space(ACC_SYSTEM, ACC_UPSIDEDOWN, ACC_ROTATION), acc(NULL) {
         DMESG("ACCEL: mounting");
         auto sda = LOOKUP_PIN(ACCELEROMETER_SDA);
         auto scl = LOOKUP_PIN(ACCELEROMETER_SCL);
@@ -76,7 +76,6 @@ class WAccel {
             return;
         }
         auto accType = getConfig(CFG_ACCELEROMETER_TYPE, PXT_DEFAULT_ACCELEROMETER);
-        acc = NULL;
         switch (accType) {
 #if PXT_SUPPORT_LIS3DH
         case ACCELEROMETER_TYPE_LIS3DH:
@@ -105,26 +104,23 @@ class WAccel {
 #endif
         }
 
-        if (acc == NULL) {
+        if (NULL == acc) {
             if (LOOKUP_PIN(ACCELEROMETER_SDA))
                 target_panic(PANIC_CODAL_HARDWARE_CONFIGURATION_ERROR);
             else
                 DMESG("acc: invalid ACCELEROMETER_TYPE");
         }
-
-        if (acc) {
+        else {
             // acc->init(); - doesn't do anything
             acc->configure();
             acc->requestUpdate();
         }
     }
 };
-SINGLETON_IF_PIN(WAccel, ACCELEROMETER_SDA);
+SINGLETON(WAccel);
 
 codal::Accelerometer *getAccelerometer() {
-    auto acc = getWAccel();
-    if (acc) return acc->acc;
-    else return NULL;
+    return getWAccel()->acc;
 }
 
 } // namespace pxt

--- a/libs/accelerometer/accelhw.cpp
+++ b/libs/accelerometer/accelhw.cpp
@@ -65,7 +65,7 @@ class WAccel {
         DMESG("ACCEL: mounting");
         auto sda = LOOKUP_PIN(ACCELEROMETER_SDA);
         auto scl = LOOKUP_PIN(ACCELEROMETER_SCL);
-        if (!sda || !scl) { // use default i2c instead
+        if (NULL == sda || NULL == scl) { // use default i2c instead
             DMESG("accelerometer: using SDA, SCL");
             sda = LOOKUP_PIN(SDA);
             scl = LOOKUP_PIN(SCL);


### PR DESCRIPTION
If ACCELEREMETER_SDA/SCL not provided, default to SDA/SCL. 
If not configured properly, gracefully ignore accelerometer.