### PR TITLE
set projectile to always be 1, and raise other initial kinds

### DIFF
--- a/libs/game/spritekind.ts
+++ b/libs/game/spritekind.ts
@@ -24,7 +24,7 @@ namespace SpriteKind {
     let nextKind: number;
 
     export function create() {
-        if (nextKind === undefined) nextKind = 1;
+        if (nextKind === undefined) nextKind = 1000;
         return nextKind++;
     }
 
@@ -32,7 +32,7 @@ namespace SpriteKind {
     export const Player = create();
 
     //% isKind
-    export const Projectile = create();
+    export const Projectile = 1;
 
     //% isKind
     export const Food = create();


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1078; backwards compat, and allow for hardcoded user kinds without conflicts