### PR TITLE
Console inspect and pretty printing for objects / arrays in console.log

### DIFF
--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -74,18 +74,19 @@ namespace console {
     /**
      * Convert any object or value to a string representation
      * @param obj value to be converted to a string
+     * @param maxElements [optional] max number values in an object to include in output
      */
-    export function inspect(obj: any): string {
+    export function inspect(obj: any, maxElements = 20): string {
         if (typeof obj == "string") {
             return obj;
         } else if (typeof obj == "number") {
             return "" + obj;
         } else if (Array.isArray(obj)) {
             const asArr = (obj as Array<string>);
-            if (asArr.length <= 20) {
+            if (asArr.length <= maxElements) {
                 return asArr.join(",");
             } else {
-                return `${asArr.slice(0, 20).join(",")}...`;
+                return `${asArr.slice(0, maxElements).join(",")}...`;
             }
         /** TODO: should handle objects with toString like this:
          * } else if (obj.toString) {
@@ -101,9 +102,9 @@ namespace console {
             }
 
             let keys = Object.keys(obj);
-            const snipped = keys.length >= 20;
+            const snipped = keys.length > maxElements;
             if (snipped) {
-                keys = keys.slice(0, 20);
+                keys = keys.slice(0, maxElements);
             }
 
             return`{

--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -112,8 +112,8 @@ namespace console {
     ${
         keys
             .map(key => key + ": " + obj[key])
-            .join(",\n\t")
-        + (snipped ? "\n\t..." : "")
+            .join(",\n    ")
+        + (snipped ? "\n    ..." : "")
     }
 }`;
         }

--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -56,7 +56,7 @@ namespace console {
     //% blockId=console_log block="console log $value"
     //% value.shadow=text
     export function log(value: any): void {
-        add(ConsolePriority.Log, value + "");
+        add(ConsolePriority.Log, inspect(value));
     }
 
     /**
@@ -69,6 +69,41 @@ namespace console {
     //% blockId=console_log_value block="console|log value %name|= %value"
     export function logValue(name: string, value: number): void {
         log(name ? `${name}: ${value}` : `${value}`)
+    }
+
+    /**
+     * Convert any object or value to a string representation
+     * @param obj value to be converted to a string
+     */
+    export function inspect(obj: any): string {
+        if (typeof obj == "string") {
+            return obj;
+        } else if (typeof obj == "number") {
+            return "" + obj;
+        } else if (Array.isArray(obj)) {
+            return (obj as Array<string>).join(",");
+        /** TODO: should handle objects with toString like this:
+         * } else if (obj.toString) {
+         *    return obj.toString();
+         *
+         * instead of coercing it and checking against '[object Object]'
+         * but this is blocked by https://github.com/microsoft/pxt-arcade/issues/515 for now
+         */
+        } else {
+            const asString = obj + "";
+            if (asString != "[object Object]") {
+                return asString;
+            }
+
+            const keys = Object.keys(obj);
+            return`{
+    ${
+        keys
+            .map(key => key + ": " + obj[key])
+            .join(",\n\t")
+    }
+}`;
+        }
     }
 
     /**

--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -88,13 +88,6 @@ namespace console {
             } else {
                 return `${asArr.slice(0, maxElements).join(",")}...`;
             }
-        /** TODO: should handle objects with toString like this:
-         * } else if (obj.toString) {
-         *    return obj.toString();
-         *
-         * instead of coercing it and checking against '[object Object]'
-         * but this is blocked by https://github.com/microsoft/pxt-arcade/issues/515 for now
-         */
         } else {
             const asString = obj + "";
             if (asString != "[object Object]"
@@ -108,13 +101,12 @@ namespace console {
                 keys = keys.slice(0, maxElements);
             }
 
-            return`{
-    ${
-        keys
-            .map(key => key + ": " + obj[key])
-            .join(",\n    ")
-        + (snipped ? "\n    ..." : "")
-    }
+            return `{${
+                keys.reduce(
+                    (prev, currKey) => prev + `\n    ${currKey}: ${obj[currKey]}`,
+                    ""
+                ) + (snipped ? "\n    ..." : "")
+            }
 }`;
         }
     }

--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -81,7 +81,12 @@ namespace console {
         } else if (typeof obj == "number") {
             return "" + obj;
         } else if (Array.isArray(obj)) {
-            return (obj as Array<string>).join(",");
+            const asArr = (obj as Array<string>);
+            if (asArr.length <= 20) {
+                return asArr.join(",");
+            } else {
+                return `${asArr.slice(0, 20).join(",")}...`;
+            }
         /** TODO: should handle objects with toString like this:
          * } else if (obj.toString) {
          *    return obj.toString();
@@ -95,12 +100,18 @@ namespace console {
                 return asString;
             }
 
-            const keys = Object.keys(obj);
+            let keys = Object.keys(obj);
+            const snipped = keys.length >= 20;
+            if (snipped) {
+                keys = keys.slice(0, 20);
+            }
+
             return`{
     ${
         keys
             .map(key => key + ": " + obj[key])
             .join(",\n\t")
+        + (snipped ? "\n\t..." : "")
     }
 }`;
         }

--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -97,7 +97,8 @@ namespace console {
          */
         } else {
             const asString = obj + "";
-            if (asString != "[object Object]") {
+            if (asString != "[object Object]"
+                && asString != "[Object]") { // on arcade at least, default toString is [Object] on hardware instead of standard
                 return asString;
             }
 


### PR DESCRIPTION
re: discussion in https://github.com/microsoft/pxt-common-packages/pull/885

~Had to work around minor bug: https://github.com/microsoft/pxt-arcade/issues/515~

Noticed that the default toString for objects is ``[Object]`` on pygamer in arcade, rather than ``[object Object]``; could fix that I suppose, as it looks like it's defined here https://github.com/microsoft/pxt-common-packages/blob/68c76b90636c9dcd9ec3de0774a06e5d58ec0316/libs/base/core.cpp#L408

Also, the ``console overlay`` doesn't handle new lines nicely (it just offsets by a single line per console.log rather than by how many lines it takes up), will fix that separately

here's the test I used: https://makecode.com/_9vd7opftoaqP

```typescript
game.consoleOverlay.setVisible(true)
const myObj = {
    a: "a",
    b: "b",
    c: "c",
    d: "d",
    e: "e",
    s: sprites.create(img`2`)
}

const myLargeObj = {
    a: "a",
    b: "b",
    c: "c",
    d: "d",
    e: "e",
    f: "f",
    g: "g",
    h: "h",
    i: "i",
    j: "j",
    k: "k",
    l: "l",
    m: "m",
    n: "n",
    o: "o",
    p: "p",
    q: "q",
    r: "r",
    s: sprites.create(img`2`),
    t: "t",
    u: "u",
    v: "v",
    w: "w",
    x: "x",
    y: "y",
    z: "z"
}
let myLargeArr = [0]
for (let i = 1; i < 100; i++) myLargeArr.push(i);

console.log("hello")
console.log([1, 2, 3])
console.log(sprites.create(img`1`))
console.log(1)

console.log(myObj)
console.log(myLargeObj)
console.log(myLargeArr)
```

with output

```
sim.js:3449 l>hello
sim.js:3449 l>1,2,3
sim.js:3449 l>2(79,59)->(0,0)
sim.js:3449 l>1
sim.js:3449 l>{
    a: a,
    b: b,
    c: c,
    d: d,
    e: e,
    s: 0(79,59)->(0,0)
}
sim.js:3449 l>{
    a: a,
    b: b,
    c: c,
    d: d,
    e: e,
    f: f,
    g: g,
    h: h,
    i: i,
    j: j,
    k: k,
    l: l,
    m: m,
    n: n,
    o: o,
    p: p,
    q: q,
    r: r,
    s: 1(79,59)->(0,0),
    t: t
    ...
}
sim.js:3449 l>0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19...
```