### PR TITLE
don't use Easing type

### DIFF
--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -215,7 +215,7 @@ namespace light {
         //% blockId="lightsetgradient" block="set %strip gradient from %startColor=colorNumberPicker to %endColor=colorNumberPicker"
         //% weight=79 blockGap=8
         //% advanced=true
-        setGradient(startColor: number, endColor: number, easing?: easing.Easing) {
+        setGradient(startColor: number, endColor: number, easing?: (t: number) => number) {
             const sr = unpackR(startColor);
             const sg = unpackG(startColor);
             const sb = unpackB(startColor);

--- a/libs/light/transitions.ts
+++ b/libs/light/transitions.ts
@@ -6,7 +6,6 @@ namespace easing {
     export function inCubic(t: number): number { return t * t * t; }
     export function outCubic(t: number): number { return (--t) * t * t + 1; }
     export function inOutCubic(t: number): number { return t < .5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1; }
-    export type Easing = (t: number) => number;
 }
 
 namespace light {
@@ -18,12 +17,12 @@ namespace light {
     }
 
     export class EasingBrightnessTransition extends BrightnessTransition {
-        private timeEasing: easing.Easing;
-        private spatialEasing: easing.Easing;
+        private timeEasing: (t: number) => number;
+        private spatialEasing: (t: number) => number;
 
         constructor(
-            timeEasing: easing.Easing, 
-            spatialEasing?: easing.Easing) {
+            timeEasing: (t: number) => number, 
+            spatialEasing?: (t: number) => number) {
             super();
             this.timeEasing = timeEasing || easing.inOutQuad;
             this.spatialEasing = spatialEasing;


### PR DESCRIPTION
It messes up Python
@darzu you should be able to recreate a repro out of this. This is different from the unexported enum.