### PR TITLE
fix null dereference if TileMap not set

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -119,7 +119,7 @@ namespace tiles {
         }
 
         public getTilesByType(index: number): Tile[] {
-            if (this.isInvalidIndex(index) || !this.enabled) return undefined;
+            if (this.isInvalidIndex(index) || !this.enabled) return [];
 
             let output: Tile[] = [];
             for (let col = 0; col < this._map.width; ++col) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1015