### PR TITLE
fix sprite z index sorting

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -168,7 +168,7 @@ class Sprite implements SpriteLike {
     constructor(img: Image) {
         this._x = Fx8(screen.width - img.width >> 1);
         this._y = Fx8(screen.height - img.height >> 1);
-        this._z = 0
+        this.z = 0
         this._lastX = this._x;
         this._lastY = this._y;
         this.vx = 0


### PR DESCRIPTION
Just noticed the z index was messed up for all sprites if you don't explicitly set them to something non zero - e.g. in https://makecode.com/_hyW4WRR1eVaD the hero should be on top of any spawned shapes rather than behind them, because it has a z index of 5.

This is because the constructor is explicitly setting the _z field to 0, rather than passing it through the setter function for z which tells the scene to sort the sprites. So when a new sprite is created, it will be overlayed on top of all other sprites until the z index for another sprite is changed (to a new value - explicitly setting them to 0 won't work as it will be the same as the one set in the constructor and ignored). 

Maybe worth taking as a patch to the live site? Not a regression from the old one but it's a really simple change I'm surprised we never noticed