### PR TITLE
fix animation of rainbow in Adafruit

### DIFF
--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -1409,7 +1409,7 @@ namespace light {
                 for (let i = 0; i < n; i++) {
                     strip.setPixelColor(i, hsv(((i * 256) / (n - 1) + offset) % 0xff, 0xff, 0xff));
                 }
-                offset += Math.ceil(Math.max(1, Math.min(8, n / 20)));
+                offset += Math.ceil(128 / n);
                 if (offset >= 0xff) {
                     offset = 0;
                     return false;


### PR DESCRIPTION
Restore animation behavior (broken while trying to handle longer strips in fashion)
See https://github.com/microsoft/pxt-common-packages/blame/2cc52cf710412941a0c496b52d669511be824d6b/libs/light/neopixel.ts#L1317