### PR TITLE
Do not maintain animations for destroyed sprites

### DIFF
--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -4,7 +4,7 @@
 //% color="#03AA74" weight=78 icon="\uf021"
 namespace animation {
     //Handles all the updates
-    let _onAnimUpdate: (() => void)[] = null;
+    let animations: Animation[] = null;
 
     export class Animation {
 
@@ -27,15 +27,13 @@ namespace animation {
         }
 
         _init() {
-            if (!_onAnimUpdate) {
-                _onAnimUpdate = [];
+            if (!animations) {
+                animations = [];
                 game.eventContext().registerFrameHandler(scene.ANIMATION_UPDATE_PRIORITY, () => {
-                    _onAnimUpdate.forEach(element => {
-                        element();
-                    });
+                    animations.forEach(anim => anim.update());
                 });
             }
-            _onAnimUpdate.push(() => this.update());
+            animations.push(this);
         }
 
         update() {

--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -5,10 +5,10 @@
 namespace animation {
     //Handles all the updates
     let _onAnimUpdate: (() => void)[] = null;
-    let _onSpriteUpdate: (() => void)[] = null;
 
     export class Animation {
 
+        sprites: Sprite[];
         frames: Image[];
         index: number;
         interval: number;
@@ -20,6 +20,7 @@ namespace animation {
             this.index = -1;
             this.action = action;
             this.frames = [];
+            this.sprites = [];
             this.lastTime = control.millis();
 
             this._init();
@@ -44,6 +45,18 @@ namespace animation {
                 this.index = (this.index + 1) % this.frames.length;
                 this.lastTime = currentTime;
             }
+            
+            this.sprites = this.sprites.filter(sprite => !(sprite.flags & sprites.Flag.Destroyed));
+
+            this.sprites.forEach(sprite => {
+                if (sprite._action === this.action) {
+                    let newImage = this.getImage();
+                    //Update only if the image has changed
+                    if (sprite.image !== newImage) {
+                        sprite.setImage(newImage);
+                    }
+                }
+            });
         }
 
         getImage() {
@@ -71,6 +84,12 @@ namespace animation {
         //% help=animation/add-animation
         addAnimationFrame(frame: Image) {
             this.frames[++this.index] = frame;
+        }
+
+        registerSprite(sprite: Sprite) {
+            if (this.sprites.indexOf(sprite) === -1) {
+                this.sprites.push(sprite);
+            }
         }
 
     }
@@ -110,27 +129,7 @@ namespace animation {
     //% weight=30
     //% help=animation/attach-animation
     export function attachAnimation(sprite: Sprite, set: Animation) {
-        if (!_onSpriteUpdate) {
-            //First attach register the update call back.
-            //Priority 16 is slightly lower than 15 for animation update loop.
-            //This is allow the animation to complete, so we have the new display ready to go.
-            _onSpriteUpdate = [];
-            game.eventContext().registerFrameHandler(scene.SPRITE_ANIMATION_UPDATE_PRIORITY, () => {
-                _onSpriteUpdate.forEach(element => {
-                    element();
-                });
-            });
-        }
-
-        _onSpriteUpdate.push(() => {
-            if (sprite._action === set.action) {
-                let newImage = set.getImage();
-                //Update only if the image has changed
-                if (sprite.image !== newImage) {
-                    sprite.setImage(newImage)
-                }
-            }
-        })
+        set.registerSprite(sprite);
     }
 
     /**

--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -4,7 +4,7 @@
 //% color="#03AA74" weight=78 icon="\uf021"
 namespace animation {
     //Handles all the updates
-    let animations: Animation[] = null;
+    let animations: Animation[];
 
     export class Animation {
 

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -27,7 +27,6 @@ namespace scene {
     export const TILEMAP_PRIORITY = 9;
     export const PHYSICS_PRIORITY = 10;
     export const ANIMATION_UPDATE_PRIORITY = 15;
-    export const SPRITE_ANIMATION_UPDATE_PRIORITY = 16;
     export const UPDATE_INTERVAL_PRIORITY = 19;
     export const UPDATE_PRIORITY = 20;
     export const CONTROLLER_SPRITES_PRIORITY = 19;


### PR DESCRIPTION
I was getting some pretty poor frame rates on hardware in a platformer I'm making as games went on even when the number of elements on screen was relatively static.

Looks like the primary cause was a memory leak in animations, as the updates were keeping old sprites around and trying to update them forever rather than ignoring them after they were destroyed. For example: https://makecode.com/_A6i4uucDtdpu

So this fixes the memory leak