### PR TITLE
Always show win/lose toggle in game.over

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -158,7 +158,7 @@ namespace game {
      * Finish the game and display the score
      */
     //% group="Gameplay"
-    //% blockId=gameOver block="game over %gameWon=toggleWinLose || with %effect effect"
+    //% blockId=gameOver block="game over %win=toggleWinLose || with %effect effect"
     //% weight=80 help=game/over
     export function over(win: boolean = false, effect?: effects.BackgroundEffect) {
         init();

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -158,7 +158,7 @@ namespace game {
      * Finish the game and display the score
      */
     //% group="Gameplay"
-    //% blockId=gameOver block="game over || %win=toggleWinLose with %effect effect"
+    //% blockId=gameOver block="game over %win=toggleWinLose with %effect effect"
     //% weight=80 help=game/over
     export function over(win: boolean = false, effect?: effects.BackgroundEffect) {
         init();

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -158,15 +158,15 @@ namespace game {
      * Finish the game and display the score
      */
     //% group="Gameplay"
-    //% blockId=gameOver block="game over %win=toggleWinLose with %effect effect"
+    //% blockId=gameOver block="game over %gameWon=toggleWinLose || with %effect effect"
     //% weight=80 help=game/over
-    export function over(win: boolean = false, effect?: effects.BackgroundEffect) {
+    export function over(gameWon: boolean = false, effect?: effects.BackgroundEffect) {
         init();
         if (__isOver) return;
         __isOver = true;
 
         if (!effect) {
-            effect = win ? winEffect : loseEffect;
+            effect = gameWon ? winEffect : loseEffect;
         }
 
         // releasing memory and clear fibers. Do not add anything that releases the fiber until background is set below,
@@ -178,7 +178,7 @@ namespace game {
         pushScene();
         scene.setBackgroundImage(screen.clone());
 
-        if (win)
+        if (gameWon)
             winSound.play();
         else
             loseSound.play();
@@ -189,7 +189,7 @@ namespace game {
 
         game.eventContext().registerFrameHandler(scene.HUD_PRIORITY, () => {
             let top = showDialogBackground(46, 4);
-            screen.printCenter(win ? "YOU WIN!" : "GAME OVER!", top + 8, screen.isMono ? 1 : 5, image.font8);
+            screen.printCenter(gameWon ? "YOU WIN!" : "GAME OVER!", top + 8, screen.isMono ? 1 : 5, image.font8);
             if (info.hasScore()) {
                 screen.printCenter("Score:" + info.score(), top + 23, screen.isMono ? 1 : 2, image.font8);
                 if (info.score() > info.highScore()) {

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -160,13 +160,13 @@ namespace game {
     //% group="Gameplay"
     //% blockId=gameOver block="game over %gameWon=toggleWinLose || with %effect effect"
     //% weight=80 help=game/over
-    export function over(gameWon: boolean = false, effect?: effects.BackgroundEffect) {
+    export function over(win: boolean = false, effect?: effects.BackgroundEffect) {
         init();
         if (__isOver) return;
         __isOver = true;
 
         if (!effect) {
-            effect = gameWon ? winEffect : loseEffect;
+            effect = win ? winEffect : loseEffect;
         }
 
         // releasing memory and clear fibers. Do not add anything that releases the fiber until background is set below,
@@ -178,7 +178,7 @@ namespace game {
         pushScene();
         scene.setBackgroundImage(screen.clone());
 
-        if (gameWon)
+        if (win)
             winSound.play();
         else
             loseSound.play();
@@ -189,7 +189,7 @@ namespace game {
 
         game.eventContext().registerFrameHandler(scene.HUD_PRIORITY, () => {
             let top = showDialogBackground(46, 4);
-            screen.printCenter(gameWon ? "YOU WIN!" : "GAME OVER!", top + 8, screen.isMono ? 1 : 5, image.font8);
+            screen.printCenter(win ? "YOU WIN!" : "GAME OVER!", top + 8, screen.isMono ? 1 : 5, image.font8);
             if (info.hasScore()) {
                 screen.printCenter("Score:" + info.score(), top + 23, screen.isMono ? 1 : 2, image.font8);
                 if (info.score() > info.highScore()) {


### PR DESCRIPTION
closes https://github.com/Microsoft/pxt-arcade/issues/872

Changed parameter name mainly to disambiguate upgraded / un-upgraded scripts for the upgrade rules.

### Old:

<img width="450" alt="Screen Shot 2019-04-15 at 4 11 10 PM" src="https://user-images.githubusercontent.com/5615930/56171156-1b0d4400-5f99-11e9-85b1-766549b30156.png">
<img width="458" alt="Screen Shot 2019-04-15 at 4 10 56 PM" src="https://user-images.githubusercontent.com/5615930/56171157-1b0d4400-5f99-11e9-97e6-9b5c4d32d33e.png">


### New:

<img width="455" alt="Screen Shot 2019-04-15 at 4 10 10 PM" src="https://user-images.githubusercontent.com/5615930/56171123-0335c000-5f99-11e9-9e8e-9d836a6c3cf1.png">
<img width="446" alt="Screen Shot 2019-04-15 at 4 09 55 PM" src="https://user-images.githubusercontent.com/5615930/56171124-03ce5680-5f99-11e9-88ed-d3e70646ec4f.png">
