### PR TITLE
Allow game.askForNumber prompt to span screen width

### DIFF
--- a/libs/game/numberprompt.ts
+++ b/libs/game/numberprompt.ts
@@ -88,9 +88,15 @@ namespace game {
     //% whenUsed=true
     const INPUT_TOP = NUMPAD_TOP - INPUT_HEIGHT - NUMPAD_INPUT_MARGIN;
 
+    // Pixels kept blank on left and right sides of prompt
+    //% whenUsed=true
+    const PROMPT_MARGIN_HORIZ = 3;
+
     // Dimensions of prompt message area
     //% whenUsed=true
     const PROMPT_HEIGHT = INPUT_TOP - CONTENT_TOP;
+    //% whenUsed=true
+    const PROMPT_WIDTH = screen.width - PROMPT_MARGIN_HORIZ * 2
 
     //% whenUsed=true
     const confirmText = "OK";
@@ -168,7 +174,7 @@ namespace game {
         }
 
         private drawPromptText() {
-            const prompt = sprites.create(layoutText(this.message, CONTENT_WIDTH, PROMPT_HEIGHT, this.theme.colorPrompt), -1);
+            const prompt = sprites.create(layoutText(this.message, PROMPT_WIDTH, PROMPT_HEIGHT, this.theme.colorPrompt), -1);
             prompt.x = screen.width / 2
             prompt.y = CONTENT_TOP + Math.floor((PROMPT_HEIGHT - prompt.height) / 2) + Math.floor(prompt.height / 2);
         }


### PR DESCRIPTION
Modify @ChaseMor's commit to allow `game.askForNumber` prompt to span the width of the screen, rather than restrict it to the width of the number pad.

Before:
![before](https://user-images.githubusercontent.com/38046796/62738647-d18dac80-ba00-11e9-9e91-6754ec6ff00f.png)

After:
![after](https://user-images.githubusercontent.com/38046796/62738656-d5b9ca00-ba00-11e9-8855-4f2aa15780d9.png)
