### PR TITLE
Iffy jsDoc on 'isMono'

### DIFF
--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -153,7 +153,7 @@ int height(Image_ img) {
 }
 
 /**
- * True iff the image is monochromatic (black and white)
+ * True if the image is monochromatic (black and white)
  */
 //% property
 bool isMono(Image_ img) {


### PR DESCRIPTION
Translator found spelling. Shows up in jsdoc strings.

RE: https://crowdin.com/translate/kindscript/2961/en-zhtw#118775