### PR TITLE
Added black background to distinguish dialog footers

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -113,6 +113,9 @@ namespace game {
         if (subtitle)
             screen.print(subtitle, 8, top + 8 + font.charHeight + 2, screen.isMono ? 1 : 6, font);
         if (footer) {
+            const footerTop = screen.height - font.charHeight - 4;
+            screen.fillRect(0, footerTop, screen.width, font.charHeight + 4, 0);
+            screen.drawLine(0, footerTop, screen.width, footerTop, 1);
             screen.print(
                 footer,
                 screen.width - footer.length * font.charWidth - 8,


### PR DESCRIPTION
Fixes Microsoft/pxt-arcade#759

This adds a black bar to the footer of a dialog so that the footer text can be read more clearly.

![image](https://user-images.githubusercontent.com/13285164/52840875-72815780-30af-11e9-996b-0a10b48505da.png)