### PR TITLE
Give effects their own factories rather than shared across same effect

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -145,10 +145,9 @@ namespace effects {
 
     function createEffect(defaultParticlesPerSecond: number, defaultLifespan: number,
             factoryFactory: (anchor?: particles.ParticleAnchor) => particles.ParticleFactory): ParticleEffect {
-        const factory = factoryFactory();
-        if (!factory) return undefined;
         return new ParticleEffect(defaultParticlesPerSecond, defaultLifespan,
-                    (anchor: particles.ParticleAnchor, pps: number) => new particles.ParticleSource(anchor, pps, factory));
+                    (anchor: particles.ParticleAnchor, pps: number) =>
+                        new particles.ParticleSource(anchor, pps, factoryFactory()));
     }
 
     //% fixedInstance whenUsed block="spray"


### PR DESCRIPTION
Calling the factory early makes each source refer to the same factory, which leads to some unintuitive behaviors when the factory maintains state.

Easiest example of this is in the space destroyer game on the home page, when you fire the laser it creates a short radial effect. Currently, this will continue to rotate around weirdly each time the effect is invoked

![2019-02-19 17 28 16](https://user-images.githubusercontent.com/5615930/53059512-e0d96780-346b-11e9-8177-3306ace3f4df.gif)

it should just start from scratch each time, sending particles in the same direction.

![2019-02-19 17 28 39](https://user-images.githubusercontent.com/5615930/53059540-01092680-346c-11e9-8f3c-c59bb27a8153.gif)

Example of effects 'synchronizing' when called multiple times: https://makecode.com/_H1hgpi3g4HH2

Current behavior (notice it speed up instead of creating a second halo, and left and right halo both keep pace with eachother):

![2019-02-19 17 21 03](https://user-images.githubusercontent.com/5615930/53059145-c488fb00-346a-11e9-89dc-71a401476100.gif)

After this change (notice that the radials 'start' at the beginning, rather than where the previous one is):

![2019-02-19 17 14 55](https://user-images.githubusercontent.com/5615930/53059094-8f7ca880-346a-11e9-809b-f75eccf13fae.gif)
