### PR TITLE
Add the option to change separator in datalogger

### DIFF
--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -1,3 +1,12 @@
+enum LogSeparator {
+    //% block="tab"
+    Tab,
+    //% block="comma"
+    Comma,
+    //% block="semicolon"
+    Semicolon
+};
+
 /**
  * A tiny data logging framework
  */
@@ -22,7 +31,7 @@ namespace datalogger {
         /**
          * Appends a row of data
          */
-        appendRow(values: number[]): void { }
+        appendRow(values: string[]): void { }
         /**
          * Flushes any buffered data
          */
@@ -80,10 +89,11 @@ namespace datalogger {
                     }
                 }
                 // append row
-                _storage.appendRow(_row);
+                let textRow: string[] = _row.map(x => "" + x);
+                _storage.appendRow(textRow);
                 if (_console) {
                     // drop time
-                    console.log(_row.slice(1, _row.length).join(','));
+                    console.log(textRow.slice(1, _row.length).join(','));
                 }
                 // clear values
                 _row = undefined;
@@ -185,5 +195,21 @@ namespace datalogger {
     //% enabled.shadow=toggleOnOff
     export function sendToConsole(enabled: boolean) {
         _console = enabled;
+    }
+
+    /**
+     * Set the character used to separate values in a row.
+     * @param separator the value separator character, eg: "\t"
+     */
+    //% group="Configuration"
+    //% blockId="datalogSeparator" block="data logger set separator $separator"
+    export function setSeparator(separator: LogSeparator) {
+        if (!_enabled) {
+            switch(separator) {
+                case LogSeparator.Tab: SEPARATOR = "\t"; break;
+                case LogSeparator.Comma: SEPARATOR = ","; break;
+                case LogSeparator.Semicolon: SEPARATOR = ";"; break;
+            }
+        }
     }
 }

