### PR TITLE
Add ability to ramp frequencies of sounds

### DIFF
--- a/libs/mixer/melody.cpp
+++ b/libs/mixer/melody.cpp
@@ -223,7 +223,7 @@ int WSynthesizer::fillSamples(int16_t *dst, int numsamples) {
                         toneStep = (uint32_t)(toneStepMult * instr->frequency);
                         if (instr->frequency != instr->endFrequency) {
                             uint32_t endToneStep = (uint32_t)(toneStepMult * instr->endFrequency);
-                            toneDelta = (int32_t)(toneStep - endToneStep) / samplesLeft;
+                            toneDelta = (int32_t)(endToneStep - toneStep) / (int32_t)samplesLeft;
                         } else {
                             toneDelta = 0;
                         }

--- a/libs/mixer/melody.cpp
+++ b/libs/mixer/melody.cpp
@@ -141,6 +141,7 @@ int WSynthesizer::updateQueues() {
             snd->instrEnd = snd->currInstr + p->instructions->length / sizeof(SoundInstruction);
             for (auto p = snd->currInstr; p < snd->instrEnd; p++) {
                 CLAMP(20, p->frequency, 20000);
+                CLAMP(20, p->endFrequency, 20000);
                 CLAMP(0, p->startVolume, 1023);
                 CLAMP(0, p->endVolume, 1023);
                 CLAMP(1, p->duration, 60000);
@@ -186,12 +187,14 @@ int WSynthesizer::fillSamples(int16_t *dst, int numsamples) {
         gentone_t fn = NULL;
         snd->currInstr--;
         uint32_t toneStep = 0;
+        int32_t toneDelta = 0;
         int32_t volumeStep = 0;
         uint32_t tonePosition = snd->tonePosition;
         uint32_t samplesLeft = 0;
         uint8_t wave = 0;
         int32_t volume = 0;
         uint32_t prevFreq = 0;
+        uint32_t prevEndFreq = 0;
 
         for (int j = 0; j < numsamples; ++j) {
             if (samplesLeft == 0) {
@@ -201,19 +204,32 @@ int WSynthesizer::fillSamples(int16_t *dst, int numsamples) {
                 }
                 wave = instr->soundWave;
                 fn = getWaveFn(wave);
+
                 samplesLeft = (uint32_t)(instr->duration * samplesPerMS >> 8);
-                if (prevFreq != instr->frequency) {
-                    toneStep = (uint32_t)(toneStepMult * instr->frequency);
-                    prevFreq = instr->frequency;
-                }
                 volumeStep = ((int)(instr->endVolume - instr->startVolume) << 16) / samplesLeft;
+
                 if (j == 0 && snd->prevVolume != -1) {
                     // restore previous state
                     samplesLeft = snd->samplesLeftInCurr;
                     volume = snd->prevVolume;
+                    toneStep = snd->prevToneStep;
+                    toneDelta = snd->prevToneDelta;
+                    prevFreq = instr->frequency;
+                    prevEndFreq = instr->endFrequency;
                 } else {
                     LOG("#sampl %d %p", samplesLeft, instr);
                     volume = instr->startVolume << 16;
+                    if (prevFreq != instr->frequency || prevEndFreq != instr->endFrequency) {
+                        toneStep = (uint32_t)(toneStepMult * instr->frequency);
+                        if (instr->frequency != instr->endFrequency) {
+                            uint32_t endToneStep = (uint32_t)(toneStepMult * instr->endFrequency);
+                            toneDelta = (int32_t)(toneStep - endToneStep) / samplesLeft;
+                        } else {
+                            toneDelta = 0;
+                        }
+                        prevFreq = instr->frequency;
+                        prevEndFreq = instr->endFrequency;
+                    }
                 }
             }
 
@@ -226,6 +242,7 @@ int WSynthesizer::fillSamples(int16_t *dst, int numsamples) {
             dst[j] += v;
 
             tonePosition += toneStep;
+            toneStep += toneDelta;
             volume += volumeStep;
             samplesLeft--;
         }
@@ -239,6 +256,8 @@ int WSynthesizer::fillSamples(int16_t *dst, int numsamples) {
                 samplesLeft++; // avoid infinite loop in next iteration
             snd->samplesLeftInCurr = samplesLeft;
             snd->prevVolume = volume;
+            snd->prevToneDelta = toneDelta;
+            snd->prevToneStep = toneStep;
         }
     }
 

--- a/libs/mixer/melody.h
+++ b/libs/mixer/melody.h
@@ -19,6 +19,7 @@ struct SoundInstruction {
     uint16_t duration;   // ms
     int16_t startVolume; // 0-1023
     int16_t endVolume;   // 0-1023
+    uint16_t endFrequency;  // Hz
 };
 
 #ifdef DATASTREAM_MAXIMUM_BUFFERS
@@ -49,6 +50,8 @@ struct PlayingSound {
     uint32_t samplesLeftInCurr;
     uint32_t tonePosition;
     int32_t prevVolume;
+    uint32_t prevToneStep;
+    int32_t prevToneDelta;
     WaitingSound *sound;
     SoundInstruction *currInstr, *instrEnd;
 };

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -24,6 +24,8 @@ namespace music {
 
     let globalVolume: number = null
 
+    const BUFFER_SIZE: number = 12;
+
     //% shim=music::enableAmp
     function enableAmp(en: number) {
         return // for sim
@@ -63,8 +65,8 @@ namespace music {
     }
 
     function playNoteCore(when: number, frequency: number, ms: number) {
-        let buf = control.createBuffer(10)
-        addNote(buf, 0, ms, 255, 255, 1, frequency, volume())
+        let buf = control.createBuffer(BUFFER_SIZE)
+        addNote(buf, 0, ms, 255, 255, 1, frequency, volume(), frequency)
         queuePlayInstructions(when, buf)
     }
 
@@ -244,7 +246,7 @@ namespace music {
         }
     }
 
-    function addNote(sndInstr: Buffer, sndInstrPtr: number, ms: number, beg: number, end: number, soundWave: number, hz: number, volume: number) {
+    function addNote(sndInstr: Buffer, sndInstrPtr: number, ms: number, beg: number, end: number, soundWave: number, hz: number, volume: number, endHz: number) {
         if (ms > 0) {
             sndInstr.setNumber(NumberFormat.UInt8LE, sndInstrPtr, soundWave)
             sndInstr.setNumber(NumberFormat.UInt8LE, sndInstrPtr + 1, 0)
@@ -252,7 +254,8 @@ namespace music {
             sndInstr.setNumber(NumberFormat.UInt16LE, sndInstrPtr + 4, ms)
             sndInstr.setNumber(NumberFormat.UInt16LE, sndInstrPtr + 6, (beg * volume) >> 6)
             sndInstr.setNumber(NumberFormat.UInt16LE, sndInstrPtr + 8, (end * volume) >> 6)
-            sndInstrPtr += 10
+            sndInstr.setNumber(NumberFormat.UInt16LE, sndInstrPtr + 10, endHz);
+            sndInstrPtr += BUFFER_SIZE;
         }
         sndInstr.setNumber(NumberFormat.UInt8LE, sndInstrPtr, 0) // terminate
         return sndInstrPtr
@@ -284,6 +287,7 @@ namespace music {
             let tempo = 120; // default tempo
 
             let hz = 0
+            let endHz = -1
             let ms = 0
             let timePos = 0
             let startTime = control.millis()
@@ -294,11 +298,20 @@ namespace music {
             let envS = 255
             let envR = 0
             let soundWave = 1 // triangle
-            let sndInstr = control.createBuffer(5 * 10)
+            let sndInstr = control.createBuffer(5 * BUFFER_SIZE)
             let sndInstrPtr = 0
 
-            const addForm = (ms: number, beg: number, end: number) => {
-                sndInstrPtr = addNote(sndInstr, sndInstrPtr, ms, beg, end, soundWave, hz, volume)
+            const addForm = (formDuration: number, beg: number, end: number, msOff: number) => {
+                let freqStart = hz;
+                let freqEnd = endHz;
+
+                const envelopeWidth = ms > 0 ? 1000 : duration * Math.idiv(15000, tempo) + envR;
+                if (endHz != hz && envelopeWidth != 0) {
+                    const slope = (freqEnd - freqStart) / envelopeWidth;
+                    freqStart = hz + slope * msOff;
+                    freqEnd = hz + slope * (msOff + formDuration);
+                }
+                sndInstrPtr = addNote(sndInstr, sndInstrPtr, formDuration, beg, end, soundWave, freqStart, volume, freqEnd);
             }
 
             const scanNextWord = () => {
@@ -331,12 +344,13 @@ namespace music {
                 Beat,
                 Tempo,
                 Hz,
+                EndHz,
                 Ms,
                 WaveForm,
                 EnvelopeA,
                 EnvelopeD,
                 EnvelopeS,
-                EnvelopeR,
+                EnvelopeR
             }
 
             let token: string = "";
@@ -375,6 +389,7 @@ namespace music {
                         case Token.EnvelopeD: envD = d; tokenKind = Token.EnvelopeS; break;
                         case Token.EnvelopeS: envS = Math.clamp(0, 255, d); tokenKind = Token.EnvelopeR; break;
                         case Token.EnvelopeR: envR = d; break;
+                        case Token.EndHz: endHz = d; break;
                     }
                     token = "";
                 }
@@ -382,7 +397,6 @@ namespace music {
 
             while (true) {
                 let currNote = scanNextWord();
-                let prevNote: boolean = false;
                 if (!currNote) {
                     if (this.onPlayFinished)
                         this.onPlayFinished();
@@ -398,49 +412,46 @@ namespace music {
                 for (let i = 0; i < currNote.length; i++) {
                     let noteChar = currNote.charAt(i);
                     switch (noteChar) {
-                        case 'c': case 'C': note = 1; prevNote = true; break;
-                        case 'd': case 'D': note = 3; prevNote = true; break;
-                        case 'e': case 'E': note = 5; prevNote = true; break;
-                        case 'f': case 'F': note = 6; prevNote = true; break;
-                        case 'g': case 'G': note = 8; prevNote = true; break;
-                        case 'a': case 'A': note = 10; prevNote = true; break;
-                        case 'B': note = 12; prevNote = true; break;
-                        case 'r': case 'R': hz = 0; prevNote = false; break;
-                        case '#': note++; prevNote = false; break;
-                        case 'b': if (prevNote) note--; else { note = 12; prevNote = true; } break;
+                        case 'c': case 'C': note = 1; break;
+                        case 'd': case 'D': note = 3; break;
+                        case 'e': case 'E': note = 5; break;
+                        case 'f': case 'F': note = 6; break;
+                        case 'g': case 'G': note = 8; break;
+                        case 'a': case 'A': note = 10; break;
+                        case 'b': case 'B': note = 12; break;
+                        case 'r': case 'R': hz = 0; break;
+                        case '#': note++; break;
+                        case 'b': note--; break; // doesn't do anything
                         case ',':
                             consumeToken();
-                            prevNote = false;
                             break;
                         case '!':
                             tokenKind = Token.Hz;
-                            prevNote = false;
                             break;
                         case '@':
                             consumeToken();
                             tokenKind = Token.EnvelopeA;
-                            prevNote = false;
                             break;
                         case '~':
                             consumeToken();
                             tokenKind = Token.WaveForm;
-                            prevNote = false;
                             break;
                         case ':':
                             consumeToken();
                             tokenKind = Token.Beat;
-                            prevNote = false;
                             break;
                         case '-':
                             consumeToken();
                             tokenKind = Token.Tempo;
-                            prevNote = false;
+                            break;
+                        case '^':
+                            consumeToken();
+                            tokenKind = Token.EndHz;
                             break;
                         default:
                             if (tokenKind == Token.Note)
                                 tokenKind = Token.Octave;
                             token += noteChar;
-                            prevNote = false;
                             break;
                     }
                 }
@@ -463,13 +474,18 @@ namespace music {
                 } else if (hz == 0) {
                     timePos += currMs
                 } else {
+                    if (endHz < 0) {
+                        endHz = hz;
+                    }
+
                     sndInstrPtr = 0
-                    addForm(envA, 0, 255)
-                    addForm(envD, 255, envS)
-                    addForm(currMs - (envA + envD), envS, envS)
-                    addForm(envR, envS, 0)
+                    addForm(envA, 0, 255, 0)
+                    addForm(envD, 255, envS, envA)
+                    addForm(currMs - (envA + envD), envS, envS, envD + envA)
+                    addForm(envR, envS, 0, currMs)
 
                     queuePlayInstructions(timePos - now, sndInstr.slice(0, sndInstrPtr))
+                    endHz = -1;
                     timePos += currMs // don't add envR - it's supposed overlap next sound
                 }
 

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -382,6 +382,7 @@ namespace music {
 
             while (true) {
                 let currNote = scanNextWord();
+                let prevNote: boolean = false;
                 if (!currNote) {
                     if (this.onPlayFinished)
                         this.onPlayFinished();
@@ -397,42 +398,49 @@ namespace music {
                 for (let i = 0; i < currNote.length; i++) {
                     let noteChar = currNote.charAt(i);
                     switch (noteChar) {
-                        case 'c': case 'C': note = 1; break;
-                        case 'd': case 'D': note = 3; break;
-                        case 'e': case 'E': note = 5; break;
-                        case 'f': case 'F': note = 6; break;
-                        case 'g': case 'G': note = 8; break;
-                        case 'a': case 'A': note = 10; break;
-                        case 'b': case 'B': note = 12; break;
-                        case 'r': case 'R': hz = 0; break;
-                        case '#': note++; break;
-                        case 'b': note--; break; // doesn't do anything
+                        case 'c': case 'C': note = 1; prevNote = true; break;
+                        case 'd': case 'D': note = 3; prevNote = true; break;
+                        case 'e': case 'E': note = 5; prevNote = true; break;
+                        case 'f': case 'F': note = 6; prevNote = true; break;
+                        case 'g': case 'G': note = 8; prevNote = true; break;
+                        case 'a': case 'A': note = 10; prevNote = true; break;
+                        case 'B': note = 12; prevNote = true; break;
+                        case 'r': case 'R': hz = 0; prevNote = false; break;
+                        case '#': note++; prevNote = false; break;
+                        case 'b': if (prevNote) note--; else { note = 12; prevNote = true; } break;
                         case ',':
                             consumeToken();
+                            prevNote = false;
                             break;
                         case '!':
                             tokenKind = Token.Hz;
+                            prevNote = false;
                             break;
                         case '@':
                             consumeToken();
                             tokenKind = Token.EnvelopeA;
+                            prevNote = false;
                             break;
                         case '~':
                             consumeToken();
                             tokenKind = Token.WaveForm;
+                            prevNote = false;
                             break;
                         case ':':
                             consumeToken();
                             tokenKind = Token.Beat;
+                            prevNote = false;
                             break;
                         case '-':
                             consumeToken();
                             tokenKind = Token.Tempo;
+                            prevNote = false;
                             break;
                         default:
                             if (tokenKind == Token.Note)
                                 tokenKind = Token.Octave;
                             token += noteChar;
+                            prevNote = false;
                             break;
                     }
                 }

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -397,6 +397,7 @@ namespace music {
 
             while (true) {
                 let currNote = scanNextWord();
+                let prevNote: boolean = false;
                 if (!currNote) {
                     if (this.onPlayFinished)
                         this.onPlayFinished();
@@ -412,37 +413,43 @@ namespace music {
                 for (let i = 0; i < currNote.length; i++) {
                     let noteChar = currNote.charAt(i);
                     switch (noteChar) {
-                        case 'c': case 'C': note = 1; break;
-                        case 'd': case 'D': note = 3; break;
-                        case 'e': case 'E': note = 5; break;
-                        case 'f': case 'F': note = 6; break;
-                        case 'g': case 'G': note = 8; break;
-                        case 'a': case 'A': note = 10; break;
-                        case 'b': case 'B': note = 12; break;
-                        case 'r': case 'R': hz = 0; break;
-                        case '#': note++; break;
-                        case 'b': note--; break; // doesn't do anything
+                        case 'c': case 'C': note = 1; prevNote = true; break;
+                        case 'd': case 'D': note = 3; prevNote = true; break;
+                        case 'e': case 'E': note = 5; prevNote = true; break;
+                        case 'f': case 'F': note = 6; prevNote = true; break;
+                        case 'g': case 'G': note = 8; prevNote = true; break;
+                        case 'a': case 'A': note = 10; prevNote = true; break;
+                        case 'B': note = 12; prevNote = true; break;
+                        case 'r': case 'R': hz = 0; prevNote = false; break;
+                        case '#': note++; prevNote = false; break;
+                        case 'b': if (prevNote) note--; else { note = 12; prevNote = true; } break;
                         case ',':
                             consumeToken();
+                            prevNote = false;
                             break;
                         case '!':
                             tokenKind = Token.Hz;
+                            prevNote = false;
                             break;
                         case '@':
                             consumeToken();
                             tokenKind = Token.EnvelopeA;
+                            prevNote = false;
                             break;
                         case '~':
                             consumeToken();
                             tokenKind = Token.WaveForm;
+                            prevNote = false;
                             break;
                         case ':':
                             consumeToken();
                             tokenKind = Token.Beat;
+                            prevNote = false;
                             break;
                         case '-':
                             consumeToken();
                             tokenKind = Token.Tempo;
+                            prevNote = false;
                             break;
                         case '^':
                             consumeToken();
@@ -452,6 +459,7 @@ namespace music {
                             if (tokenKind == Token.Note)
                                 tokenKind = Token.Octave;
                             token += noteChar;
+                            prevNote = false;
                             break;
                     }
                 }


### PR DESCRIPTION
This allows for you to ramp the frequency of a sound over time. 

Adds the ```^``` operator which is followed by which frequency the sound should end at. For example,
```
music.playSound("!1300,200^50")
```
will play a sound that starts at 1300 hz, but ramps down to 50 hz over the course of 200 ms.