### PR TITLE
Better double->string conversion

### DIFF
--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1249,6 +1249,8 @@ void mycvt(NUMBER d, char *buf) {
     // if we used e-notation, handle that
     if (e != 1) {
         *buf++ = 'e';
+        if (e > 0)
+            *buf++ = '+';
         itoa(e, buf);
     } else {
         *buf = 0;

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1193,7 +1193,10 @@ void mycvt(NUMBER d, char *buf) {
     // if outside 1e-6 -- 1e21 range, we use the e-notation
     if (d < 1e-6 || d > 1e21) {
         // normalize number to 1.XYZ, save e, and reset pw
-        d /= p10(pw);
+        if (pw < 0)
+            d *= p10(-pw);
+        else
+            d /= p10(pw);
         e = pw;
         pw = 0;
     }
@@ -1220,8 +1223,6 @@ void mycvt(NUMBER d, char *buf) {
         while (n--)
             *buf++ = '0';
     }
-
-    //uint64_t q = 100000000000000LL;
 
     // now print out the actual number
     for (int i = DIGITS - 1; i >= 0; i--) {

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1154,6 +1154,9 @@ TNumber neqq(TNumber a, TNumber b) {
 // in 64 bit double. Otherwise this code may crash.
 #define DIGITS 15
 
+// The basic idea is we convert d to an double representing integer with DIGITS
+// digits, and then print it out, putting dot in the right place.
+
 void mycvt(NUMBER d, char *buf) {
     if (d < 0) {
         *buf++ = '-';

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1154,7 +1154,25 @@ TNumber neqq(TNumber a, TNumber b) {
 // in 64 bit double. Otherwise this code may crash.
 #define DIGITS 15
 
-// The basic idea is we convert d to an double representing integer with DIGITS
+static const uint64_t pows[] = {
+    1LL,
+    10LL,
+    100LL,
+    1000LL,
+    10000LL,
+    100000LL,
+    1000000LL,
+    10000000LL,
+    100000000LL,
+    1000000000LL,
+    10000000000LL,    
+    100000000000LL,
+    1000000000000LL,
+    10000000000000LL,
+    100000000000000LL,
+};
+
+// The basic idea is we convert d to a 64 bit integer with DIGITS
 // digits, and then print it out, putting dot in the right place.
 
 void mycvt(NUMBER d, char *buf) {
@@ -1183,17 +1201,16 @@ void mycvt(NUMBER d, char *buf) {
     int trailingZ = 0;
     int dotAfter = pw + 1; // at which position the dot should be in the number
 
+    uint64_t dd;
+
     // normalize number to be integer with exactly DIGITS digits
     if (pw >= DIGITS) {
         // if the number is larger than DIGITS, we need trailing zeroes
         trailingZ = pw - DIGITS + 1;
-        d /= p10(trailingZ);
+        dd = (uint64_t)(d / p10(trailingZ) + 0.5);
     } else {
-        d *= p10(DIGITS - pw - 1);
+        dd = (uint64_t)(d * p10(DIGITS - pw - 1) + 0.5);
     }
-
-    // make sure we have an integer
-    d = round(d);
 
     // if number is less than 1, we need 0.00...00 at the beginning
     if (dotAfter < 1) {
@@ -1204,19 +1221,21 @@ void mycvt(NUMBER d, char *buf) {
             *buf++ = '0';
     }
 
+    //uint64_t q = 100000000000000LL;
+
     // now print out the actual number
     for (int i = DIGITS - 1; i >= 0; i--) {
-        NUMBER q = p10(i);
+        uint64_t q = pows[i];
         // this may be faster than fp-division and fmod(); or maybe not
         // anyways, it works
         int k = '0';
-        while (d >= q) {
-            d -= q;
+        while (dd >= q) {
+            dd -= q;
             k++;
         }
         *buf++ = k;
         // if we're after dot, and what's left is zeroes, stop
-        if (d == 0 && (DIGITS - i) >= dotAfter)
+        if (dd == 0 && (DIGITS - i) >= dotAfter)
             break;
         // print the dot, if we arrived at it
         if ((DIGITS - i) == dotAfter)


### PR DESCRIPTION
This no longer prints `1233.99999999999` instead of `1234`.

Fixes https://github.com/microsoft/pxt-microbit/issues/2019 - to be cherry-picked to master if everything works out

Tested on following numbers:
```
    13.7, 1234.56789, 1073741825,
    10737418250,
    107374182500,
    2000000001, 1, 0.1, 0.00001,
    1e101, 1.23456789e90
```
