### PR TITLE
Fix crash in Segment::setLength manifesting in Object.keys()

### DIFF
--- a/libs/base/pxt.cpp
+++ b/libs/base/pxt.cpp
@@ -535,11 +535,13 @@ RefCollection *keysOf(TValue v) {
     auto len = rm->keys.getLength();
     if (!len)
         return r;
+    registerGCObj(r);
     r->setLength(len);
     auto dst = r->getData();
     memcpy(dst, rm->keys.getData(), len * sizeof(TValue));
     for (unsigned i = 0; i < len; ++i)
         incr(dst[i]);
+    unregisterGCObj(r);
     return r;
 }
 } // namespace pxtrt

--- a/libs/base/pxt.cpp
+++ b/libs/base/pxt.cpp
@@ -240,7 +240,7 @@ void Segment::ensure(ramint_t newSize) {
 
 void Segment::setLength(unsigned newLength) {
     if (newLength > size) {
-        ensure(length);
+        ensure(newLength);
     }
     length = newLength;
     return;

--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -945,6 +945,8 @@ void registerGC(TValue *root, int numwords = 1);
 void unregisterGC(TValue *root, int numwords = 1);
 void registerGCPtr(TValue ptr);
 void unregisterGCPtr(TValue ptr);
+static inline void registerGCObj(RefObject *ptr) { registerGCPtr((TValue)ptr); }
+static inline void unregisterGCObj(RefObject *ptr) { unregisterGCPtr((TValue)ptr); }
 void gc(int flags);
 #else
 inline void registerGC(TValue *root, int numwords = 1) {}

--- a/libs/core---vm/vmcache.cpp
+++ b/libs/core---vm/vmcache.cpp
@@ -136,7 +136,7 @@ static bool nameExists(const char *name) {
 //%
 RefCollection *list() {
     auto res = Array_::mk();
-    registerGCPtr((TValue)res);
+    registerGCObj(res);
 
     auto dp = openCacheDir();
     FullHeader fh;
@@ -155,10 +155,12 @@ RefCollection *list() {
                  id, fh.header.publicationTime, fh.header.installationTime, fh.header.lastUsageTime,
                  fh.header.name);
         auto str = mkString(buf, -1);
+        registerGCObj(str);
         Array_::push(res, (TValue)str);
+        unregisterGCObj(str);
     }
 
-    unregisterGCPtr((TValue)res);
+    unregisterGCObj(res);
     return res;
 }
 


### PR DESCRIPTION
This also makes sure to interface with GC correctly in Object.keys() (though this wasn't the cause of the crash)

@jwunderl this fixes your 843