### PR TITLE
add priority ranking for sources (don't destroy scene effects)

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -108,6 +108,7 @@ namespace effects {
 
             this.endScreenEffect();
             this.source = this.sourceFactory(new SceneAnchor(), particlesPerSecond ? particlesPerSecond : this.sceneDefaultRate);
+            this.source.priority = 10;
             if (duration)
                 this.source.lifespan = duration;
         }

--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -327,7 +327,7 @@ namespace particles {
             sources[i]._update(dt);
         }
     }
-    
+
     function pruneParticles() {
         const sources = particleSources();
         if (sources)

--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -43,6 +43,13 @@ namespace particles {
     export class ParticleSource implements SpriteLike {
         private _z: number;
 
+        /**
+         * A relative ranking of this sources priority
+         * When necessary, a source with a lower priority will
+         * be culled before a source with a higher priority.
+         */
+        priority: number;
+
         id: number;
         _dt: number;
         /**
@@ -99,6 +106,7 @@ namespace particles {
             this.lifespan = undefined;
             this._dt = 0;
             this.z = 0;
+            this.priority = 0;
             this.setFactory(factory || particles.defaultFactory);
             sources.push(this);
             scene.addSprite(this);
@@ -315,6 +323,7 @@ namespace particles {
         for (let i = 0; i < sources.length; i++) {
             sources[i]._update(dt);
         }
+        sources.sort((a, b) => (a.priority - b.priority || a.id - b.id));
     }
 
     function pruneParticles() {

--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -94,6 +94,7 @@ namespace particles {
 
             // remove and immediately destroy oldest source if over MAX_SOURCES
             if (sources.length > MAX_SOURCES) {
+                sortSources();
                 const removedSource = sources.shift();
                 removedSource.clear();
                 removedSource.destroy();
@@ -316,6 +317,8 @@ namespace particles {
 
     function updateParticles() {
         const sources = particleSources();
+        sortSources();
+
         const time = control.millis();
         const dt = time - lastUpdate;
         lastUpdate = time;
@@ -323,13 +326,17 @@ namespace particles {
         for (let i = 0; i < sources.length; i++) {
             sources[i]._update(dt);
         }
-        sources.sort((a, b) => (a.priority - b.priority || a.id - b.id));
     }
-
+    
     function pruneParticles() {
         const sources = particleSources();
         if (sources)
-            sources.slice(0, sources.length).forEach(s => s._prune());
+        sources.slice(0, sources.length).forEach(s => s._prune());
+    }
+    
+    function sortSources() {
+        const sources = particleSources();
+        sources.sort((a, b) => (a.priority - b.priority || a.id - b.id));
     }
 
     /**

--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -331,7 +331,7 @@ namespace particles {
     function pruneParticles() {
         const sources = particleSources();
         if (sources)
-        sources.slice(0, sources.length).forEach(s => s._prune());
+            sources.slice(0, sources.length).forEach(s => s._prune());
     }
     
     function sortSources() {


### PR DESCRIPTION
Add a relative priority ranking, so that developers can choose which effects should be destroyed when removing effects is deemed necessary so that the game doesn't crash.

This is used to give scene effects a higher priority, so that they are not destroyed when too many smaller effects are triggered at once

![arcade-screenshot 5](https://user-images.githubusercontent.com/5615930/53837385-4dae3080-3f47-11e9-9964-53e9fddd6a29.png)

![2019-03-05 12 53 42](https://user-images.githubusercontent.com/5615930/53837354-3cfdba80-3f47-11e9-95a2-67dd2c37f05b.gif)

I didn't add in a dirty bit for sorting the array for now (e.g. scene's ``Flag.NeedsSorting``), as the array being sorted will never have more than ``MAX_SOURCES`` (7) elements for the time being. If / when a PID controller is implemented for controlling particle effects, probably would want to revisit that.

@pelikhan for handling scene effects turning off when the player causes too many effects to be created at once: here's space destroyer with firing changed to repeat and star field effect on

![2019-03-05 13 10 47](https://user-images.githubusercontent.com/5615930/53837763-358ae100-3f48-11e9-9582-e23b95e4bcd7.gif)
