### PR TITLE
Fix private/export modifier on types

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -8,7 +8,7 @@
 //% blockGap=8
 namespace info {
 
-    enum Visibility {
+    export enum Visibility {
         None = 0,
         Countdown = 1 << 0,
         Score = 1 << 1,

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -84,7 +84,7 @@ namespace music {
     //% fixedInstances
     export class Melody {
         _text: string;
-        _player: MelodyPlayer;
+        private _player: MelodyPlayer;
 
         constructor(text: string) {
             this._text = text


### PR DESCRIPTION
MelodyPlayer class is private, and I guess should be.

Visibilty is exposed in PlayerInfo and I guess should be.