### PR TITLE
Add control.ramSize()

### DIFF
--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -252,6 +252,16 @@ namespace control {
             }
         }
     }
+
+    //% shim=control::_ramSize
+    function _ramSize() {
+        return 32 * 1024 * 1024;
+    }
+
+    /** Returns estimated size of memory in bytes. */
+    export function ramSize() {
+        return getConfigValue(DAL.CFG_RAM_BYTES, 0) || _ramSize();
+    }
 }
 
 /**

--- a/libs/core---linux/control.cpp
+++ b/libs/core---linux/control.cpp
@@ -29,6 +29,17 @@ void dmesg(String s) {
     DMESG("# %s", s->getUTF8Data());
 }
 
+//%
+uint32_t _ramSize()
+{
+#ifdef POKY
+    return 128 * 1024;
+#else
+    // a lot! doesn't really matter how much
+    return 16 * 1024 * 1024;
+#endif
+}
+
 }
 
 namespace serial {

--- a/libs/core/control.cpp
+++ b/libs/core/control.cpp
@@ -1,5 +1,7 @@
 #include "pxt.h"
 
+extern uint32_t _estack;
+
 namespace control {
 
 /**
@@ -43,5 +45,10 @@ void dmesgPtr(String str, Object_ ptr) {
     DMESG("# %s: %p", str->getUTF8Data(), ptr);
 }
 
+//%
+uint32_t _ramSize()
+{
+    return (uint32_t)&_estack & 0x1fffffff;
+}
 
 }


### PR DESCRIPTION
Completely untested.

See https://github.com/microsoft/pxt-arcade/pull/958

CC @jwunderl 