### PR TITLE
Servo docs update

### DIFF
--- a/libs/servo/docs/reference/servos.md
+++ b/libs/servo/docs/reference/servos.md
@@ -1,0 +1,26 @@
+# Servos
+
+Rotate and run servos connected to the pins.
+
+```cards
+servos.P0.setPulse(1500)
+servos.P0.setAngle(90)
+servos.P0.run(50)
+servos.P0.stop()
+servos.P0.setRange(0, 180)
+servos.P0.setStopOnNeutral(false)
+```
+
+## See also
+
+[set pulse](/reference/servos/set-pulse),
+[set angle](/reference/servos/set-angle),
+[run](/reference/servos/run),
+[stop](/reference/servos/stop),
+[set range](/reference/servos/set-range),
+[set stop on neutral](/reference/servos/set-stop-on-neutral)
+
+
+```package
+servo
+```

--- a/libs/servo/docs/reference/servos/run.md
+++ b/libs/servo/docs/reference/servos/run.md
@@ -1,0 +1,32 @@
+# run
+
+Tell a continuous rotation servo to turn at a certain speed.
+
+```sig
+servos.P0.run(50)
+```
+
+A continuous rotation servo can turn both clockwise and counter-clockwise. They rotate at a speed from stopped to maximum rotation speed. Normally, a continuous rotation servo interprets  an angle value as a speed value. But, by using ``||servos:run||`` though, you can use a speed percentage value to turn the servo from no speed to full speed (`0` to `100` percent). Also, for clockwise rotation, the speed value used is a positive number, speed > 0. If you want to turn the servo in the other direction (counter-clockwise), use a negative percentage value.
+
+## Parameters
+
+* **speed**: a [number](types/number) which is the percentage (`0` to `100`) of speed to turn the servo at. Use a positive value (speed > 0) to go clockwise and use a negative value to turn counter-clocwise.
+
+## Example
+
+Connect a servo to pin `P0`. Rotate the servo clockwise at `75` percent of full speed. Wait `3` seconds and then stop the servo.
+
+```blocks
+servos.P0.run(75)
+basic.pause(3000)
+servos.P0.run(0)
+```
+
+## See also
+
+[set pulse](/reference/servos/set-pulse),
+[set angle](/reference/servos/set-angle)
+
+```package
+servo
+```

--- a/libs/servo/docs/reference/servos/set-angle.md
+++ b/libs/servo/docs/reference/servos/set-angle.md
@@ -1,0 +1,55 @@
+# set Angle
+
+Tell a servo to rotate to some angle.
+
+```sig
+servos.P0.setAngle(90)
+```
+
+Servos turn a shaft in one of two of directions by an amount of angle in degrees. With a servo, you are using just 180 degrees to position an arm, gear, or wheel that is connected to the shaft. The position at 90 degrees is the base, or neutral position. To turn the servo shaft left (counter-clockwise) you write to it a number of degrees to the between 0 and 90. The `0` degree spot is all the way left and any other number up to `90` is somewhere between left and the neutral position. The same thing works for going all the way to the right (clockwise). All the way to the right is `180` degrees.
+
+### Continuous rotation
+
+Now, there is another type of servo called a _continuous rotation_ servo that might look the same as a regular servo. It's different because the shaft doesn't stop at a particular position in degrees. In this case, the number you write to the servo is not degrees but a speed number. The shaft keeps rotating if you write a number other than `90` to the servo. Instead of being an angle of degrees, the number is a speed rating in one of the directions. The number `0` is full speed rotating to the left and `180` is full speed rotating to the right. The number `90` is no rotation in any direction.
+
+An easier way to run a continuous rotation servo is to just use the [run](/reference/servos/run) function with a speed percentage value.
+
+## Parameters
+
+* **degrees**: a [number](types/number) for shaft angle or servo speed, depends on your servo type:
+> * _regular servo_: the number of degrees of angle to turn the shaft.
+
+>> * `90` is the neutral, or center, position.
+>> * `90` to `0`, the shaft turns to a position towards the left.
+>> * `0` is all the way turned to the left.
+>> * `90` to `180`, the shaft to a position towards the right.
+>> * `180` is all the way turned to the right.
+
+> * _continuous rotation_: the speed to turn the shaft in one direction or the other.
+>> * `0` full speed rotating to the _left_.
+>> * `90` to `0`, the shaft spins faster rotating to the _left_ as the number goes to `0`.
+>> * `90` no speed, shaft doesn't turn.
+>> * `90` to `180`, the shaft spins faster rotating to the _right_ as the number reaches `180`.
+>> * `180` full speed rotating to the _right_.
+
+## Example
+
+Connect a servo to pin `P0`. Wag (rotate right and left) the arm on the servo shaft 45 degrees in each direction for 5 times.
+
+```blocks
+for (let i = 0; i < 5; i++) {
+    servos.P0.setAngle(135)
+    basic.pause(500)
+    servos.P0.setAngle(45)
+    basic.pause(500)
+}
+```
+
+## See also
+
+[set pulse](/reference/servos/set-pulse),
+[run](/reference/servos/run)
+
+```package
+servo
+```

