### PR TITLE
Gamepad button enum fix

### DIFF
--- a/libs/gamepad/gamepad.ts
+++ b/libs/gamepad/gamepad.ts
@@ -12,7 +12,7 @@ enum GamepadButton {
     LeftBumper = 4,
     //% block="right bumper"
     //% blockIdentity=gamepad.button enumval=5
-    RightBumer = 5,
+    RightBumper = 5,
     //% block="left trigger"
     //% blockIdentity=gamepad.button enumval=6
     LeftTrigger = 6,

--- a/libs/jacdac-drivers/gamepadclient.ts
+++ b/libs/jacdac-drivers/gamepadclient.ts
@@ -12,7 +12,7 @@ enum JDGamepadButton {
     LeftBumper = 4,
     //% block="right bumper"
     //% enumval=5
-    RightBumer = 5,
+    RightBumper = 5,
     //% block="left trigger"
     //% enumval=6
     LeftTrigger = 6,


### PR DESCRIPTION
Unfortunate typo in ``GamepadButton`` enum. Don't take this if it's too much of a breaker.