### PR TITLE
Added string isEmpty function in cpp

### DIFF
--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -650,6 +650,11 @@ int includes(String s, String searchString, int start) {
     return -1 != indexOf(s, searchString, start);
 }
 
+//%
+bool isEmpty(String s) {
+    return !s || IS_EMPTY(s);
+}
+
 } // namespace String_
 
 namespace Boolean_ {


### PR DESCRIPTION
[In pxt, there is currently a shim](https://github.com/microsoft/pxt/blob/dba24b33ddabde0c65627be4c70de43744d4119a/libs/pxt-common/pxt-core.d.ts#L263) mapping to a string isEmpty function. To my understanding there isn't actually a function in the cpp that implements this. 

This adds that function.

Fixes Microsoft/pxt-microbit#2048