### PR TITLE
move block for repeat event defaults to controller extension

### DIFF
--- a/libs/controller/controller.ts
+++ b/libs/controller/controller.ts
@@ -1,0 +1,13 @@
+namespace controller {
+    /**
+     * Configures the timing of the on button repeat event for all of the controller buttons
+     * @param delay number of milliseconds from when the button is pressed to when the repeat event starts firing, eg: 500
+     * @param interval minimum number of milliseconds between calls to the button repeat event, eg: 30
+     */
+    //% blockId=repeatDefaultDelayInterval block="set button repeat delay $delay ms interval $interval ms"
+    //% weight=10
+    //% group="Single Player"
+    export function configureRepeatEventDefaults(delay: number, interval: number) {
+        controller.setRepeatDefault(delay, interval);
+    }
+}

--- a/libs/controller/pxt.json
+++ b/libs/controller/pxt.json
@@ -8,6 +8,7 @@
         "accelerometer.ts",
         "lightsensor.ts",
         "thermometer.ts",
+        "controller.ts",
         "light.ts"
     ],
     "public": true,

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -171,9 +171,6 @@ namespace controller {
      * @param delay number of milliseconds from when the button is pressed to when the repeat event starts firing, eg: 500
      * @param interval minimum number of milliseconds between calls to the button repeat event, eg: 30
      */
-    //% blockId=repeatDefaultDelayInterval block="set button repeat delay $delay ms interval $interval ms"
-    //% weight=10
-    //% group="Single Player"
     export function setRepeatDefault(delay: number, interval: number) {
         defaultRepeatDelay = delay;
         defaultRepeatInterval = interval;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1064; leave the functionality in typescript, and move the block to the controller extension with other advanced behaviors