### PR TITLE
Insert kitronik servo guide link

### DIFF
--- a/libs/servo/docs/reference/servos.md
+++ b/libs/servo/docs/reference/servos.md
@@ -2,6 +2,12 @@
 
 Rotate and run servos connected to the pins.
 
+### ~ hint
+
+To better understand how servos work and how they are controlled, take a few minutes to read this [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf).
+
+### 
+
 ```cards
 servos.P0.setPulse(1500)
 servos.P0.setAngle(90)
@@ -20,6 +26,7 @@ servos.P0.setStopOnNeutral(false)
 [set range](/reference/servos/set-range),
 [set stop on neutral](/reference/servos/set-stop-on-neutral)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
 
 ```package
 servo

--- a/libs/servo/docs/reference/servos/run.md
+++ b/libs/servo/docs/reference/servos/run.md
@@ -27,6 +27,8 @@ servos.P0.run(0)
 [set pulse](/reference/servos/set-pulse),
 [set angle](/reference/servos/set-angle)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
 ```package
 servo
 ```

--- a/libs/servo/docs/reference/servos/set-angle.md
+++ b/libs/servo/docs/reference/servos/set-angle.md
@@ -50,6 +50,8 @@ for (let i = 0; i < 5; i++) {
 [set pulse](/reference/servos/set-pulse),
 [run](/reference/servos/run)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
 ```package
 servo
 ```

--- a/libs/servo/docs/reference/servos/set-pulse.md
+++ b/libs/servo/docs/reference/servos/set-pulse.md
@@ -50,6 +50,8 @@ servos.P0.setAngle(90)
 [set angle](/reference/servos/set-angle),
 [run](/reference/servos/run)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
 ```package
 servo
 ```

--- a/libs/servo/docs/reference/servos/set-range.md
+++ b/libs/servo/docs/reference/servos/set-range.md
@@ -31,6 +31,8 @@ for (let i = 0; i < 5; i++) {
 
 [set angle](/reference/servos/set-angle)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
 ```package
 servo
 ```

--- a/libs/servo/docs/reference/servos/set-stop-on-neutral.md
+++ b/libs/servo/docs/reference/servos/set-stop-on-neutral.md
@@ -28,6 +28,8 @@ servos.P0.run(0)
 [run](/reference/servos/run),
 [stop](/reference/servos/stop)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
 ```package
 servo
 ```

--- a/libs/servo/docs/reference/servos/stop.md
+++ b/libs/servo/docs/reference/servos/stop.md
@@ -23,6 +23,8 @@ servos.P0.stop()
 [run](/reference/servos/run),
 [set angle](/reference/servos/set-angle)
 
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
 ```package
 servo
 ```


### PR DESCRIPTION
Include a link to the Kitronik servo guide in the servo pages.

https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf