### PR TITLE
remove id field conflicting with base class

### DIFF
--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -57,8 +57,6 @@ namespace particles {
          * be culled before a source with a higher priority.
          */
         priority: number;
-
-        id: number;
         _dt: number;
         /**
          * The anchor this source is currently attached to


### PR DESCRIPTION
re: https://forum.makecode.com/t/possibly-bogus-compilation-errors-from-beta-beta-makecode-arcade/431; just checked my old branch and I had removed it there but not pushed by accident :(

issue is that duplicate fields with the base class are failing to compile for hardware but succeed in sim; here ParticleSource had the id field redeclared accidentally