### PR TITLE
Add SWD remapping code to core---samd

### DIFF
--- a/libs/core---samd/platform.cpp
+++ b/libs/core---samd/platform.cpp
@@ -41,7 +41,30 @@ static void initRandomSeed() {
 
 void platformSendSerial(const char *data, int len) {}
 
+
+#ifdef SAMD21
+static void remapSwdPin(int pinCfg, int fallback) {
+    int pinName = getConfig(pinCfg);
+    if (pinName == PA30 || pinName == PA31) {
+        if (getConfig(CFG_SWD_ENABLED, 0)) {
+            linkPin(pinName, fallback);
+        } else {
+            PORT->Group[pinName / 32].PINCFG[pinName % 32].reg = (uint8_t)PORT_PINCFG_INEN;
+        }
+    }
+}
+
+static void initSwdPins() {
+    remapSwdPin(CFG_PIN_NEOPIXEL, PIN(D0));
+    remapSwdPin(CFG_PIN_RXLED, PIN(D1));
+    remapSwdPin(CFG_PIN_SPEAKER_AMP, PIN(A2));
+}
+#else
+static void initSwdPins() {}
+#endif
+
 void platform_init() {
+    initSwdPins();
     initRandomSeed();
     setSendToUART(platformSendSerial);
     light::clear();


### PR DESCRIPTION
CPX has SWD pin mapped to PIN_SPEAKER_AMP. Debugger needs to be enabled with:

```
namespace userconfig {
    export const SWD_ENABLED = 1
}
```

(similar on metro-m0, where the SWD is on neopixel)

this code comes from core/platform.cpp which was used with cpx mbed target