### PR TITLE
use an object to store spritesByKind instead of an array (low density)

### DIFF
--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -51,7 +51,7 @@ namespace scene {
         tileMap: tiles.TileMap;
         allSprites: SpriteLike[];
         private spriteNextId: number;
-        spritesByKind: SpriteSet[];
+        spritesByKind: { [index: number]: SpriteSet };
         physicsEngine: PhysicsEngine;
         camera: scene.Camera;
         flags: number;
@@ -80,7 +80,7 @@ namespace scene {
             this.overlapHandlers = [];
             this.collisionHandlers = [];
             this.gameForeverHandlers = [];
-            this.spritesByKind = [];
+            this.spritesByKind = {};
             this.controlledSprites = [];
             this._data = {};
             this._millis = 0;


### PR DESCRIPTION
Use an object with numeric indexing instead of an array; this way only the indices used will actually be stored. This only really matters when kinds are arbitrarily high, which was previously rare (but now the norm).

On current master this doesn't cause crashes in most cases as there's enough memory in the devices to store 1000 empty indices, but if you raise the initial spritekind to 10000 it will immediately crash (on jumpy platformer at least), and currently is just taking a huge chunk of memory unnecessarily.

I felt like I was forgetting something since about an hour after merging https://github.com/microsoft/pxt-common-packages/pull/869, glad I figured it out before going to bed :)