### PR TITLE
block to set defaults for repeat events

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -38,6 +38,8 @@ enum ControllerEvent {
 //% blockGap=8
 namespace controller {
     let _userEventsEnabled = true;
+    let defaultRepeatDelay = 500;
+    let defaultRepeatInterval = 30;
 
     //% fixedInstances
     export class Button {
@@ -60,8 +62,8 @@ namespace controller {
             this.id = id;
             this._buttonId = buttonId;
             this._pressed = false;
-            this.repeatDelay = 500;
-            this.repeatInterval = 30;
+            this.repeatDelay = undefined;
+            this.repeatInterval = undefined;
             this._repeatCount = 0;
             control.internalOnEvent(INTERNAL_KEY_UP, this.id, () => this.setPressed(false), 16)
             control.internalOnEvent(INTERNAL_KEY_DOWN, this.id, () => this.setPressed(true), 16)
@@ -142,17 +144,33 @@ namespace controller {
             if (!this._pressed) return;
             this._pressedElasped += dtms;
 
+            const delay = this.repeatDelay === undefined ? defaultRepeatDelay : this.repeatDelay;
+            const interval = this.repeatInterval === undefined ? defaultRepeatInterval : this.repeatInterval;
+
             // inital delay
-            if (this._pressedElasped < this.repeatDelay)
+            if (this._pressedElasped < delay)
                 return;
 
             // repeat count for this step
-            const count = Math.floor((this._pressedElasped - this.repeatDelay) / this.repeatInterval);
+            const count = Math.floor((this._pressedElasped - delay - interval) / interval);
             if (count != this._repeatCount) {
                 this.raiseButtonRepeat();
                 this._repeatCount = count;
             }
         }
+    }
+
+    /**
+     * Set default values for repeat button event delay and interval
+     * @param delay default delay for buttons, eg: 500
+     * @param interval default interval for buttons, eg: 30
+     */
+    //% blockId=repeatDefaultDelayInterval block="set repeat delay $delay interval $interval"
+    //% weight=10
+    //% group="Single Player"
+    export function setRepeatDefault(delay: number, interval: number) {
+        defaultRepeatDelay = delay;
+        defaultRepeatInterval = interval;
     }
 
     let _players: Controller[];

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -161,9 +161,9 @@ namespace controller {
     }
 
     /**
-     * Set default values for repeat button event delay and interval
-     * @param delay default delay for buttons, eg: 500
-     * @param interval default interval for buttons, eg: 30
+     * Configures the timing of the on button repeat event for all of the controller buttons
+     * @param delay number of milliseconds from when the button is pressed to when the repeat event starts firing, eg: 500
+     * @param interval minimum number of milliseconds between calls to the button repeat event, eg: 30
      */
     //% blockId=repeatDefaultDelayInterval block="set repeat delay $delay interval $interval"
     //% weight=10

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -165,7 +165,7 @@ namespace controller {
      * @param delay number of milliseconds from when the button is pressed to when the repeat event starts firing, eg: 500
      * @param interval minimum number of milliseconds between calls to the button repeat event, eg: 30
      */
-    //% blockId=repeatDefaultDelayInterval block="set repeat delay $delay interval $interval"
+    //% blockId=repeatDefaultDelayInterval block="set button repeat delay $delay interval $interval"
     //% weight=10
     //% group="Single Player"
     export function setRepeatDefault(delay: number, interval: number) {

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -165,7 +165,7 @@ namespace controller {
      * @param delay number of milliseconds from when the button is pressed to when the repeat event starts firing, eg: 500
      * @param interval minimum number of milliseconds between calls to the button repeat event, eg: 30
      */
-    //% blockId=repeatDefaultDelayInterval block="set button repeat delay $delay interval $interval"
+    //% blockId=repeatDefaultDelayInterval block="set button repeat delay $delay ms interval $interval ms"
     //% weight=10
     //% group="Single Player"
     export function setRepeatDefault(delay: number, interval: number) {


### PR DESCRIPTION
fixes https://github.com/Microsoft/pxt-arcade/issues/767

Block sets default for **all** buttons; setting them on a per - button basis is advanced / typescript only.

Also fixes a bug where the time before the first repeat was the repeatDelay plus the repeatInterval, rather than just the repeatDelay

![2019-04-18 16 19 52](https://user-images.githubusercontent.com/5615930/56396967-56587e80-61f6-11e9-8363-f40c70f6872e.gif)

![arcade-screenshot (5)](https://user-images.githubusercontent.com/5615930/56396969-58bad880-61f6-11e9-8b7d-29c9c7cb6583.png)

<img width="442" alt="Screen Shot 2019-04-18 at 4 25 03 PM" src="https://user-images.githubusercontent.com/5615930/56397007-8e5fc180-61f6-11e9-9312-992865d1dad1.png">
