### PR TITLE
Bring back HID for WinRT app

### DIFF
--- a/libs/core/hf2.h
+++ b/libs/core/hf2.h
@@ -36,6 +36,7 @@ class HF2 : public CodalUSBInterface {
     HF2_Buffer &pkt;
 
     bool allocateEP;
+    bool useHID;
 
     int sendResponse(int size);
     int recv();
@@ -44,6 +45,7 @@ class HF2 : public CodalUSBInterface {
     HF2(HF2_Buffer &pkt);
     virtual int endpointRequest();
     virtual int classRequest(UsbEndpointIn &ctrl, USBSetup &setup);
+    virtual int stdRequest(UsbEndpointIn &ctrl, USBSetup &setup);
     virtual const InterfaceInfo *getInterfaceInfo();
     int sendSerial(const void *data, int size, int isError = 0);
 

--- a/libs/core/usb.cpp
+++ b/libs/core/usb.cpp
@@ -9,6 +9,9 @@ CodalUSB usb;
 // share the buffer; we will crash anyway if someone talks to us over both at the same time
 HF2_Buffer hf2buf;
 HF2 hf2(hf2buf);
+#ifdef HF2_HID
+HF2 hf2hid(hf2buf);
+#endif
 DummyIface dummyIface;
 
 #if CONFIG_ENABLED(DEVICE_MOUSE)
@@ -93,9 +96,15 @@ void usb_init() {
 #endif
     usb.add(hf2);
 
+#ifdef HF2_HID
+    hf2hid.useHID = true;
+    usb.add(hf2hid);
+#else
     // the WINUSB descriptors don't seem to work if there's only one interface
     // so we add a dummy interface
     usb.add(dummyIface);
+#endif
+
 
 #if CONFIG_ENABLED(DEVICE_MOUSE)
     usb.add(mouse);
@@ -127,6 +136,9 @@ void setSendToUART(void (*f)(const char *, int)) {
 void sendSerial(const char *data, int len) {
 #if CONFIG_ENABLED(DEVICE_USB)
     hf2.sendSerial(data, len);
+#if HF2_HID
+    hf2hid.sendSerial(data, len);
+#endif
 #endif
     if (pSendToUART)
         pSendToUART(data, len);


### PR DESCRIPTION
This adds code removed in https://github.com/Microsoft/pxt-common-packages/pull/616 (under #ifdef)
