### PR TITLE
Don't let user turn off screen brightness fully from menu

### DIFF
--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -278,7 +278,7 @@ namespace scene.systemMenu {
     }
 
     function brightnessDown() {
-        screen.setBrightness(Math.max(screen.brightness() - 10, 0));
+        screen.setBrightness(Math.max(screen.brightness() - 10, 10));
     }
 
     function toggleStats() {


### PR DESCRIPTION
Set minimum brightness to 10 when changing by menu, so that the game doesn't become unusable without a reset