### PR TITLE
don't return undefined for tile outside map

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -32,7 +32,7 @@ namespace tiles {
         }
 
         get tileSet(): number {
-            return this._map.getPixel(this._col, this._row);
+            return this._map.getPixel(this._col, this._row) | 0;
         }
 
         /**
@@ -110,7 +110,6 @@ namespace tiles {
         }
 
         public getTile(col: number, row: number): Tile {
-            if (this.isOutsideMap(col, row)) return undefined;
             return new Tile(col, row, this._map);
         }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/963