### PR TITLE
switch BaseSprite namespace from sprite to sprites

### DIFF
--- a/libs/game/basesprite.ts
+++ b/libs/game/basesprite.ts
@@ -8,7 +8,7 @@ interface SpriteLike {
     __serialize(offset: number): Buffer;
 }
 
-namespace sprite {
+namespace sprites {
     export class BaseSprite implements SpriteLike {
         protected _z: number;
         id: number;

--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -50,7 +50,7 @@ namespace particles {
     /**
      * A source of particles
      */
-    export class ParticleSource extends sprite.BaseSprite {
+    export class ParticleSource extends sprites.BaseSprite {
         /**
          * A relative ranking of this sources priority
          * When necessary, a source with a lower priority will

--- a/libs/game/renderable.ts
+++ b/libs/game/renderable.ts
@@ -1,5 +1,5 @@
 namespace scene {
-    export class Renderable extends sprite.BaseSprite {
+    export class Renderable extends sprites.BaseSprite {
         public constructor(
             protected handler: (target: Image, camera: Camera) => void,
             protected shouldBeVisible: () => boolean,

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -41,7 +41,7 @@ enum FlipOption {
  * A sprite on the screen
  **/
 //% blockNamespace=sprites color="#4B7BEC" blockGap=8
-class Sprite extends sprite.BaseSprite {
+class Sprite extends sprites.BaseSprite {
     _x: Fx8
     _y: Fx8
     _vx: Fx8


### PR DESCRIPTION
Quick patch for https://github.com/microsoft/pxt-common-packages/pull/917 that I noticed after merging and testing again; I made a typo of having the namespace as ``sprite`` instead of ``sprites``, which causes some params for event handlers to be renamed unnecessarily on compilation / could conflict with any top level variables named sprite. 