### PR TITLE
Turning on duplicate on drag for image blocks

### DIFF
--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -9,7 +9,7 @@ namespace images {
     //% img.fieldEditor="sprite"
     //% img.fieldOptions.taggedTemplate="img"
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
-    //% weight=100 group="Create"
+    //% weight=100 group="Create" duplicateShadowOnDrag
     export function _spriteImage(img: Image) {
         return img
     }
@@ -21,7 +21,7 @@ namespace images {
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
     //% img.fieldOptions.sizes="-1,-1"
     //% weight=100 group="Create"
-    //% blockHidden=1
+    //% blockHidden=1 duplicateShadowOnDrag
     export function _screenImage(img: Image) {
         return img
     }
@@ -33,7 +33,7 @@ namespace images {
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
     //% img.fieldOptions.sizes="10,8;16,16;32,32;48,48;64,64;16,32;32,48;32,8;64,8"
     //% weight=100 group="Create"
-    //% blockHidden=1
+    //% blockHidden=1 duplicateShadowOnDrag
     export function _tileMapImage(img: Image) {
         return img
     }


### PR DESCRIPTION
Relies on https://github.com/Microsoft/pxt/pull/5422

Makes all image shadow blocks duplicate on drag. Safe to merge before the pxt change is merged.

![dragging_donuts](https://user-images.githubusercontent.com/13754588/55438417-5f8aef80-5556-11e9-884c-28f9e407dc86.gif)