### PR TITLE
Allow null as either argument to spi.transfer()

### DIFF
--- a/libs/core/spi.cpp
+++ b/libs/core/spi.cpp
@@ -96,8 +96,12 @@ int write(SPI_ device, int value) {
 /**
 * Transfer buffers over the SPI bus
 */
-//% 
+//% argsNullable
 void transfer(SPI_ device, Buffer command, Buffer response) {
+    if (!device)
+        target_panic(PANIC_CAST_FROM_NULL);
+    if (!command && !response)
+        return;
     device->transfer(command, response);
 }
 


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt/pull/5821 to function, but won't break build anyways