### PR TITLE
add missing basic.forever for compatibility with micro:bit

### DIFF
--- a/libs/base/basic.ts
+++ b/libs/base/basic.ts
@@ -49,4 +49,8 @@ namespace basic {
     export function pause(millis: number) {
         loops.pause(millis);
     }
+
+    export function forever(a: () => void) {
+        loops.forever(a);
+    }
 }


### PR DESCRIPTION
Add basic.forever for compatibility with microbit; it's absence was noted in https://github.com/Microsoft/pxt-arcade/pull/897