### PR TITLE
Splash loc

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -102,28 +102,35 @@ namespace game {
 
     export function showDialog(title: string, subtitle: string, footer?: string) {
         init();
-        const font = image.getFontForText(title + subtitle + (footer || ""));
+        const titleFont = image.getFontForText(title || "");
+        const subFont = image.getFontForText(subtitle || "")
+        const footerFont = image.getFontForText(footer || "");
         let h = 8;
         if (title)
-            h += font.charHeight;
+            h += titleFont.charHeight;
         if (subtitle)
-            h += 2 + font.charHeight
+            h += 2 + subFont.charHeight
         h += 8;
         const top = showDialogBackground(h, 9)
-        if (title)
-            screen.print(title, 8, top + 8, screen.isMono ? 1 : 7, font);
-        if (subtitle)
-            screen.print(subtitle, 8, top + 8 + font.charHeight + 2, screen.isMono ? 1 : 6, font);
+        let y = top + 8;
+        if (title) {
+            screen.print(title, 8, y, screen.isMono ? 1 : 7, titleFont);
+            y += titleFont.charHeight + 2;
+        }
+        if (subtitle) {
+            screen.print(subtitle, 8, y, screen.isMono ? 1 : 6, subFont);
+            y += subFont.charHeight + 2;
+        }
         if (footer) {
-            const footerTop = screen.height - font.charHeight - 4;
-            screen.fillRect(0, footerTop, screen.width, font.charHeight + 4, 0);
+            const footerTop = screen.height - footerFont.charHeight - 4;
+            screen.fillRect(0, footerTop, screen.width, footerFont.charHeight + 4, 0);
             screen.drawLine(0, footerTop, screen.width, footerTop, 1);
             screen.print(
                 footer,
-                screen.width - footer.length * font.charWidth - 8,
-                screen.height - font.charHeight - 2,
+                screen.width - footer.length * footerFont.charWidth - 8,
+                screen.height - footerFont.charHeight - 2,
                 1,
-                font
+                footerFont
             )
         }
     }

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -569,6 +569,11 @@ namespace game {
         dialogTextColor = Math.floor(Math.min(15, Math.max(0, color)));
     }
 
+    // this function is deprecated
+    //% deprecated blockHidden
+    export function setDialogFont(font: image.Font) {
+    }
+
     /**
      * Show a title and an optional subtitle menu
      * @param title

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -590,7 +590,7 @@ namespace game {
         game.pushScene();
         scene.setBackgroundImage(temp);
 
-        const dialog = new SplashDialog(screen.width, subtitle ? 44 : 35);
+        const dialog = new SplashDialog(screen.width, subtitle ? 42 : 35);
         dialog.setText(title);
         if (subtitle) dialog.setSubtext(subtitle);
 

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -16,7 +16,6 @@ enum DialogLayout {
 namespace game {
     let dialogFrame: Image;
     let dialogCursor: Image;
-    let dialogFont: image.Font;
     let dialogTextColor: number;
 
     export class BaseDialog {
@@ -40,7 +39,7 @@ namespace game {
 
             this.frame = frame || dialogFrame || (dialogFrame = defaultFrame());
 
-            this.font = font || dialogFont || (dialogFont = image.font8); // FONT8-TODO
+            this.font = font || image.font8;
 
             this.cursor = cursor || dialogCursor || (dialogCursor = defaultCursorImage());
 
@@ -149,6 +148,10 @@ namespace game {
 
         protected textAreaHeight() {
             return this.image.height - ((this.innerTop + this.unit) << 1) - 1;
+        }
+
+        protected setFont(font: image.Font) {
+            this.font = font;
         }
     }
 
@@ -293,9 +296,13 @@ namespace game {
             this.textColor = 1;
         }
 
+        private updateFont() {
+            this.setFont(image.getFontForText((this.text || "") + (this.subtext || "")));
+        }
 
         setText(text: string) {
             this.text = text;
+            this.updateFont();
             this.offset = 0;
             this.maxOffset = text.length * this.font.charWidth - screen.width + (this.unit << 1);
             this.timer = 2;
@@ -303,7 +310,8 @@ namespace game {
 
         setSubtext(sub: string) {
             this.subtext = sub;
-            this.maxSubOffset = sub.length * (image.font5.charWidth) - screen.width + (this.unit << 1);
+            this.updateFont();
+            this.maxSubOffset = sub.length * (this.font.charWidth) - screen.width + (this.unit << 1);
         }
 
         drawTextCore() {
@@ -334,11 +342,11 @@ namespace game {
 
             if (this.subtext) {
                 if (this.maxSubOffset < 0) {
-                    const left = (this.image.width >> 1) - (this.subtext.length * image.font5.charWidth >> 1)
-                    this.image.print(this.subtext, left, 20, this.textColor, image.font5);
+                    const left = (this.image.width >> 1) - (this.subtext.length * this.font.charWidth >> 1)
+                    this.image.print(this.subtext, left, 20, this.textColor, this.font);
                 }
                 else {
-                    this.image.print(this.subtext, this.unit - (Math.min(this.offset, this.maxSubOffset)), 20, this.textColor, image.font5);
+                    this.image.print(this.subtext, this.unit - (Math.min(this.offset, this.maxSubOffset)), 20, this.textColor, this.font);
                 }
             }
             this.drawBorder();
@@ -559,10 +567,6 @@ namespace game {
     //% help=game/set-dialog-text-color
     export function setDialogTextColor(color: number) {
         dialogTextColor = Math.floor(Math.min(15, Math.max(0, color)));
-    }
-
-    export function setDialogFont(font: image.Font) {
-        dialogFont = font;
     }
 
     /**

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -332,21 +332,23 @@ namespace game {
                     this.timer = 2;
                 }
             }
+            const ytitle = 10;
             if (this.maxOffset < 0) {
                 const left = (this.image.width >> 1) - (this.text.length * this.font.charWidth >> 1)
-                this.image.print(this.text, left, 10, this.textColor, this.font)
+                this.image.print(this.text, left, ytitle, this.textColor, this.font)
             }
             else {
-                this.image.print(this.text, this.unit - this.offset, 10, this.textColor, this.font)
+                this.image.print(this.text, this.unit - this.offset, ytitle, this.textColor, this.font)
             }
 
             if (this.subtext) {
+                const ysub = ytitle + this.font.charHeight + 2;
                 if (this.maxSubOffset < 0) {
                     const left = (this.image.width >> 1) - (this.subtext.length * this.font.charWidth >> 1)
-                    this.image.print(this.subtext, left, 20, this.textColor, this.font);
+                    this.image.print(this.subtext, left, ysub, this.textColor, this.font);
                 }
                 else {
-                    this.image.print(this.subtext, this.unit - (Math.min(this.offset, this.maxSubOffset)), 20, this.textColor, this.font);
+                    this.image.print(this.subtext, this.unit - (Math.min(this.offset, this.maxSubOffset)), ysub, this.textColor, this.font);
                 }
             }
             this.drawBorder();
@@ -588,7 +590,7 @@ namespace game {
         game.pushScene();
         scene.setBackgroundImage(temp);
 
-        const dialog = new SplashDialog(screen.width, subtitle ? 42 : 35);
+        const dialog = new SplashDialog(screen.width, subtitle ? 44 : 35);
         dialog.setText(title);
         if (subtitle) dialog.setSubtext(subtitle);
 

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -248,6 +248,7 @@ namespace game {
         setText(rawString: string) {
             this.chunks = this.chunkText(rawString);
             this.chunkIndex = 0;
+            this.setFont(image.getFontForText(rawString));
         }
 
         drawTextCore() {


### PR DESCRIPTION

![demo](https://user-images.githubusercontent.com/4175913/61305362-8b498280-a79f-11e9-96a7-376345495919.gif)

-  [x] Fix splash dialogs to support unicode
-  [x]  deprecate "dialogfont" as the font as to be computed based on the text

```
game.splash("你好", "世界")
game.ask("你好")
game.showDialog("你好", "你好")
game.showLongText("你好", DialogLayout.Bottom)
```