### PR TITLE
guard jacdac build in linux

### DIFF
--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1,5 +1,7 @@
 #include "pxtbase.h"
+#ifdef CODAL_JACDAC_WIRE_SERIAL
 #include "LowLevelTimer.h"
+#endif
 #include <limits.h>
 #include <stdlib.h>
 
@@ -1445,10 +1447,12 @@ void deepSleep() __attribute__((weak));
 //%
 void deepSleep() {}
 
+#ifdef CODAL_JACDAC_WIRE_SERIAL
 LowLevelTimer *getJACDACTimer() __attribute__((weak));
 LowLevelTimer *getJACDACTimer() {
     return NULL;
 }
+#endif
 
 int *getBootloaderConfigData() __attribute__((weak));
 int *getBootloaderConfigData() {

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1,12 +1,12 @@
 #include "pxtbase.h"
 #ifdef CODAL_JACDAC_WIRE_SERIAL
 #include "LowLevelTimer.h"
+using namespace codal;
 #endif
 #include <limits.h>
 #include <stdlib.h>
 
 using namespace std;
-using namespace codal;
 
 #define p10(v) __builtin_powi(10, v)
 

--- a/libs/base/gc.cpp
+++ b/libs/base/gc.cpp
@@ -405,7 +405,7 @@ static GCBlock *allocateBlockCore() {
     curr->blockSize = sz - sizeof(GCBlock);
     // make sure reference to allocated block is stored somewhere, otherwise
     // GCC optimizes out the call to GC_ALLOC_BLOCK
-    curr->data[4].vtable = (uint32_t)dummy;
+    curr->data[4].vtable = (uint32_t)(uintptr_t)dummy;
     return curr;
 }
 

--- a/libs/core---samd/platform.cpp
+++ b/libs/core---samd/platform.cpp
@@ -6,6 +6,7 @@
 
 namespace pxt {
 
+#ifdef CODAL_JACDAC_WIRE_SERIAL
 #ifdef SAMD21
 SAMDTCTimer jacdacTimer(TC4, TC4_IRQn);
 SAMDTCTimer lowTimer(TC3, TC3_IRQn);
@@ -27,6 +28,7 @@ LowLevelTimer* getJACDACTimer()
     return &jacdacTimer;
 }
 #endif
+#endif // CODAL_JACDAC_WIRE_SERIAL
 
 __attribute__((used))
 CODAL_TIMER devTimer(lowTimer);

--- a/libs/core---stm32/platform.cpp
+++ b/libs/core---stm32/platform.cpp
@@ -5,6 +5,7 @@
 
 namespace pxt {
 
+#ifdef CODAL_JACDAC_WIRE_SERIAL
 #ifdef STM32F1
 STMLowLevelTimer lowTimer(TIM4, TIM4_IRQn);
 #else
@@ -14,6 +15,7 @@ LowLevelTimer* getJACDACTimer()
 {
     return &jacdacTimer;
 }
+#endif // CODAL_JACDAC_WIRE_SERIAL
 
 STMLowLevelTimer lowTimer(TIM5, TIM5_IRQn);
 #endif

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -86,7 +86,9 @@ namespace pxt {
 CODAL_I2C* getI2C(DigitalInOutPin sda, DigitalInOutPin scl);
 #endif
 CODAL_SPI* getSPI(DigitalInOutPin mosi, DigitalInOutPin miso, DigitalInOutPin sck);
+#ifdef CODAL_JACDAC_WIRE_SERIAL
 LowLevelTimer* getJACDACTimer();
+#endif
 }
 
 namespace serial {


### PR DESCRIPTION
Skip jacdac if ndef CODAL_JACDAC_WIRE_SERIAL
