### PR TITLE
Add Image.equals(otherImage)

### DIFF
--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -412,8 +412,11 @@ void _mapRect(Image_ img, int xy, int wh, Buffer c) {
     mapRect(img, XX(xy), YY(xy), XX(wh), YY(wh), c);
 }
 
-//%
-bool _equals(Image_ img, Image_ other) {
+//% argsNullable
+bool equals(Image_ img, Image_ other) {
+    if (!other) {
+        return false;
+    }
     auto len = img->length();
     if (len != other->length()) {
         return false;

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -414,20 +414,11 @@ void _mapRect(Image_ img, int xy, int wh, Buffer c) {
 
 //%
 bool _equals(Image_ img, Image_ other) {
-    auto imgData = img->data();
-    auto otherData = other->data();
     auto len = img->length();
-
     if (len != other->length()) {
         return false;
     }
-
-    for (int i = 0; i < len; i++) {
-        if (imgData[i] != otherData[i]) {
-            return false;
-        }
-    }
-    return true;
+    return 0 == memcmp(img->data(), other->data(), len);
 }
 
 /**

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -412,6 +412,24 @@ void _mapRect(Image_ img, int xy, int wh, Buffer c) {
     mapRect(img, XX(xy), YY(xy), XX(wh), YY(wh), c);
 }
 
+//%
+bool _equals(Image_ img, Image_ other) {
+    auto imgData = img->data();
+    auto otherData = other->data();
+    auto len = img->length();
+
+    if (len != other->length()) {
+        return false;
+    }
+
+    for (int i = 0; i < len; i++) {
+        if (imgData[i] != otherData[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /**
  * Return a copy of the current image
  */

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -99,4 +99,7 @@ declare namespace image {
     //% block="create image width %width height %height" group="Create"
     //% help=images/create
     function create(width: number, height: number): Image;
+
+    //% shim=ImageMethods::_equals
+    function _equals(img: Image, other: Image): boolean;
 }

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -92,6 +92,13 @@ interface Image {
     //% block="change color in %picture=variables_get from %from=colorindexpicker to %to=colorindexpicker"
     //% help=images/image/replace
     replace(from: int32, to: int32): void;
+
+    /**
+     * Returns true if the provided image is the same as this image,
+     * otherwise returns false.
+     */
+    //% shim=ImageMethods::equals
+    equals(other: Image): boolean;
 }
 
 declare namespace image {
@@ -99,7 +106,4 @@ declare namespace image {
     //% block="create image width %width height %height" group="Create"
     //% help=images/create
     function create(width: number, height: number): Image;
-
-    //% shim=ImageMethods::_equals
-    function _equals(img: Image, other: Image): boolean;
 }

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -116,9 +116,6 @@ namespace helpers {
     //% shim=ImageMethods::_fillCircle
     function _fillCircle(img: Image, cxy: number, r: number, c: color): void { }
 
-    //% shim=ImageMethods::_equals
-    function _equals(img: Image, other: Image): boolean { return undefined }
-
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
     }
@@ -143,6 +140,11 @@ namespace helpers {
         imageDrawLine(img, x, y, x, y + h, c)
         imageDrawLine(img, x + w, y + h, x + w, y, c)
         imageDrawLine(img, x + w, y + h, x, y + h, c)
+    }
+
+    export function imageEquals(img: Image, other: Image) {
+        if (!other) return false;
+        return image._equals(img, other);
     }
 
     export function imageDrawCircle(img: Image, cx: number, cy: number, r: number, col: number) {
@@ -205,11 +207,6 @@ namespace helpers {
     }
     export function imageFillCircle(img: Image, cx: number, cy: number, r: number, col: number) {
         _fillCircle(img, pack(cx, cy), r, col);
-    }
-
-    export function imageEquals(img: Image, other: Image) {
-        if (!other) return false;
-        return _equals(img, other);
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -72,6 +72,13 @@ interface Image {
      */
     //% helper=imageRotated
     rotated(deg: number): Image;
+
+    /**
+     * Returns true if the provided image is the same as this image,
+     * otherwise returns false.
+     */
+    //% helper=imageEquals
+    equals(other: Image): boolean;
 }
 
 interface ScreenImage extends Image {
@@ -108,6 +115,9 @@ namespace helpers {
 
     //% shim=ImageMethods::_fillCircle
     function _fillCircle(img: Image, cxy: number, r: number, c: color): void { }
+
+    //% shim=ImageMethods::_equals
+    function _equals(img: Image, other: Image): boolean { return undefined }
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
@@ -195,6 +205,11 @@ namespace helpers {
     }
     export function imageFillCircle(img: Image, cx: number, cy: number, r: number, col: number) {
         _fillCircle(img, pack(cx, cy), r, col);
+    }
+
+    export function imageEquals(img: Image, other: Image) {
+        if (!other) return false;
+        return _equals(img, other);
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -72,13 +72,6 @@ interface Image {
      */
     //% helper=imageRotated
     rotated(deg: number): Image;
-
-    /**
-     * Returns true if the provided image is the same as this image,
-     * otherwise returns false.
-     */
-    //% helper=imageEquals
-    equals(other: Image): boolean;
 }
 
 interface ScreenImage extends Image {
@@ -140,11 +133,6 @@ namespace helpers {
         imageDrawLine(img, x, y, x, y + h, c)
         imageDrawLine(img, x + w, y + h, x + w, y, c)
         imageDrawLine(img, x + w, y + h, x, y + h, c)
-    }
-
-    export function imageEquals(img: Image, other: Image) {
-        if (!other) return false;
-        return image._equals(img, other);
     }
 
     export function imageDrawCircle(img: Image, cx: number, cy: number, r: number, col: number) {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -122,8 +122,8 @@ namespace pxsim.ImageMethods {
         mapRect(img, XX(xy), YY(xy), XX(wh), YY(wh), c)
     }
 
-    export function _equals(img: RefImage, other: RefImage) {
-        if (img._bpp != other._bpp || img._width != other._width || img._height != other._height) {
+    export function equals(img: RefImage, other: RefImage) {
+        if (!other || img._bpp != other._bpp || img._width != other._width || img._height != other._height) {
             return false;
         }
         let imgData = img.data;

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -122,6 +122,21 @@ namespace pxsim.ImageMethods {
         mapRect(img, XX(xy), YY(xy), XX(wh), YY(wh), c)
     }
 
+    export function _equals(img: RefImage, other: RefImage) {
+        if (img._bpp != other._bpp || img._width != other._width || img._height != other._height) {
+            return false;
+        }
+        let imgData = img.data;
+        let otherData = other.data;
+        let len = imgData.length;
+        for (let i = 0; i < len; i++) {
+            if (imgData[i] != otherData[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     export function getRows(img: RefImage, x: number, dst: RefBuffer) {
         x |= 0
         if (!img.inRange(x, 0))


### PR DESCRIPTION
needed to be able to compare images to make new animations be able to continue properly when you play the same one over again

I think https://github.com/microsoft/pxt/pull/5791 might be causing an issue compiling (to meowbit at least, I would assume all hw) now? Had to checkout a commit before to test this on hw, just giving a generic error: ``error: main.ts(1,1): error TS9200: Assertion failed``. Fun fact though, compilation is fast enough that it's actually pretty hard to read output.txt when it gets overwritten; need to stop the auto-re-running after pressing download so that it won't clobber the output I guess.