### PR TITLE
Edge serial

### DIFF
--- a/libs/edge-connector/pxt.json
+++ b/libs/edge-connector/pxt.json
@@ -8,6 +8,7 @@
     ],
     "public": true,
     "dependencies": {
-        "core": "file:../core"
+        "core": "file:../core",
+        "serial": "file:../serial"
     }
 }


### PR DESCRIPTION
The edge-connector packages also loads in the "serial" package (micro:bit compat)