### PR TITLE
Don't sleep on USB

### DIFF
--- a/libs/base/sim/control.ts
+++ b/libs/base/sim/control.ts
@@ -132,6 +132,10 @@ namespace pxsim.control {
     export function heapDump() {
         // TODO something better
     }
+
+    export function isUSBInitialized() {
+        return false;
+    }
 }
 
 // keep in sync with pxtbase.h

--- a/libs/core---linux/control.cpp
+++ b/libs/core---linux/control.cpp
@@ -40,6 +40,14 @@ uint32_t _ramSize()
 #endif
 }
 
+/**
+ * Determines if the USB has been enumerated.
+ */
+//%
+bool isUSBInitialized() {
+    return false;
+}
+
 }
 
 namespace serial {

--- a/libs/core---samd/shims.d.ts
+++ b/libs/core---samd/shims.d.ts
@@ -1,4 +1,12 @@
 // Auto-generated. Do not edit.
+declare namespace control {
+
+    /**
+     * Determines if the USB has been enumerated.
+     */
+    //% shim=control::isUSBInitialized
+    function isUSBInitialized(): boolean;
+}
 declare namespace pins {
 
     /**

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -1,4 +1,12 @@
 // Auto-generated. Do not edit.
+declare namespace control {
+
+    /**
+     * Determines if the USB has been enumerated.
+     */
+    //% shim=control::isUSBInitialized
+    function isUSBInitialized(): boolean;
+}
 declare namespace pins {
 
     /**

--- a/libs/core/usb.cpp
+++ b/libs/core/usb.cpp
@@ -133,6 +133,20 @@ void usb_init() {}
 } // namespace pxt
 #endif
 
+namespace control {
+/**
+ * Determines if the USB has been enumerated.
+ */
+//%
+bool isUSBInitialized() {
+#if CONFIG_ENABLED(DEVICE_USB)
+    return pxt::usb.isInitialised();
+#else
+    return false;
+#endif
+}
+}
+
 namespace pxt {
 static void (*pSendToUART)(const char *data, int len) = NULL;
 void setSendToUART(void (*f)(const char *, int)) {

--- a/libs/power/power.ts
+++ b/libs/power/power.ts
@@ -60,5 +60,9 @@ namespace power {
 
         // read default value
         _timeout = control.getConfigValue(DAL.CFG_POWER_DEEPSLEEP_TIMEOUT, -1) * 1000;
+        // ensure deepsleep is long enough
+        const minDeepSleepTimeout = 300000;
+        if (_timeout > 0 && _timeout < minDeepSleepTimeout)
+            _timeout = minDeepSleepTimeout;
     }
 }

--- a/libs/power/power.ts
+++ b/libs/power/power.ts
@@ -39,7 +39,8 @@ namespace power {
         const p = _poked || 0;
         const to = _timeout || 0;
         if (to > 0 && 
-            control.millis() - p > to) {
+            control.millis() - p > to &&
+            !control.isUSBInitialized()) {
             // going to deep sleep
             deepSleep();
         }


### PR DESCRIPTION
- [x] don't go to deep sleep if the USB stack has been initialized by the USB host
- [x] wait at least 5 minutes before deepsleep (regardless of bootloader option)