### PR TITLE
Move lowTimer on SAMD21 from TC3 to TCC0 to avoid conflict with DAC

### DIFF
--- a/libs/core---samd/platform.cpp
+++ b/libs/core---samd/platform.cpp
@@ -7,9 +7,10 @@
 namespace pxt {
 
 #ifdef CODAL_JACDAC_WIRE_SERIAL
+// TC3 is used by DAC on both D21 and D51
 #ifdef SAMD21
 SAMDTCTimer jacdacTimer(TC4, TC4_IRQn);
-SAMDTCTimer lowTimer(TC3, TC3_IRQn);
+SAMDTCCTimer lowTimer(TCC0, TCC0_IRQn);
 
 LowLevelTimer* getJACDACTimer()
 {


### PR DESCRIPTION
Note that the JACDAC timer on TC4-5 will conflict with PWM on A6, A7.

A2, A3 have PWM on TCC1, so should be fine.

@jamesadevine can jacdac use 16 bit timer? TCC2 or TC5 would be good.