### PR TITLE
Add top level `toString` block

### DIFF
--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -287,6 +287,17 @@ function pause(ms: number): void {
     loops.pause(ms);
 }
 
+/**
+ * Convert any value to a string
+ * @param value value to be converted to a string
+ */
+//% help=text/to-string weight=1
+//% block="convert $value=variables_get(myValue) to string"
+//% blockId=variable_to_string blockNamespace="text"
+function toString(value: any): string {
+    return "" + value;
+}
+
 // micro:bit compatibility
 // these functions allow some level of reuse
 // between micro:bit and other maker-style editors

--- a/libs/base/docs/reference/text/to-string.md
+++ b/libs/base/docs/reference/text/to-string.md
@@ -1,0 +1,7 @@
+# to string
+
+Converts a value into a text representation.
+
+```sig
+toString(123)
+```


### PR DESCRIPTION
requires https://github.com/Microsoft/pxt/pull/5424 to behave nicely with variable reporters [merged]

Add a top level ``toString`` block to allow for conversions from numbers / any object to text. This could also be handled with join currently, but that is a bit unintuitive for new developers; see https://github.com/Microsoft/pxt-microbit/issues/1637

![Screen Shot 2019-04-02 at 5 03 46 PM](https://user-images.githubusercontent.com/5615930/55443899-4d667c80-5569-11e9-8b50-28df75603c76.png)

To show up in Microbit I'll have to duplicate this over to one of the libs there, will do that once this one is finalized to make sure they're consistent