### PR TITLE
Scenify info and animations

### DIFF
--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -6,6 +6,35 @@ namespace animation {
     //Handles all the updates
     let animations: Animation[];
 
+    let animationStateStack: {
+        state: Animation[],
+        scene: scene.Scene
+    }[];
+
+    game.addScenePushHandler(oldScene => {
+        if (animations) {
+            if (!animationStateStack) animationStateStack = [];
+            animationStateStack.push({
+                state: animations,
+                scene: oldScene
+            });
+            animations = undefined;
+        }
+    });
+
+    game.addScenePopHandler(() => {
+        const scene = game.currentScene();
+        animations = undefined;
+        if (animationStateStack && animationStateStack.length) {
+            const nextState = animationStateStack.pop();
+            if (nextState.scene == scene) {
+                animations = nextState.state;
+            } else {
+                animationStateStack.push(nextState);
+            }
+        }
+    });
+
     export class Animation {
 
         sprites: Sprite[];

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -17,8 +17,8 @@ namespace game {
     let _scene: scene.Scene;
     let _sceneStack: scene.Scene[];
 
-    let _scenePushHandlers: (() => void)[];
-    let _scenePopHandlers: (() => void)[];
+    let _scenePushHandlers: ((scene: scene.Scene) => void)[];
+    let _scenePopHandlers: ((scene: scene.Scene) => void)[];
 
     export function currentScene(): scene.Scene {
         init();
@@ -58,7 +58,7 @@ namespace game {
     }
 
     export function pushScene() {
-        init();
+        const oldScene = game.currentScene()
         particles.clearAll();
         particles.disableAll();
         if (!_sceneStack) _sceneStack = [];
@@ -67,11 +67,12 @@ namespace game {
         init();
 
         if (_scenePushHandlers) {
-            _scenePushHandlers.forEach(cb => cb());
+            _scenePushHandlers.forEach(cb => cb(oldScene));
         }
     }
 
     export function popScene() {
+        const oldScene = game.currentScene()
         if (_sceneStack && _sceneStack.length) {
             // pop scenes from the stack
             _scene = _sceneStack.pop();
@@ -81,11 +82,12 @@ namespace game {
             control.popEventContext();
             _scene = undefined;
         }
+
         if (_scene)
             particles.enableAll();
 
         if (_scenePopHandlers) {
-            _scenePopHandlers.forEach(cb => cb());
+            _scenePopHandlers.forEach(cb => cb(oldScene));
         }
     }
 
@@ -317,7 +319,7 @@ namespace game {
      *
      * @param handler Code to run when a scene is pushed onto the stack
      */
-    export function addScenePushHandler(handler: () => void) {
+    export function addScenePushHandler(handler: (oldScene: scene.Scene) => void) {
         if (!_scenePushHandlers) _scenePushHandlers = [];
         _scenePushHandlers.push(handler);
     }
@@ -328,7 +330,7 @@ namespace game {
      *
      * @param handler The handler to remove
      */
-    export function removeScenePushHandler(handler: () => void) {
+    export function removeScenePushHandler(handler: (oldScene: scene.Scene) => void) {
         if (_scenePushHandlers) _scenePushHandlers.removeElement(handler);
     }
 
@@ -340,7 +342,7 @@ namespace game {
      *
      * @param handler Code to run when a scene is removed from the top of the stack
      */
-    export function addScenePopHandler(handler: () => void) {
+    export function addScenePopHandler(handler: (oldScene: scene.Scene) => void) {
         if (!_scenePopHandlers) _scenePopHandlers = [];
         _scenePopHandlers.push(handler);
     }
@@ -351,7 +353,7 @@ namespace game {
      *
      * @param handler The handler to remove
      */
-    export function removeScenePopHandler(handler: () => void) {
+    export function removeScenePopHandler(handler: (oldScene: scene.Scene) => void) {
         if (_scenePopHandlers) _scenePopHandlers.removeElement(handler);
     }
 }

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -95,7 +95,6 @@ namespace info {
 
     function initHUD() {
         if (infoState) return;
-        players = [];
 
         infoState = new InfoState();
 
@@ -495,29 +494,29 @@ namespace info {
     //% fixedInstances
     //% blockGap=8
     export class PlayerInfo {
-        _player: number;
-        bg: number; // background color
-        border: number; // border color
-        fc: number; // font color
-        showScore?: boolean;
-        showLife?: boolean;
-        visilibity: Visibility;
-        showPlayer?: boolean;
-        x?: number;
-        y?: number;
-        left?: boolean; // if true banner goes from x to the left, else goes rightward
-        up?: boolean; // if true banner goes from y up, else goes downward
+        protected _player: number;
+        public bg: number; // background color
+        public border: number; // border color
+        public fc: number; // font color
+        public showScore?: boolean;
+        public showLife?: boolean;
+        public visilibity: Visibility;
+        public showPlayer?: boolean;
+        public x?: number;
+        public y?: number;
+        public left?: boolean; // if true banner goes from x to the left, else goes rightward
+        public up?: boolean; // if true banner goes from y up, else goes downward
 
         constructor(player: number) {
             this._player = player;
             this.border = 1;
             this.fc = 1;
             this.visilibity = Visibility.None;
-            this.showScore = null;
-            this.showLife = null;
-            this.showPlayer = null;
-            this.left = null;
-            this.up = null;
+            this.showScore = undefined;
+            this.showLife = undefined;
+            this.showPlayer = undefined;
+            this.left = undefined;
+            this.up = undefined;
             if (this._player === 1) {
                 // Top left, and banner is white on red
                 this.bg = screen.isMono ? 0 : 2;
@@ -543,8 +542,7 @@ namespace info {
                 this.up = true;
             }
 
-            if (players == undefined)
-                players = [];
+            if (!players) players = [];
             players[this._player - 1] = this;
         }
 
@@ -561,6 +559,11 @@ namespace info {
             return infoState.playerStates[this._player - 1];
         }
 
+        // the id numbera of the player
+        id(): number {
+            return this._player;
+        }
+
         /**
          * Get the player score
          */
@@ -568,14 +571,14 @@ namespace info {
         //% blockId=piscore block="%player score"
         //% help=info/score
         score(): number {
-            if (this.showScore === null) this.showScore = true;
-            if (this.showPlayer === null) this.showPlayer = true;
+            if (this.showScore === undefined) this.showScore = true;
+            if (this.showPlayer === undefined) this.showPlayer = true;
 
             const state = this.getState();
 
             if (!state.score) {
                 state.score = 0;
-                saveHighScore();
+                updateHighScore(0);
             }
             return state.score;
         }
@@ -609,7 +612,7 @@ namespace info {
 
         hasScore() {
             const state = this.getState();
-            return state.score !== null;
+            return state.score !== undefined;
         }
 
         /**
@@ -620,10 +623,10 @@ namespace info {
         //% help=info/life
         life(): number {
             const state = this.getState();
-            if (this.showLife === null) this.showLife = true;
-            if (this.showPlayer === null) this.showPlayer = true;
+            if (this.showLife === undefined) this.showLife = true;
+            if (this.showPlayer === undefined) this.showPlayer = true;
 
-            if (state.life === null) {
+            if (state.life === undefined) {
                 state.life = 3;
             }
             return state.life;
@@ -666,7 +669,7 @@ namespace info {
         //% help=info/has-life
         hasLife(): boolean {
             const state = this.getState();
-            return state.life !== null;
+            return state.life !== undefined;
         }
 
         /**
@@ -683,8 +686,8 @@ namespace info {
 
         raiseLifeZero(gameOver: boolean) {
             const state = this.getState();
-            if (state.life !== null && state.life <= 0) {
-                state.life = null;
+            if (state.life !== undefined && state.life <= 0) {
+                state.life = undefined;
                 if (state.lifeZeroHandler) {
                     state.lifeZeroHandler();
                 } else if (gameOver) {
@@ -704,8 +707,8 @@ namespace info {
             let lifeWidth = 0;
             const offsetX = 1;
             let offsetY = 2;
-            let showScore = this.showScore && state.score !== null;
-            let showLife = this.showLife && state.life !== null;
+            let showScore = this.showScore && state.score !== undefined;
+            let showLife = this.showLife && state.life !== undefined;
 
             if (showScore) {
                 score = "" + state.score;

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -100,6 +100,7 @@ namespace info {
         infoState = new InfoState();
 
         game.eventContext().registerFrameHandler(scene.HUD_PRIORITY, () => {
+            if (!infoState) return;
             control.enablePerfCounter("info")
             // show score, lifes
             if (infoState.visibilityFlag & Visibility.Multi) {

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -18,24 +18,46 @@ namespace info {
         UserHeartImage = 1 << 5
     }
 
-    interface PlayerState {
-        score: number;
-        life: number;
-        lifeZeroHandler: () => void; // onPlayerLifeOver handler
+    class PlayerState {
+        public score: number;
+        public life: number;
+        public lifeZeroHandler: () => void;
+
+        constructor() { }
     }
 
-    interface InfoState {
-        visibilityFlag : number;
-        playerStates: PlayerState[];
+    class InfoState {
+        public playerStates: PlayerState[];
+        public visibilityFlag : number;
 
-        gameEnd: number;
-        heartImage: Image;
-        multiplierImage: Image;
-        bgColor: number;
-        borderColor: number;
-        fontColor: number;
-        countdownExpired: boolean;
-        countdownEndHandler: () => void;
+        public gameEnd: number;
+        public heartImage: Image;
+        public multiplierImage: Image;
+        public bgColor: number;
+        public borderColor: number;
+        public fontColor: number;
+        public countdownExpired: boolean;
+        public countdownEndHandler: () => void;
+
+        constructor() {
+            this.visibilityFlag = Visibility.Hud;
+            this.playerStates = [];
+            this.heartImage = defaultHeartImage();
+            this.multiplierImage = img`
+                1 . . . 1
+                . 1 . 1 .
+                . . 1 . .
+                . 1 . 1 .
+                1 . . . 1
+            `;
+            this.bgColor = screen.isMono ? 0 : 1;
+            this.borderColor = screen.isMono ? 1 : 3;
+            this.fontColor = screen.isMono ? 1 : 3;
+            this.countdownExpired = undefined;
+            this.countdownEndHandler = undefined;
+            this.gameEnd = undefined;
+            this.playerStates = [];
+        }
     }
 
     let infoState: InfoState = undefined;
@@ -75,24 +97,7 @@ namespace info {
         if (infoState) return;
         players = [];
 
-        infoState = {
-            visibilityFlag: Visibility.Hud,
-            playerStates: [],
-            heartImage: defaultHeartImage(),
-            multiplierImage: img`
-                1 . . . 1
-                . 1 . 1 .
-                . . 1 . .
-                . 1 . 1 .
-                1 . . . 1
-            `,
-            bgColor: screen.isMono ? 0 : 1,
-            borderColor: screen.isMono ? 1 : 3,
-            fontColor: screen.isMono ? 1 : 3,
-            countdownExpired: undefined,
-            countdownEndHandler: undefined,
-            gameEnd: undefined
-        };
+        infoState = new InfoState();
 
         game.eventContext().registerFrameHandler(scene.HUD_PRIORITY, () => {
             control.enablePerfCounter("info")
@@ -546,11 +551,7 @@ namespace info {
             initHUD();
             if (this._player > 1) initMultiHUD();
             if (!infoState.playerStates[this._player - 1]) {
-                infoState.playerStates[this._player - 1] = {
-                    score: undefined,
-                    life: undefined,
-                    lifeZeroHandler: undefined
-                };
+                infoState.playerStates[this._player - 1] = new PlayerState();
             }
         }
 

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -26,6 +26,7 @@ namespace info {
 
     interface InfoState {
         visibilityFlag : number;
+        playerStates: PlayerState[];
 
         gameEnd: number;
         heartImage: Image;
@@ -40,15 +41,9 @@ namespace info {
     let infoState: InfoState = undefined;
 
     let players: PlayerInfo[];
-    let playerStates: PlayerState[];
 
     let infoStateStack: {
         state: InfoState,
-        scene: scene.Scene
-    }[];
-
-    let playerStateStack: {
-        state: PlayerState[],
         scene: scene.Scene
     }[];
 
@@ -60,14 +55,6 @@ namespace info {
                 scene: oldScene
             });
             infoState = undefined;
-        }
-        if (playerStates) {
-            if (!playerStateStack) playerStateStack = [];
-            playerStateStack.push({
-                state: playerStates,
-                scene: oldScene
-            });
-            playerStates = undefined;
         }
     });
 
@@ -82,15 +69,6 @@ namespace info {
                 infoStateStack.push(nextState);
             }
         }
-        playerStates = undefined;
-        if (playerStateStack && playerStateStack.length) {
-            const nextState = playerStateStack.pop();
-            if (nextState.scene == scene) {
-                playerStates = nextState.state;
-            } else {
-                playerStateStack.push(nextState);
-            }
-        }
     });
 
     function initHUD() {
@@ -99,6 +77,7 @@ namespace info {
 
         infoState = {
             visibilityFlag: Visibility.Hud,
+            playerStates: [],
             heartImage: defaultHeartImage(),
             multiplierImage: img`
                 1 . . . 1
@@ -524,7 +503,6 @@ namespace info {
         up?: boolean; // if true banner goes from y up, else goes downward
 
         constructor(player: number) {
-            if (!playerStates) playerStates = [];
             this._player = player;
             this.border = 1;
             this.fc = 1;
@@ -567,9 +545,8 @@ namespace info {
         private init() {
             initHUD();
             if (this._player > 1) initMultiHUD();
-            if (!playerStates) playerStates = [];
-            if (!playerStates[this._player - 1]) {
-                playerStates[this._player - 1] = {
+            if (!infoState.playerStates[this._player - 1]) {
+                infoState.playerStates[this._player - 1] = {
                     score: undefined,
                     life: undefined,
                     lifeZeroHandler: undefined
@@ -579,7 +556,7 @@ namespace info {
 
         private getState() {
             this.init();
-            return playerStates[this._player - 1];
+            return infoState.playerStates[this._player - 1];
         }
 
         /**

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -45,10 +45,10 @@ class MovingSprite {
 class ArcadePhysicsEngine extends PhysicsEngine {
     protected sprites: Sprite[];
     protected map: sprites.SpriteMap;
-    private maxVelocity: Fx8;
-    private maxNegativeVelocity: Fx8;
-    private minSingleStep: Fx8;
-    private maxSingleStep: Fx8;
+    protected maxVelocity: Fx8;
+    protected maxNegativeVelocity: Fx8;
+    protected minSingleStep: Fx8;
+    protected maxSingleStep: Fx8;
 
     constructor(maxVelocity = 500, minSingleStep = 2, maxSingleStep = 4) {
         super();


### PR DESCRIPTION
Clean up info and animations state so they stay relative to the scene

fixes https://github.com/microsoft/pxt-arcade/issues/1101

also makes the game on push and and pop handlers pass the old scene, so that can be used when relevant

Will test this a little bit more before merging, as it seems pretty easy to break things here

https://makecode.com/_9FbM8q7mDW8w

![2019-06-26 17 37 50](https://user-images.githubusercontent.com/5615930/60224865-2dc5b400-9839-11e9-9530-90e4d2e5bdbd.gif)

```typescript
info.setScore(0)
info.setLife(3)
info.changeScoreBy(1)
info.startCountdown(1)

info.onCountdownEnd(function () {
    info.changeScoreBy(1)
})

pause(2000)
game.pushScene()
info.changeScoreBy(15)
info.startCountdown(1)

info.onCountdownEnd(function () {
    info.changeScoreBy(15)
})

pause(2000)
game.popScene()

pause(1500)

info.onLifeZero(function () {
    info.changeScoreBy(200)
})

while (true) {
    info.changeLifeBy(-1)
    pause(750)
}
```

test for multiplayer info:

```typescript
let players = [
    info.player1,
    info.player2,
    info.player3,
    info.player4
]
players.forEach(p => {
    p.onLifeZero(() => {
        console.log("player" + p.id() + " died")
    })
    info.setLife(3);
})

game.onUpdateInterval(1000, function () {
    players
        .forEach(p => {
            if (Math.percentChance(50)) {
                p.changeScoreBy(5)
            } else {
                p.changeLifeBy(Math.randomRange(-2, 1))
            }
        })
})
```