--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -207,6 +207,7 @@ namespace datalogger {
      */
     //% group="Configuration"
     //% blockId="datalogSeparator" block="data logger set separator $separator"
+    //% help=datalogger/set-separator
     export function setSeparator(separator: LogSeparator) {
         if (!_enabled) {
             SEPARATOR = String.fromCharCode(separator);

--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -1,10 +1,10 @@
 enum LogSeparator {
     //% block="tab"
-    Tab,
+    Tab = 0x09,
     //% block="comma"
-    Comma,
+    Comma = 0x2c,
     //% block="semicolon"
-    Semicolon
+    Semicolon = 0x3b
 };
 
 /**
@@ -31,7 +31,7 @@ namespace datalogger {
         /**
          * Appends a row of data
          */
-        appendRow(values: number[]): void { }
+        appendRow(values: string[]): void { }
         /**
          * Flushes any buffered data
          */
@@ -89,10 +89,11 @@ namespace datalogger {
                     }
                 }
                 // append row
-                _storage.appendRow(_row);
+                let textRow: string[] = _row.map(x => "" + x);
+                _storage.appendRow(textRow);
                 if (_console) {
                     // drop time
-                    console.log(_row.slice(1, _row.length).join(','));
+                    console.log(textRow.slice(1, _row.length).join(','));
                 }
                 // clear values
                 _row = undefined;
@@ -204,11 +205,7 @@ namespace datalogger {
     //% blockId="datalogSeparator" block="data logger set separator $separator"
     export function setSeparator(separator: LogSeparator) {
         if (!_enabled) {
-            switch(separator) {
-                case LogSeparator.Tab: SEPARATOR = "\t"; break;
-                case LogSeparator.Comma: SEPARATOR = ","; break;
-                case LogSeparator.Semicolon: SEPARATOR = ";"; break;
-            }
+            SEPARATOR = String.fromCharCode(separator);
         }
     }
 }

--- a/libs/datalogger/datalogger.ts
+++ b/libs/datalogger/datalogger.ts
@@ -31,7 +31,7 @@ namespace datalogger {
         /**
          * Appends a row of data
          */
-        appendRow(values: string[]): void { }
+        appendRow(values: number[]): void { }
         /**
          * Flushes any buffered data
          */
@@ -89,11 +89,10 @@ namespace datalogger {
                     }
                 }
                 // append row
-                let textRow: string[] = _row.map(x => "" + x);
-                _storage.appendRow(textRow);
+                _storage.appendRow(_row);
                 if (_console) {
                     // drop time
-                    console.log(textRow.slice(1, _row.length).join(','));
+                    console.log(_row.slice(1, _row.length).join(','));
                 }
                 // clear values
                 _row = undefined;

--- a/libs/datalogger/docs/reference/datalogger.md
+++ b/libs/datalogger/docs/reference/datalogger.md
@@ -14,6 +14,7 @@ datalogger.addValue("x", 0)
 datalogger.setEnabled(false)
 datalogger.setSampleInterval(50)
 datalogger.sendToConsole(false)
+datalogger.setSeparator(LogSeparator.Tab)
 ```
 
 ## See also
@@ -22,7 +23,8 @@ datalogger.sendToConsole(false)
 [add value](/reference/datalogger/add-value),
 [set enabled](/reference/datalogger/set-enabled),
 [set sample interval](/reference/datalogger/set-sample-interval),
-[send to console](/reference/datalogger/send-to-console)
+[send to console](/reference/datalogger/send-to-console),
+[set separator](/reference/datalogger/set-separator)
 
 ```package
 datalogger

--- a/libs/datalogger/docs/reference/datalogger/set-separator.md
+++ b/libs/datalogger/docs/reference/datalogger/set-separator.md
@@ -1,0 +1,55 @@
+# set Separator
+
+Set the log value separator charactor.
+
+```sig
+datalogger.setSeparator(LogSeparator.Tab)
+```
+
+A special character is used to separate the values in the rows that are written to the log file. The default separator is the TAB character, ``\t``. The text format of the data values in a row using a tab separator might look like:
+
+```
+time (s) x   y   z
+45  5   9   34
+46  67  98  71
+47  73  4   82
+```
+
+You can change the separator to something else if you have a program or application that uses a different character to read each value from a row. The same data from the previous example written to the log file using a comma separator appears this way:
+
+```
+time (s),x,y,z
+45,5,9,34
+46,67,98,71
+47,73,4,82
+```
+
+## Parameters
+
+* **separator**: the text character used to separate the values in a row of data in the log file. The separator characters to choose from are `tab ('    ')`, `comma (',')`, or `semicolon (';')`.
+
+## Example #example
+
+Create log file rows with random `x`, `y`, and, `z` values. Use a comma as the value separator.
+
+```blocks
+datalogger.setEnabled(false)
+datalogger.setSeparator(LogSeparator.Comma)
+datalogger.setEnabled(true)
+datalogger.sendToConsole(true)
+forever(function () {
+    datalogger.addValue("x", Math.randomRange(0, 10))
+    datalogger.addValue("y", Math.randomRange(0, 10))
+    datalogger.addValue("z", Math.randomRange(0, 10))
+    datalogger.addRow()
+    pause(500)
+})
+```
+
+## See also #seealso
+
+[add value](/reference/datalogger/add-value)
+
+```package
+datalogger
+```

--- a/libs/datalogger/docs/reference/datalogger/set-separator.md
+++ b/libs/datalogger/docs/reference/datalogger/set-separator.md
@@ -1,6 +1,6 @@
 # set Separator
 
-Set the log value separator charactor.
+Set the log value separator character.
 
 ```sig
 datalogger.setSeparator(LogSeparator.Tab)

--- a/libs/datalogger/docs/reference/datalogger/set-separator.md
+++ b/libs/datalogger/docs/reference/datalogger/set-separator.md
@@ -24,6 +24,8 @@ time (s),x,y,z
 47,73,4,82
 ```
 
+You can only change the separator character when logging is not enabled. The new separator is used when logging is enabled again.
+
 ## Parameters
 
 * **separator**: the text character used to separate the values in a row of data in the log file. The separator characters to choose from are `tab ('    ')`, `comma (',')`, or `semicolon (';')`.

--- a/libs/datalogger/storagedatalogger.ts
+++ b/libs/datalogger/storagedatalogger.ts
@@ -29,7 +29,7 @@ namespace datalogger {
         /**
          * Appends a row of data
          */
-        appendRow(values: number[]): void { 
+        appendRow(values: string[]): void { 
             const line = values.join(datalogger.SEPARATOR);
             storage.appendLine(this.filename, line);
         }

--- a/libs/datalogger/storagedatalogger.ts
+++ b/libs/datalogger/storagedatalogger.ts
@@ -29,7 +29,7 @@ namespace datalogger {
         /**
          * Appends a row of data
          */
-        appendRow(values: string[]): void { 
+        appendRow(values: number[]): void { 
             const line = values.join(datalogger.SEPARATOR);
             storage.appendLine(this.filename, line);
         }


### PR DESCRIPTION
Datalogger

Values of `0` are omitted from the text rows on output. Seems that ``array.join()`` treats values of `0` as `null` and drops them out of the result string. See below:

```typescript
let testRows: number[][] = []
testRows = [[23, 9, 56], [87, 0, 45], [75, 0, 0], [0, 32, 45]]
for (let row of testRows) {
	console.log(row.join(','))
}
```

result:

```
23,9,56
87,,45
75,,
,32,45
```

A suggested fix is to convert the row to string prior to formatting and output.

- [x] Convert output row to string values.
- [x] Add the option to change the separator character.