### PR TITLE
fix positioning of particles when using tilemap

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -246,7 +246,7 @@ namespace effects {
     });
 
     //% fixedInstance whenUsed block="fire"
-    export const fire = new ParticleEffect(40, 5000, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
+    export const fire = new ParticleEffect(50, 5000, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
         const factory = new particles.FireFactory(5);
         const src = new particles.FireSource(anchor, particlesPerSecond, factory);
         src.setAcceleration(0, -20);
@@ -260,7 +260,7 @@ namespace effects {
     export const coolRadial = createEffect(30, 2000, function () { return new particles.RadialFactory(0, 30, 10, [0x6, 0x7, 0x8, 0x9, 0xA]) });
 
     //% fixedInstance whenUsed block="halo"
-    export const halo = createEffect(40, 3000, function () {
+    export const halo = createEffect(70, 3000, function () {
         class RingFactory extends particles.RadialFactory {
             createParticle(anchor: particles.ParticleAnchor) {
                 const p = super.createParticle(anchor);
@@ -329,7 +329,7 @@ namespace effects {
     });
 
     //% fixedInstance whenUsed block="clouds"
-    export const clouds = new ScreenEffect(0.2, 0.5, 5000, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
+    export const clouds = new ScreenEffect(.5, 1.5, 5000, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
         const factory = new particles.CloudFactory();
         const source = new particles.ParticleSource(anchor, particlesPerSecond, factory);
 

--- a/libs/game/particlefactories.ts
+++ b/libs/game/particlefactories.ts
@@ -307,7 +307,11 @@ namespace particles {
         }
 
         drawParticle(p: Particle, x: Fx8, y: Fx8) {
-            screen.setPixel(Fx.toInt(p._x), Fx.toInt(p._y), p.color);
+            screen.setPixel(
+                Fx.toInt(x),
+                Fx.toInt(y),
+                p.color
+            );
         }
     }
 
@@ -352,7 +356,11 @@ namespace particles {
         }
 
         drawParticle(p: Particle, x: Fx8, y: Fx8) {
-            screen.setPixel(Fx.toInt(p._x), Fx.toInt(p._y), p.color);
+            screen.setPixel(
+                Fx.toInt(x),
+                Fx.toInt(y),
+                p.color
+            );
         }
 
         setRadius(r: number) {
@@ -682,13 +690,10 @@ namespace particles {
             const p = super.createParticle(anchor);
             const yRange = anchor.height ? anchor.height >> 1 : 8;
             p.data = Math.randomRange(0, this.clouds.length - 1);
-            p._x = Fx.sub(
-                Fx8(anchor.width ? anchor.x + (anchor.width >> 1) : anchor.x),
-                Fx8(this.camera.offsetX)
-            );
-            p._y = Fx.sub(
+            p._x = Fx8(anchor.width ? anchor.x + (anchor.width >> 1) : anchor.x)
+            p._y = Fx.add(
                 Fx8(Math.randomRange(anchor.y - yRange, anchor.y + yRange)),
-                Fx8(this.camera.offsetY - (this.clouds[p.data].width >> 1))
+                Fx8(this.clouds[p.data].width >> 1)
             );
             p.vx = Fx8(-Math.randomRange(this.minRate, this.maxRate));
 
@@ -720,8 +725,8 @@ namespace particles {
             const mainImage = this.clouds[p.data];
             screen.drawTransparentImage(
                 mainImage,
-                Fx.toInt(p._x),
-                Fx.toInt(p._y)
+                Fx.toInt(x),
+                Fx.toInt(y)
             );
 
             if (p.color & 1) {
@@ -734,8 +739,8 @@ namespace particles {
 
                 screen.drawTransparentImage(
                     selection,
-                    Fx.toInt(Fx.add(p._x, xOffset)),
-                    Fx.toInt(Fx.add(p._y, yOffset))
+                    Fx.toInt(Fx.add(x, xOffset)),
+                    Fx.toInt(Fx.add(y, yOffset))
                 );
             }
         }


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/976

A handful of the particle effects were being positioned on the screen solely off of their position, rather than respecting the camera position. (For the clouds this was intentional to make them move across the screen ignoring the relative change in position of the player, but that behavior is a bit wonky / messes things up when it's in the tilemap).

Also changes a handful of default rates to make the effects look a bit nicer