--- a/libs/servo/docs/reference/servos/set-pulse.md
+++ b/libs/servo/docs/reference/servos/set-pulse.md
@@ -1,0 +1,55 @@
+# set Pulse
+
+Write a pulse to a servo with your own pulse time.
+
+```sig
+servos.P0.setPulse(2000)
+```
+
+A servo turns a shaft by an amount of angle or speed that it reads from a pulse signal. A digital
+pulse signal can have only two values, high and low. How do you do you tell the servo how much
+to turn the shaft if there are only two values to use?
+
+### Servo angle
+
+The trick is to use the duration (the amount of time the pulse is on) as a way to tell the servo
+how much to turn the shaft. Servos use different, but really short, amounts of time to mean how much the shaft will turn or how fast it rotates in a direction. Most hobby servos use a pulse that lasts between 1 millisecond and 2 milliseconds to tell it how much to turn. You see that half of that amount of time is 0.5 milliseconds. A 0.5 millisecond pulse is the amount of time that tells the servo to stay in its neutral position. A 1 millisecond pulse means that the servo shaft is turned all the way to the left, usually called the 0 degree position. a 2 millisecond pulse tells the servo to turn all the way to the right, the 180 degree position.
+
+So that you can move the servo shaft very precisely, you get to use microseconds for the pulse time. Remember to multiply the millisecond numbers by 1000 when you pulse the servo. The neutral position, for example, is 1500 microseconds. The servo moves the shaft all the way to the left with a pulse of 1000 microseconds. All the way to the right is a pulse that is 2000 microseconds.
+
+### Continuous rotation
+
+There is another type of servo called a _continuous rotation_ servo that might look the same as a regular servo. It's different because the shaft doesn't stop at a particular position. In this case, the pulse you send to the servo doesn't mean position, but instead it's a speed number. The shaft keeps rotating if you send a pulse number other than `1500` milliseconds to the servo. Instead of being an angle of rotation, the duration is a speed rating in one of the directions. The `1000` microseconds is full speed rotating to the left and `2000` microseconds is full speed rotating to the right. The number `1500` microseconds is no rotation in any direction.
+
+#### ~hint
+
+Most, but not all, hobby servos that are made use the 1 to 2 millisecond pulse time to control the shaft rotation. Some might have smaller amount of rotation or use different pulse times for positions and speed. If you have one of those types of servos, find out what pulse times move the shaft where you want and use them in ``||servos:set servo pulse||``.
+
+#### ~
+
+## Parameters
+
+* **micros**: a [number](types/number) that is the length of the pulse sent to the servo, in microseconds. For the different types of servos, pulse time means:
+> * _regular servo_: the amount of rotation to turn the shaft.
+>>Most often, `1000` is full rotation to the left, `2000` is full rotation to the right, and `1500` is go to neutral.
+> * _continuous rotation_: the speed to turn the shaft in one direction or the other.
+>>Most often, `1000` is turn full speed to the left, `2000` is full speed to the right, and `1500` stopped.
+
+## Example #example
+
+Turn a standard servo connected to pin `P0` by 135 degrees. Wait for 3 seconds and set it back to neutral.
+
+```blocks
+servos.P0.setPulse(1750)
+basic.pause(3000)
+servos.P0.setAngle(90)
+```
+
+## See also
+
+[set angle](/reference/servos/set-angle),
+[run](/reference/servos/run)
+
+```package
+servo
+```

--- a/libs/servo/docs/reference/servos/set-range.md
+++ b/libs/servo/docs/reference/servos/set-range.md
@@ -1,0 +1,36 @@
+# set Range
+
+Set the minimum and maximum rotation angles for a servo.
+
+```sig
+servos.P0.setRange(0, 180)
+```
+
+If you want to limit the rotation range of a servo you can set it's minimum and maximum rotation angle. The minimum angle limit is set in degrees from `0` to `90`. The maximum rotation angle is set in degress from `90` to `180`.
+
+## Parameters
+
+* **minAngle**: a [number](types/number) of degrees to set as the minimum rotation angle, `0` - `90` degrees,
+* **maxAngle**: a [number](types/number) of degrees to set as the maximum rotation angle, `90` - `180` degrees,
+
+## Example
+
+Connect a servo to pin `P0`. Try to rotate the servo past it range angles.
+
+```blocks
+servos.P0.setRange(30, 150)
+for (let i = 0; i < 5; i++) {
+    servos.P0.setAngle(180)
+    basic.pause(500)
+    servos.P0.setAngle(0)
+    basic.pause(500)
+}
+```
+
+## See also
+
+[set angle](/reference/servos/set-angle)
+
+```package
+servo
+```

