### PR TITLE
Cleanup some tool tips when editting locally

### DIFF
--- a/libs/game/temp.d.ts
+++ b/libs/game/temp.d.ts
@@ -24,8 +24,8 @@ declare interface String {
 
 declare namespace Math {
     function clamp(min: number, max: number, value: number): number;
-    function ceil(n: number): number;
-    function floor(n: number): number;
+    function ceil(x: number): number;
+    function floor(x: number): number;
     function max(a: number, b: number): number;
     function min(a: number, b: number): number;
     function abs(x: number): number;

--- a/libs/game/temp.d.ts
+++ b/libs/game/temp.d.ts
@@ -23,14 +23,15 @@ declare interface String {
 }
 
 declare namespace Math {
-    function clamp(a: number, b: number, c: number): number;
+    function clamp(min: number, max: number, value: number): number;
     function ceil(n: number): number;
     function floor(n: number): number;
     function max(a: number, b: number): number;
     function min(a: number, b: number): number;
-    function abs(a: number): number;
-    function sqrt(a: number): number;
-    function randomRange(a: number, b: number): number;
+    function abs(x: number): number;
+    function sqrt(x: number): number;
+    function randomRange(min: number, max: number): number;
+    function roundWithPrecision(x: number, digits: number): number;
     function idiv(x: number, y: number): number;
     function sign(x: number): number;
 }


### PR DESCRIPTION
Just noticed after editing these that they only affect the tooltips from vs code / etc (as the parameter names are already good in the actual implementations in pxt), but still nice to change for future clamping in vs code.  Parameter names here match the ones you'd see in the editor now