### PR TITLE
defer tmap velocity changes until after overlap events; allow override

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -339,19 +339,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
 
                 if (tm.isObstacle(x0, y0)) {
-                    if (sprite.flags & sprites.Flag.DestroyOnWall) {
-                        sprite.destroy();
-                    } else if (sprite.flags & sprites.Flag.BounceOnWall) {
-                        if ((!right && sprite.vx < 0) || (right && sprite.vx > 0)) {
-                            sprite._vx = Fx.neg(sprite._vx);
-                            movingSprite.xStep = Fx.neg(movingSprite.xStep);
-                            movingSprite.dx = Fx.neg(movingSprite.dx);
-                        }
-                    } else {
-                        movingSprite.dx = Fx.zeroFx8;
-                        sprite._vx = Fx.zeroFx8;
-                    }
-
                     sprite._x = Fx.iadd(
                         -sprite._hitbox.ox,
                         right ?
@@ -362,7 +349,31 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             :
                             Fx8((x0 + 1) << tileScale)
                     );
+
+                    const currVx = sprite.vx;
                     sprite.registerObstacle(right ? CollisionDirection.Right : CollisionDirection.Left, tm.getObstacle(x0, y0));
+
+                    if (sprite.flags & sprites.Flag.DestroyOnWall) {
+                        sprite.destroy();
+                    } else if (sprite.vx === currVx){
+                        // sprite collision event didn't change velocity in this direction;
+                        // apply normal updates
+                        if (sprite.flags & sprites.Flag.BounceOnWall) {
+                            if ((!right && sprite.vx < 0) || (right && sprite.vx > 0)) {
+                                sprite._vx = Fx.neg(sprite._vx);
+                                movingSprite.xStep = Fx.neg(movingSprite.xStep);
+                                movingSprite.dx = Fx.neg(movingSprite.dx);
+                            }
+                        } else {
+                            movingSprite.dx = Fx.zeroFx8;
+                            sprite._vx = Fx.zeroFx8;
+                        }
+                    }
+                    else if (Math.sign(sprite.vx) === Math.sign(currVx)) {
+                        // sprite collision event changed velocity,
+                        // but still facing same direction; prevent further movement this update.
+                        movingSprite.dx = Fx.zeroFx8;
+                    }
                     break;
                 }
             }
@@ -399,19 +410,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
 
                 if (tm.isObstacle(x0, y0)) {
-                    if (sprite.flags & sprites.Flag.DestroyOnWall) {
-                        sprite.destroy();
-                    } else if (sprite.flags & sprites.Flag.BounceOnWall) {
-                        if ((!down && sprite.vy < 0) || (down && sprite.vy > 0)) {
-                            sprite._vy = Fx.neg(sprite._vy);
-                            movingSprite.yStep = Fx.neg(movingSprite.yStep);
-                            movingSprite.dy = Fx.neg(movingSprite.dy);
-                        }
-                    } else {
-                        movingSprite.dy = Fx.zeroFx8;
-                        sprite._vy = Fx.zeroFx8;
-                    }
-
                     sprite._y = Fx.iadd(
                         -sprite._hitbox.oy,
                         down ?
@@ -422,7 +420,30 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             :
                             Fx8((y0 + 1) << tileScale)
                     );
+
+                    const currVy = sprite.vy;
                     sprite.registerObstacle(down ? CollisionDirection.Bottom : CollisionDirection.Top, tm.getObstacle(x0, y0));
+
+                    if (sprite.flags & sprites.Flag.DestroyOnWall) {
+                        sprite.destroy();
+                    } else if (sprite.vy === currVy) {
+                        // sprite collision event didn't change velocity in this direction;
+                        // apply normal updates
+                        if (sprite.flags & sprites.Flag.BounceOnWall) {
+                            if ((!down && sprite.vy < 0) || (down && sprite.vy > 0)) {
+                                sprite._vy = Fx.neg(sprite._vy);
+                                movingSprite.yStep = Fx.neg(movingSprite.yStep);
+                                movingSprite.dy = Fx.neg(movingSprite.dy);
+                            }
+                        } else {
+                            movingSprite.dy = Fx.zeroFx8;
+                            sprite._vy = Fx.zeroFx8;
+                        }
+                    } else if (Math.sign(sprite.vy) === Math.sign(currVy)) {
+                        // sprite collision event changed velocity,
+                        // but still facing same direction; prevent further movement this update.
+                        movingSprite.dy = Fx.zeroFx8;
+                    }
                     break;
                 }
             }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -350,12 +350,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             Fx8((x0 + 1) << tileScale)
                     );
 
-                    const currVx = sprite.vx;
                     sprite.registerObstacle(right ? CollisionDirection.Right : CollisionDirection.Left, tm.getObstacle(x0, y0));
 
                     if (sprite.flags & sprites.Flag.DestroyOnWall) {
                         sprite.destroy();
-                    } else if (sprite.vx === currVx){
+                    } else if (sprite._vx === movingSprite.cachedVx){
                         // sprite collision event didn't change velocity in this direction;
                         // apply normal updates
                         if (sprite.flags & sprites.Flag.BounceOnWall) {
@@ -368,8 +367,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             movingSprite.dx = Fx.zeroFx8;
                             sprite._vx = Fx.zeroFx8;
                         }
-                    }
-                    else if (Math.sign(sprite.vx) === Math.sign(currVx)) {
+                    } else if (Math.sign(Fx.toInt(sprite._vx)) === Math.sign(Fx.toInt(movingSprite.cachedVx))) {
                         // sprite collision event changed velocity,
                         // but still facing same direction; prevent further movement this update.
                         movingSprite.dx = Fx.zeroFx8;
@@ -421,12 +419,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             Fx8((y0 + 1) << tileScale)
                     );
 
-                    const currVy = sprite.vy;
                     sprite.registerObstacle(down ? CollisionDirection.Bottom : CollisionDirection.Top, tm.getObstacle(x0, y0));
 
                     if (sprite.flags & sprites.Flag.DestroyOnWall) {
                         sprite.destroy();
-                    } else if (sprite.vy === currVy) {
+                    } else if (sprite._vy === movingSprite.cachedVy) {
                         // sprite collision event didn't change velocity in this direction;
                         // apply normal updates
                         if (sprite.flags & sprites.Flag.BounceOnWall) {
@@ -439,7 +436,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                             movingSprite.dy = Fx.zeroFx8;
                             sprite._vy = Fx.zeroFx8;
                         }
-                    } else if (Math.sign(sprite.vy) === Math.sign(currVy)) {
+                    } else if (Math.sign(Fx.toInt(sprite._vy)) === Math.sign(Fx.toInt(movingSprite.cachedVy))) {
                         // sprite collision event changed velocity,
                         // but still facing same direction; prevent further movement this update.
                         movingSprite.dy = Fx.zeroFx8;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1143

behavior is effectively the same unless a tile collision event accesses or updates velocity in the same axis as the collision; in that case:

* if just reading, the event will have access to the velocity as it collides, rather than the velocity that will be applied after the collision
* if changing the velocity, the event get priority over the default collision handling - bounces and stopping won't occur (useful if you only want it to e.g. make the ball only bounce on certain tiles). If the speed has changed but is still moving in the same direction as the collision, it will stop moving (to prevent retrigger tile collision); otherwise it will update trajectory here on the next step:

https://github.com/microsoft/pxt-common-packages/blob/3bbdf9dc7f864d4f03e84538840c6286efdd95bb/libs/game/physics.ts#L122-L143