### PR TITLE
don't change sprite velocities in moveSprite when set to 0

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -419,6 +419,7 @@ namespace controller {
                     deadSprites = true;
                     return;
                 }
+
                 svx = 0;
                 svy = 0;
 
@@ -441,13 +442,13 @@ namespace controller {
                 }
 
                 if (sprite._inputLastFrame) {
-                    sprite.s.vx = 0;
-                    sprite.s.vy = 0;
+                    if (sprite.vx) sprite.s.vx = 0;
+                    if (sprite.vy) sprite.s.vy = 0;
                 }
 
                 if (svx || svy) {
-                    sprite.s.vx = svx;
-                    sprite.s.vy = svy;
+                    if (sprite.vx) sprite.s.vx = svx;
+                    if (sprite.vy) sprite.s.vy = svy;
                     sprite._inputLastFrame = true;
                 }
                 else {


### PR DESCRIPTION
#704 made it so the controller api only applies when pressed, but also made it always apply when pressed, which changes the nice behavior that it ignores the axes that are 0 (e.g. the jumping in this game https://makecode.com/_8ajcjogxp6hF gets messed up as it continually overrides the ``vy`` whenever the left or right button was pressed, setting vy to 0)

This just returns the behavior of the current beta branch - don't change a sprite's ``vx`` or ``vy`` if the speed is set to 0 for that value in moveSprite