### PR TITLE
Macros for accessing buffer and string data across versions

### DIFF
--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -711,6 +711,16 @@ class BoxedString : public RefObject {
     BoxedString(const VTable *vt) : RefObject(vt) {}
 };
 
+// cross version compatible way of accessing string data
+#ifndef PXT_STRING_DATA
+#define PXT_STRING_DATA(str) str->getUTF8Data()
+#endif
+
+// cross version compatible way of accessing string length
+#ifndef PXT_STRING_DATA_LENGTH
+#define PXT_STRING_DATA_LENGTH(str) str->getUTF8Size()
+#endif
+
 class BoxedBuffer : public RefObject {
   public:
     // data needs to be word-aligned, so we use 32 bits for length
@@ -718,6 +728,20 @@ class BoxedBuffer : public RefObject {
     uint8_t data[0];
     BoxedBuffer() : RefObject(&buffer_vt) {}
 };
+
+// cross version compatible way of access data field
+#ifndef PXT_BUFFER_DATA
+#define PXT_BUFFER_DATA(buffer) buffer->data
+#endif
+
+// cross version compatible way of access data length
+#ifndef PXT_BUFFER_LENGTH
+#define PXT_BUFFER_LENGTH(buffer) buffer->length
+#endif
+
+#ifndef PXT_CREATE_BUFFER
+#define PXT_CREATE_BUFFER(data, len) pxt::mkBuffer(data, len)
+#endif
 
 // the first byte of data indicates the format - currently 0xE1 or 0xE4 to 1 or 4 bit bitmaps
 // second byte indicates width in pixels


### PR DESCRIPTION
will fix https://github.com/Microsoft/pxt-microbit/issues/1941, still need to make a PR to the extension repo once this is merged though

moves the macros from microbit to be structures themselves