--- a/libs/servo/docs/reference/servos/set-stop-on-neutral.md
+++ b/libs/servo/docs/reference/servos/set-stop-on-neutral.md
@@ -1,0 +1,33 @@
+# set Stop On Neutral
+
+Set a servo to return to the neutral position when it stops.
+
+```sig
+servos.P0.setStopOnNeutral(false)
+```
+
+When telling a servo to stop, instead just stopping an the current rotation angle, you can have the servo return to the neutral position (`90` degrees) when stopped.
+
+## Parameters
+
+* **on**: a [boolean](types/boolean) which, when `true`, sets the servo to return to the neutral position when stopped. Otherwise, if `false`, the servo will remain at its current position when stopped.
+
+## Example
+
+Connect a servo to pin `P0`. Set the servo to go to neutral when stopped. Rotate the servo clockwise at `75` percent of full speed. Wait `3` seconds and then stop the servo.
+
+```blocks
+servos.P0.setStopOnNeutral(true)
+servos.P0.run(75)
+basic.pause(3000)
+servos.P0.run(0)
+```
+
+## See also
+
+[run](/reference/servos/run),
+[stop](/reference/servos/stop)
+
+```package
+servo
+```

--- a/libs/servo/docs/reference/servos/stop.md
+++ b/libs/servo/docs/reference/servos/stop.md
@@ -1,0 +1,28 @@
+# stop
+
+Stop sending commands to the servo so that its rotation will stop at the current position.
+
+```sig
+servos.P0.stop()
+```
+
+A servo is stopped by not sending anymore commands to drive the rotation angle. This lets you stop a servo at its current postion which is useful for stopping a continuous rotation servo. The servo drive is stopped but it's shaft has no force on it to lock the current position.
+
+## Example
+
+Connect a servo to pin `P0`. Rotate the servo clockwise at `75` percent of full speed. Wait `3` seconds and then stop the servo.
+
+```blocks
+servos.P0.run(75)
+basic.pause(3000)
+servos.P0.stop()
+```
+
+## See also
+
+[run](/reference/servos/run),
+[set angle](/reference/servos/set-angle)
+
+```package
+servo
+```

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -64,9 +64,11 @@ namespace servos {
                 this.setAngle(degrees);
         }
 
-        /*
+        /**
          * Set the pulse width to the servo in microseconds
+         * @param micros the width of the pulse in microseconds
          */
+
         //% weight=10 help=servos/set-pulse
         //% blockId=servoservosetpulse block="set %servo pulse to %micros μs"
         //% micros.min=500 micros.max=2500
@@ -87,11 +89,11 @@ namespace servos {
 
         }
 
-        /*
+        /**
          * Stop sending commands to the servo so that its rotation will stop at the current position.
-         * On a normal servo this will stop the servo where it is, rather than return it to neutral position.
-         * It will also not provide any holding force.
          */
+        // On a normal servo this will stop the servo where it is, rather than return it to neutral position.
+        // It will also not provide any holding force.
         //% weight=10 help=servos/stop
         //% blockId=servoservostop block="stop %servo"
         //% servo.fieldEditor="gridpicker"

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -88,7 +88,7 @@ namespace servos {
         }
 
         /*
-         * Stop sending commands to the servo. 
+         * Stop sending commands to the servo so that its rotation will stop at the current position.
          * On a normal servo this will stop the servo where it is, rather than return it to neutral position.
          * It will also not provide any holding force.
          */
@@ -119,7 +119,7 @@ namespace servos {
         }
 
         /**
-         * Configure the range support by the servo between 0 and 180
+         * Set the possible rotation range angles for the servo between 0 and 180
          * @param minAngle the minimum angle from 0 to 90
          * @param maxAngle the maximum angle from 90 to 180
          */
@@ -139,7 +139,7 @@ namespace servos {
         }
 
         /**
-         * Sets a mode where the servo is stopped when the angle is neutral (0%).
+         * Set a servo stop mode so it will stop when the rotation angle is in the neutral position, 90 degrees.
          * @param on true to enable this mode
          */
         //% help=servos/set-stop-on-neutral


### PR DESCRIPTION
- [x] Touch up the jsDoc descriptions.
- [x] Port the servo docs from [pxt-microbit](https://github.com/Microsoft/pxt-microbit/tree/master/libs/servo/docs/reference/servos)
- [x] Add pages for **stop**, **setRange**, and **setStopOnNeutral**.

**Comment**: Seems to be a decompile to field editor problem in docs:

![image](https://user-images.githubusercontent.com/27789908/53612900-217e6280-3b89-11e9-9b90-a0ba92c33629.png)

RE: #720 