### PR TITLE
Enable neopixel support on STM32F4

### DIFF
--- a/libs/core/light.cpp
+++ b/libs/core/light.cpp
@@ -1,6 +1,6 @@
 #include "light.h"
 
-#if defined(SAMD21) || defined(SAMD51)
+#if defined(SAMD21) || defined(SAMD51) || defined(STM32F4)
 #include "neopixel.h"
 #endif
 
@@ -65,7 +65,7 @@ void spiNeopixelSendBuffer(DevicePin* pin, const uint8_t *data, unsigned size) {
 void neopixelSendData(DevicePin* pin, int mode, const uint8_t* data, unsigned length) {
     if (!pin || !length) return;
 
-#if defined(SAMD21) || defined(SAMD51)
+#if defined(SAMD21) || defined(SAMD51) || defined(STM32F4)
     if (length > NEOPIXEL_MIN_LENGTH_FOR_SPI && isValidMOSIPin(pin))
         spiNeopixelSendBuffer(pin, data, length);
     else


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1047

There was already neopixel support in codal-stm32 contributed by Riven from Kittenbot. It seems to just work. It will break if we run at higher frequency, but we can fix it when we have these.