### PR TITLE
handle multi line strings in console overlay

### DIFF
--- a/libs/game/console.ts
+++ b/libs/game/console.ts
@@ -4,7 +4,7 @@ namespace game.consoleOverlay {
     const marginx = 4;
     const marginy = 2;
     const consoleFont = image.font5;
-    const consoleLines = Math.floor(screen.height / (consoleFont.charHeight + marginy)) - 1;
+    const MAX_CONSOLE_LINES = Math.floor(screen.height / (consoleFont.charHeight + marginy)) - 1;
     console.addListener(listener);
 
     export function isVisible() {
@@ -15,31 +15,40 @@ namespace game.consoleOverlay {
         consoleStrings = [];
     }
 
-    export function setVisible(value: boolean) {
+    export function setVisible(value: boolean, col?: number) {
         if (value != !!consoleStrings)
             consoleStrings = value ? [] : undefined;
+        if (col !== undefined)
+            consoleColor = col;
     }
 
     function listener(priority: ConsolePriority, text: string) {
         if (!consoleStrings)
             return;
-        else if (consoleStrings.length < consoleLines)
+
+        let newLineIndex = text.indexOf("\n");
+        while (newLineIndex >= 0) {
+            consoleStrings.push(text.substr(0, newLineIndex))
+            text = text.substr(newLineIndex + 1, text.length);
+            newLineIndex = text.indexOf("\n");
+        }
+
+        if (!!text) {
             consoleStrings.push(text);
-        else {
-            for (let i = 1; i < consoleStrings.length; ++i) {
-                consoleStrings[i - 1] = consoleStrings[i];
-            }
-            consoleStrings[consoleStrings.length - 1] = text;
+        }
+
+        if (consoleStrings.length > MAX_CONSOLE_LINES) {
+            consoleStrings.splice(0, consoleStrings.length - MAX_CONSOLE_LINES);
         }
     }
 
     export function draw() {
         if (!consoleStrings || scene.systemMenu.isVisible()) return;
-        const height = consoleFont.charHeight + marginy ;
-        const top = 2 + (game.stats ? height : 0);
+        const lineHeight = consoleFont.charHeight + marginy;
+        const top = 2 + (game.stats ? lineHeight : 0);
         for (let i = 0; i < consoleStrings.length; ++i) {
             const t = consoleStrings[i];
-            screen.print(t, marginx, top + i * height, consoleColor, consoleFont);
+            screen.print(t, marginx, top + i * lineHeight, consoleColor, consoleFont);
         }
     }
 }

--- a/libs/game/console.ts
+++ b/libs/game/console.ts
@@ -26,16 +26,9 @@ namespace game.consoleOverlay {
         if (!consoleStrings)
             return;
 
-        let newLineIndex = text.indexOf("\n");
-        while (newLineIndex >= 0) {
-            consoleStrings.push(text.substr(0, newLineIndex))
-            text = text.substr(newLineIndex + 1, text.length);
-            newLineIndex = text.indexOf("\n");
-        }
-
-        if (!!text) {
-            consoleStrings.push(text);
-        }
+        text.split("\n")
+            .filter(line => !!line)
+            .forEach(line => consoleStrings.push(line));
 
         if (consoleStrings.length > MAX_CONSOLE_LINES) {
             consoleStrings.splice(0, consoleStrings.length - MAX_CONSOLE_LINES);
@@ -44,11 +37,11 @@ namespace game.consoleOverlay {
 
     export function draw() {
         if (!consoleStrings || scene.systemMenu.isVisible()) return;
-        const lineHeight = consoleFont.charHeight + marginy;
-        const top = 2 + (game.stats ? lineHeight : 0);
+        const height = consoleFont.charHeight + marginy;
+        const top = 2 + (game.stats ? height : 0);
         for (let i = 0; i < consoleStrings.length; ++i) {
             const t = consoleStrings[i];
-            screen.print(t, marginx, top + i * lineHeight, consoleColor, consoleFont);
+            screen.print(t, marginx, top + i * height, consoleColor, consoleFont);
         }
     }
 }


### PR DESCRIPTION
splits up lines so multi line strings fit nicely into the console overlay; e.g. this:

![2019-07-11 10 56 53](https://user-images.githubusercontent.com/5615930/61075480-ec074280-a3ce-11e9-84bd-854eadbaefa1.gif)

instead of this:

![2019-07-11 11 29 29](https://user-images.githubusercontent.com/5615930/61075606-34266500-a3cf-11e9-863a-6fb10491674f.gif)

this was annoying with https://github.com/microsoft/pxt-common-packages/pull/886, as the pretty printing wasn't that pretty due to everything overlapping

Also add optional parameter to to ``.setVisible``, so that people can set the color if they want to

https://makecode.com/_1y3W2ceD8C3J