### PR TITLE
Make small position adjustments respect tile map

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -147,11 +147,10 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 ms.dx = Fx.sub(ms.dx, stepX);
                 ms.dy = Fx.sub(ms.dy, stepY);
 
-                this.moveSprite(
-                    s,
-                    stepX,
-                    stepY
-                );
+                s._lastX = s._x;
+                s._lastY = s._y;
+                s._x = Fx.add(s._x, stepX);
+                s._y = Fx.add(s._y, stepY);
 
                 // if the sprite can collide with things, check tile map
                 // and add to collision detection
@@ -444,6 +443,27 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         s._lastY = s._y;
         s._x = Fx.add(s._x, dx);
         s._y = Fx.add(s._y, dy);
+
+        // if the sprite can collide with things, check tile map
+        if (!(s.flags & SPRITE_CANNOT_COLLIDE)) {
+            const tm = game.currentScene().tileMap;
+            if (!(tm && tm.enabled)) return;
+
+            const tileSize = 1 << tm.scale;
+            // only check tile map if moving within a single tile
+            if (Math.abs(Fx.toInt(dx)) < tileSize && Fx.toInt(dy) < tileSize) {
+                const ms = new MovingSprite(
+                    s,
+                    s._vx,
+                    s._vy,
+                    dx,
+                    dy,
+                    dx,
+                    dy
+                );
+                this.tilemapCollisions(ms, tm);
+            }
+        }
     }
 
     private constrain(v: Fx8) {

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -177,6 +177,8 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     private createMovingSprite(sprite: Sprite, dtSec: Fx8, dt2: Fx8): MovingSprite {
         const ovx = this.constrain(sprite._vx);
         const ovy = this.constrain(sprite._vy);
+        sprite._lastX = sprite._x;
+        sprite._lastY = sprite._y;
 
         sprite._vx = this.constrain(
             Fx.add(
@@ -336,7 +338,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
 
                 if (tm.isObstacle(x0, y0)) {
-                    sprite.registerObstacle(right ? CollisionDirection.Right : CollisionDirection.Left, tm.getObstacle(x0, y0));
                     if (sprite.flags & sprites.Flag.DestroyOnWall) {
                         sprite.destroy();
                     } else if (sprite.flags & sprites.Flag.BounceOnWall) {
@@ -360,6 +361,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             :
                             Fx8((x0 + 1) << tileScale)
                     );
+                    sprite.registerObstacle(right ? CollisionDirection.Right : CollisionDirection.Left, tm.getObstacle(x0, y0));
                     break;
                 }
             }
@@ -399,7 +401,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
 
                 if (tm.isObstacle(x0, y0)) {
-                    sprite.registerObstacle(down ? CollisionDirection.Bottom : CollisionDirection.Top, tm.getObstacle(x0, y0));
                     if (sprite.flags & sprites.Flag.DestroyOnWall) {
                         sprite.destroy();
                     } else if (sprite.flags & sprites.Flag.BounceOnWall) {
@@ -423,6 +424,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             :
                             Fx8((y0 + 1) << tileScale)
                     );
+                    sprite.registerObstacle(down ? CollisionDirection.Bottom : CollisionDirection.Top, tm.getObstacle(x0, y0));
                     break;
                 }
             }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -455,7 +455,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
             const tileSize = 1 << tm.scale;
             // only check tile map if moving within a single tile
-            if (Math.abs(Fx.toInt(dx)) < tileSize && Fx.toInt(dy) < tileSize) {
+            if (Math.abs(Fx.toInt(dx)) < tileSize && Math.abs(Fx.toInt(dy)) < tileSize) {
                 const ms = new MovingSprite(
                     s,
                     s._vx,

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -10,11 +10,12 @@ class PhysicsEngine {
 
     removeSprite(sprite: Sprite) { }
 
+    /** move a single sprite **/
     moveSprite(s: Sprite, dx: Fx8, dy: Fx8) { }
 
     draw() { }
 
-    /** Apply physics and collisions */
+    /** Apply physics and collisions to all sprites **/
     move(dt: number) { }
 
     overlaps(sprite: Sprite): Sprite[] { return []; }
@@ -440,6 +441,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         return this.map.overlaps(sprite);
     }
 
+    /** moves a sprite explicitly outside of the normal velocity changes **/
     public moveSprite(s: Sprite, dx: Fx8, dy: Fx8) {
         s._lastX = s._x;
         s._lastY = s._y;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -83,7 +83,6 @@ class Sprite implements SpriteLike {
     lifespan: number;
     private _image: Image;
     private _obstacles: sprites.Obstacle[];
-    private ongoingObstacles: sprites.Obstacle[];
 
     private updateSay: (dt: number, camera: scene.Camera) => void;
     private sayBubbleSprite: Sprite;
@@ -691,21 +690,9 @@ class Sprite implements SpriteLike {
 
         const collisionHandlers = game.currentScene().collisionHandlers[other.tileIndex];
         if (collisionHandlers) {
-            if (!this.ongoingObstacles) this.ongoingObstacles = [];
-            const handlerOccuring = this.ongoingObstacles
-                .some(obs => obs.x === other.x && obs.y === other.y);
-
-            if (!handlerOccuring) {
-                collisionHandlers
-                    .filter(h => h.kind == this.kind())
-                    .forEach(h => {
-                        this.ongoingObstacles.push(other);
-                        control.runInParallel(() => {
-                            h.handler(this);
-                            this.ongoingObstacles.removeElement(other);
-                        });
-                    });
-            }
+            collisionHandlers
+                .filter(h => h.kind == this.kind())
+                .forEach(h => h.handler(this));
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -56,74 +56,6 @@ class Sprite implements SpriteLike {
     _ax: Fx8
     _ay: Fx8
 
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="x" callInDebugger
-    get x(): number {
-        return Fx.toInt(this._x) + (this._image.width >> 1)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="x"
-    set x(v: number) {
-        this._lastX = this._x;
-        this._x = Fx8(v - (this._image.width >> 1))
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="y" callInDebugger
-    get y(): number {
-        return Fx.toInt(this._y) + (this._image.height >> 1)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="y"
-    set y(v: number) {
-        this._lastY = this._y;
-        this._y = Fx8(v - (this._image.height >> 1))
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vx (velocity x)" callInDebugger
-    get vx(): number {
-        return Fx.toFloat(this._vx)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vx (velocity x)"
-    set vx(v: number) {
-        this._vx = Fx8(v)
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vy (velocity y)" callInDebugger
-    get vy(): number {
-        return Fx.toFloat(this._vy)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vy (velocity y)"
-    set vy(v: number) {
-        this._vy = Fx8(v)
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ax (acceleration x)" callInDebugger
-    get ax(): number {
-        return Fx.toFloat(this._ax)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ax (acceleration x)"
-    set ax(v: number) {
-        this._ax = Fx8(v)
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ay (acceleration y)" callInDebugger
-    get ay(): number {
-        return Fx.toFloat(this._ay)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ay (acceleration y)"
-    set ay(v: number) {
-        this._ay = Fx8(v)
-    }
-
     /**
      * Custom data
      */
@@ -278,6 +210,7 @@ class Sprite implements SpriteLike {
     get height() {
         return this._image.height
     }
+
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="left"
     get left() {
@@ -286,7 +219,25 @@ class Sprite implements SpriteLike {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="left"
     set left(value: number) {
-        this._x = Fx8(value)
+        const physics = game.currentScene().physicsEngine;
+        physics.moveSprite(
+            this,
+            Fx.sub(
+                Fx8(value),
+                this._x
+            ),
+            Fx.zeroFx8
+        );
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="x" callInDebugger
+    get x(): number {
+        return Fx.toInt(this._x) + (this._image.width >> 1)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="x"
+    set x(v: number) {
+        this.left = v - (this._image.width >> 1)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="right"
@@ -306,7 +257,25 @@ class Sprite implements SpriteLike {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine
     set top(value: number) {
-        this._y = Fx8(value);
+        const physics = game.currentScene().physicsEngine;
+        physics.moveSprite(
+            this,
+            Fx.zeroFx8,
+            Fx.sub(
+                Fx8(value),
+                this._y
+            )
+        );
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="y" callInDebugger
+    get y(): number {
+        return Fx.toInt(this._y) + (this._image.height >> 1)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="y"
+    set y(v: number) {
+        this.top = v - (this._image.height >> 1)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="bottom"
@@ -317,6 +286,50 @@ class Sprite implements SpriteLike {
     //% blockCombine block="bottom"
     set bottom(value: number) {
         this.top = value - this.height;
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vx (velocity x)" callInDebugger
+    get vx(): number {
+        return Fx.toFloat(this._vx)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vx (velocity x)"
+    set vx(v: number) {
+        this._vx = Fx8(v)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vy (velocity y)" callInDebugger
+    get vy(): number {
+        return Fx.toFloat(this._vy)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vy (velocity y)"
+    set vy(v: number) {
+        this._vy = Fx8(v)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ax (acceleration x)" callInDebugger
+    get ax(): number {
+        return Fx.toFloat(this._ax)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ax (acceleration x)"
+    set ax(v: number) {
+        this._ax = Fx8(v)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ay (acceleration y)" callInDebugger
+    get ay(): number {
+        return Fx.toFloat(this._ay)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ay (acceleration y)"
+    set ay(v: number) {
+        this._ay = Fx8(v)
     }
     /**
      * The type of sprite
@@ -368,8 +381,12 @@ class Sprite implements SpriteLike {
     //% help=sprites/sprite/set-position
     //% x.shadow="positionPicker" y.shadow="positionPicker"
     setPosition(x: number, y: number): void {
-        this.x = x;
-        this.y = y;
+        const physics = game.currentScene().physicsEngine;
+        physics.moveSprite(
+            this,
+            Fx8(x - this.x),
+            Fx8(y - this.y)
+        );
     }
 
     /**

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -83,6 +83,7 @@ class Sprite implements SpriteLike {
     lifespan: number;
     private _image: Image;
     private _obstacles: sprites.Obstacle[];
+    private ongoingObstacles: sprites.Obstacle[];
 
     private updateSay: (dt: number, camera: scene.Camera) => void;
     private sayBubbleSprite: Sprite;
@@ -690,9 +691,21 @@ class Sprite implements SpriteLike {
 
         const collisionHandlers = game.currentScene().collisionHandlers[other.tileIndex];
         if (collisionHandlers) {
-            collisionHandlers
-                .filter(h => h.kind == this.kind())
-                .forEach(h => h.handler(this));
+            if (!this.ongoingObstacles) this.ongoingObstacles = [];
+            const handlerOccuring = this.ongoingObstacles
+                .some(obs => obs.x === other.x && obs.y === other.y);
+
+            if (!handlerOccuring) {
+                collisionHandlers
+                    .filter(h => h.kind == this.kind())
+                    .forEach(h => {
+                        this.ongoingObstacles.push(other);
+                        control.runInParallel(() => {
+                            h.handler(this);
+                            this.ongoingObstacles.removeElement(other);
+                        });
+                    });
+            }
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -56,6 +56,72 @@ class Sprite implements SpriteLike {
     _ax: Fx8
     _ay: Fx8
 
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="x" callInDebugger
+    get x(): number {
+        return Fx.toInt(this._x) + (this._image.width >> 1)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="x"
+    set x(v: number) {
+        this.left = v - (this._image.width >> 1)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="y" callInDebugger
+    get y(): number {
+        return Fx.toInt(this._y) + (this._image.height >> 1)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="y"
+    set y(v: number) {
+        this.top = v - (this._image.height >> 1)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vx (velocity x)" callInDebugger
+    get vx(): number {
+        return Fx.toFloat(this._vx)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vx (velocity x)"
+    set vx(v: number) {
+        this._vx = Fx8(v)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vy (velocity y)" callInDebugger
+    get vy(): number {
+        return Fx.toFloat(this._vy)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="vy (velocity y)"
+    set vy(v: number) {
+        this._vy = Fx8(v)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ax (acceleration x)" callInDebugger
+    get ax(): number {
+        return Fx.toFloat(this._ax)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ax (acceleration x)"
+    set ax(v: number) {
+        this._ax = Fx8(v)
+    }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ay (acceleration y)" callInDebugger
+    get ay(): number {
+        return Fx.toFloat(this._ay)
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="ay (acceleration y)"
+    set ay(v: number) {
+        this._ay = Fx8(v)
+    }
+
     /**
      * Custom data
      */
@@ -190,7 +256,6 @@ class Sprite implements SpriteLike {
     get z(): number {
         return this._z;
     }
-
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="z (depth)"
     set z(value: number) {
@@ -229,16 +294,7 @@ class Sprite implements SpriteLike {
             Fx.zeroFx8
         );
     }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="x" callInDebugger
-    get x(): number {
-        return Fx.toInt(this._x) + (this._image.width >> 1)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="x"
-    set x(v: number) {
-        this.left = v - (this._image.width >> 1)
-    }
+
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="right"
     get right() {
@@ -249,6 +305,7 @@ class Sprite implements SpriteLike {
     set right(value: number) {
         this.left = value - this.width
     }
+
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine
     get top() {
@@ -267,16 +324,7 @@ class Sprite implements SpriteLike {
             )
         );
     }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="y" callInDebugger
-    get y(): number {
-        return Fx.toInt(this._y) + (this._image.height >> 1)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="y"
-    set y(v: number) {
-        this.top = v - (this._image.height >> 1)
-    }
+
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="bottom"
     get bottom() {
@@ -288,49 +336,6 @@ class Sprite implements SpriteLike {
         this.top = value - this.height;
     }
 
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vx (velocity x)" callInDebugger
-    get vx(): number {
-        return Fx.toFloat(this._vx)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vx (velocity x)"
-    set vx(v: number) {
-        this._vx = Fx8(v)
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vy (velocity y)" callInDebugger
-    get vy(): number {
-        return Fx.toFloat(this._vy)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="vy (velocity y)"
-    set vy(v: number) {
-        this._vy = Fx8(v)
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ax (acceleration x)" callInDebugger
-    get ax(): number {
-        return Fx.toFloat(this._ax)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ax (acceleration x)"
-    set ax(v: number) {
-        this._ax = Fx8(v)
-    }
-
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ay (acceleration y)" callInDebugger
-    get ay(): number {
-        return Fx.toFloat(this._ay)
-    }
-    //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="ay (acceleration y)"
-    set ay(v: number) {
-        this._ay = Fx8(v)
-    }
     /**
      * The type of sprite
      */


### PR DESCRIPTION
Make small adjustments in position respect the tile map; this makes it so behaviors like this don't cause the sprite to ignore the tile map:

<img width="693" alt="Screen Shot 2019-06-30 at 12 51 33 PM" src="https://user-images.githubusercontent.com/5615930/60401410-d7f15480-9b35-11e9-95ee-0a4adfb42211.png">

Also reorders the tile collision handler detection; it would overwrite the change if you tried to change position in the event handler, which is invoked from ``sprite.registerObstacle``, making the end position incorrect if you e.g. change the scene and move the sprite to the beginning of the level. (I think I want to change this to behave like sprite overlap events, with the 'run in parallel but drop when running' behavior, though - I'll add that change here in a second unless anyone strongly opposes it, as it feels very weird to have different behaviors between the two main types of 'collisions')