### PR TITLE
Allow game.askForNumber prompt to use screen's width

### DIFF
--- a/libs/game/numberprompt.ts
+++ b/libs/game/numberprompt.ts
@@ -95,6 +95,7 @@ namespace game {
     // Dimensions of prompt message area
     //% whenUsed=true
     const PROMPT_HEIGHT = INPUT_TOP - CONTENT_TOP;
+    //% whenUsed=true
     const PROMPT_WIDTH = screen.width - PROMPT_MARGIN_HORIZ * 2;
 
     //% whenUsed=true

--- a/libs/game/numberprompt.ts
+++ b/libs/game/numberprompt.ts
@@ -88,9 +88,14 @@ namespace game {
     //% whenUsed=true
     const INPUT_TOP = NUMPAD_TOP - INPUT_HEIGHT - NUMPAD_INPUT_MARGIN;
 
+    // Pixels kept blank on left and right sides of prompt
+    //% whenUsed=true
+    const PROMPT_MARGIN_HORIZ = 3;
+
     // Dimensions of prompt message area
     //% whenUsed=true
     const PROMPT_HEIGHT = INPUT_TOP - CONTENT_TOP;
+    const PROMPT_WIDTH = screen.width - PROMPT_MARGIN_HORIZ * 2;
 
     //% whenUsed=true
     const confirmText = "OK";
@@ -168,7 +173,7 @@ namespace game {
         }
 
         private drawPromptText() {
-            const prompt = sprites.create(layoutText(this.message, CONTENT_WIDTH, PROMPT_HEIGHT, this.theme.colorPrompt), -1);
+            const prompt = sprites.create(layoutText(this.message, PROMPT_WIDTH, PROMPT_HEIGHT, this.theme.colorPrompt), -1);
             prompt.x = screen.width / 2
             prompt.y = CONTENT_TOP + Math.floor((PROMPT_HEIGHT - prompt.height) / 2) + Math.floor(prompt.height / 2);
         }


### PR DESCRIPTION
Allow `game.askForNumber` prompt to span the width of the screen, instead of restricting it to the number pad's width.

Before:
![before](https://user-images.githubusercontent.com/38046796/62737429-c5ecb680-b9fd-11e9-888e-b498cbc7aa1f.png)

After:
![after](https://user-images.githubusercontent.com/38046796/62737442-cab16a80-b9fd-11e9-99fa-3de457142d7c.png)
