### PR TITLE
make console log take any to match browser

### DIFF
--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -53,10 +53,10 @@ namespace console {
      */
     //% weight=90
     //% help=console/log blockGap=8
-    //% blockId=console_log block="console|log %text"
-    //% text.shadowOptions.toString=true
-    export function log(text: string): void {
-        add(ConsolePriority.Log, text);
+    //% blockId=console_log block="console log $value"
+    //% value.shadow=text
+    export function log(value: any): void {
+        add(ConsolePriority.Log, value + "");
     }
 
     /**


### PR DESCRIPTION
make ``console.log`` accept ``any`` like the dom version. Possibly noteworthy that ``text.shadowOptions.toString=true`` makes the blocks version already behave like this, except the string coercion shows up in the javascript after decompiling instead of just being part of log

@mmoskal are there any potential perf / object size issues that would block this?