### PR TITLE
Fix blockly category on sprite image blocks

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -182,7 +182,7 @@ class Sprite implements SpriteLike {
         this.lifespan = undefined;
         this._overlappers = [];
     }
-    
+
     __serialize(offset: number): Buffer {
         const buf = control.createBuffer(offset + 12);
         let k = offset;
@@ -198,7 +198,7 @@ class Sprite implements SpriteLike {
     /**
      * Gets the current image
      */
-    //% group="Lifecycle"
+    //% group="Image"
     //% blockId=spriteimage block="%sprite(mySprite) image"
     //% weight=8
     get image(): Image {
@@ -208,7 +208,7 @@ class Sprite implements SpriteLike {
     /**
      * Sets the image on the sprite
      */
-    //% group="Lifecycle"
+    //% group="Image"
     //% blockId=spritesetimage block="set %sprite(mySprite) image to %img=screen_image_picker"
     //% weight=7 help=sprites/sprite/set-image
     setImage(img: Image) {
@@ -725,7 +725,7 @@ class Sprite implements SpriteLike {
     destroy(effect?: effects.ParticleEffect, duration?: number) {
         if (this.flags & sprites.Flag.Destroyed)
             return;
-        
+
         if (effect) {
             effect.destroy(this, duration);
             return;


### PR DESCRIPTION
Before:
<image src="https://user-images.githubusercontent.com/6453828/53916365-56dff000-4062-11e9-810b-a35ecb70101c.png" height="400" />

After:
<image src="https://user-images.githubusercontent.com/6453828/53916375-5e9f9480-4062-11e9-9031-61eac7265bda.png" height="400" />