### PR TITLE
keep volume aligned to 32 when using systemmenu

### DIFF
--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -268,17 +268,19 @@ namespace scene.systemMenu {
     }
 
     function volumeDown() {
-        const v = music.volume();
-        music.setVolume(v - 32);
+        const v = music.volume()
+        const newVolume = ((v - 1) >> 5) << 5;
+
+        music.setVolume(newVolume);
         music.playTone(440, 500);
     }
 
     function brightnessUp() {
-        screen.setBrightness(Math.min(screen.brightness() + 10, 100));
+        screen.setBrightness(screen.brightness() + 10);
     }
 
     function brightnessDown() {
-        screen.setBrightness(Math.max(screen.brightness() - 10, 10));
+        screen.setBrightness(screen.brightness() - 10);
     }
 
     function toggleStats() {

--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -263,13 +263,17 @@ namespace scene.systemMenu {
 
     function volumeUp() {
         const v = music.volume();
-        music.setVolume(v + 32);
+        const remainder = v % 32;
+        let newVolume = v + 32 - remainder;
+
+        music.setVolume(newVolume);
         music.playTone(440, 500);
     }
 
     function volumeDown() {
         const v = music.volume();
-        const newVolume = ((v - 1) >> 5) << 5;
+        const remainder = v % 32;
+        let newVolume = v - (remainder ? remainder : 32);
 
         music.setVolume(newVolume);
         music.playTone(440, 500);

--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -268,7 +268,7 @@ namespace scene.systemMenu {
     }
 
     function volumeDown() {
-        const v = music.volume()
+        const v = music.volume();
         const newVolume = ((v - 1) >> 5) << 5;
 
         music.setVolume(newVolume);

--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -264,7 +264,7 @@ namespace scene.systemMenu {
     function volumeUp() {
         const v = music.volume();
         const remainder = v % 32;
-        let newVolume = v + 32 - remainder;
+        const newVolume = v + 32 - remainder;
 
         music.setVolume(newVolume);
         music.playTone(440, 500);
@@ -273,7 +273,7 @@ namespace scene.systemMenu {
     function volumeDown() {
         const v = music.volume();
         const remainder = v % 32;
-        let newVolume = v - (remainder ? remainder : 32);
+        const newVolume = v - (remainder ? remainder : 32);
 
         music.setVolume(newVolume);
         music.playTone(440, 500);


### PR DESCRIPTION
(also remove redundant mins/maxes as that's handled in setBrightness)