### PR TITLE
Let user override controller velocity when there is no input

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -177,6 +177,7 @@ namespace controller {
         s: Sprite;
         vx: number;
         vy: number;
+        _inputLastFrame: boolean;
     }
 
     export function _moveSprites() {
@@ -303,7 +304,7 @@ namespace controller {
             if (!this._controlledSprites) this._controlledSprites = [];
             let cp = this._controlledSprites.find(cp => cp.s.id == sprite.id);
             if (!cp) {
-                cp = { s: sprite, vx: vx, vy: vy }
+                cp = { s: sprite, vx: vx, vy: vy, _inputLastFrame: false }
                 this._controlledSprites.push(cp);
             }
             if (cp.vx && vx == 0) {
@@ -409,32 +410,46 @@ namespace controller {
             if (!this._controlledSprites) return;
 
             let deadSprites = false;
+            let svx: number;
+            let svy: number;
             this._controlledSprites.forEach(sprite => {
                 if (sprite.s.flags & sprites.Flag.Destroyed) {
                     deadSprites = true;
                     return;
                 }
+                svx = 0;
+                svy = 0;
 
                 if (sprite.vx) {
-                    sprite.s.vx = 0;
-
                     if (this.right.isPressed()) {
-                        sprite.s.vx = sprite.vx;
+                        svx += sprite.vx;
                     }
                     if (this.left.isPressed()) {
-                        sprite.s.vx = -sprite.vx;
+                        svx -=sprite.vx;
                     }
                 }
 
                 if (sprite.vy) {
-                    sprite.s.vy = 0;
-
                     if (this.down.isPressed()) {
-                        sprite.s.vy = sprite.vy;
+                        svy += sprite.vy;
                     }
                     if (this.up.isPressed()) {
-                        sprite.s.vy = -sprite.vy;
+                        svy -= sprite.vy;
                     }
+                }
+
+                if (sprite._inputLastFrame) {
+                    sprite.s.vx = 0;
+                    sprite.s.vy = 0;
+                }
+
+                if (svx || svy) {
+                    sprite.s.vx = svx;
+                    sprite.s.vy = svy;
+                    sprite._inputLastFrame = true;
+                }
+                else {
+                    sprite._inputLastFrame = false;
                 }
             });
 

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -285,9 +285,9 @@ namespace controller {
         }
 
         /**
-         * Control a sprite using the direction buttons from the controller. Note that this
-         * control will take over the vx and vy of the sprite and overwrite any changes
-         * made unless a 0 is passed.
+         * Control a sprite using the direction buttons from the controller. Note that this will overwrite
+         * the current velocity of the sprite whenever a directional button is pressed. To stop controlling
+         * a sprite, pass 0 for vx and vy.
          *
          * @param sprite The Sprite to control
          * @param vx The velocity used for horizontal movement when left/right is pressed


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-arcade/issues/755

Right now if you use the `moveSprite()` API, you can't ever change the velocity directly because it gets immediately overwritten (the controller takes complete control of the velocity even when buttons aren't being pressed). This change makes it so that it only controls the velocity when there is actual input.

Here's an example:

![image](https://user-images.githubusercontent.com/13754588/52751255-af602800-2fa3-11e9-8fb0-08364e762e5d.png)

In the current editor, nothing will happen when the apple and lemon overlap because the controller is controlling the lemon's velocity. With this change, you get this:


![new_ctrl](https://user-images.githubusercontent.com/13754588/52751340-f3ebc380-2fa3-11e9-948c-4b5282a22597.gif)

The pink arrows are the button's I'm pressing in that gif.


Also, I made it so that pressing directional buttons in opposite directions now cancels out the movement. Before we arbitrarily gave precedence to the up and left buttons.

@jwunderl @ChaseMor FYI
