### PR TITLE
Fix memory mgmt in Image.doubled()

### DIFF
--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -610,7 +610,9 @@ void replace(Image_ img, int from, int to) {
 //%
 Image_ doubled(Image_ img) {
     Image_ tmp = doubledX(img);
+    registerGCObj(tmp);
     Image_ r = doubledY(tmp);
+    unregisterGCObj(tmp);
     decrRC(tmp);
     return r;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1133