### PR TITLE
Fixes Adafruit IR

### DIFF
--- a/libs/cable/cable.cpp
+++ b/libs/cable/cable.cpp
@@ -22,7 +22,10 @@ class CableWrap : public PulseBase {
         inpin->eventOn(DEVICE_PIN_EVENT_ON_PULSE);
     }
 
-    CableWrap() : PulseBase(PULSE_CABLE_COMPONENT_ID, PIN(TX), PIN(TX),new SAMDTCCTimer(TCC2, TCC2_IRQn)) { setupGapEvents(); }
+    CableWrap()
+        : PulseBase(PULSE_CABLE_COMPONENT_ID, PIN(TX), PIN(TX), new SAMDTCTimer(TC4, TC4_IRQn)) {
+        setupGapEvents();
+    }
 };
 SINGLETON(CableWrap);
 
@@ -62,4 +65,4 @@ void onCableError(Action body) {
     registerWithDal(PULSE_CABLE_COMPONENT_ID, PULSE_PACKET_ERROR_EVENT, body);
 }
 
-}
+} // namespace network

--- a/libs/core---samd/platform.cpp
+++ b/libs/core---samd/platform.cpp
@@ -8,14 +8,13 @@ namespace pxt {
 
 #ifdef CODAL_JACDAC_WIRE_SERIAL
 // TC3 is used by DAC on both D21 and D51
-// TCC0 is used by IR
+// TCC0 and TC4 is used by IR
 // TCC0, TCC1, TC4 is used by PWM on CPX
 #ifdef SAMD21
 SAMDTCCTimer jacdacTimer(TCC2, TCC2_IRQn);
 SAMDTCTimer lowTimer(TC5, TC5_IRQn);
 
-LowLevelTimer* getJACDACTimer()
-{
+LowLevelTimer *getJACDACTimer() {
     jacdacTimer.setIRQPriority(1);
     return &jacdacTimer;
 }
@@ -25,16 +24,14 @@ LowLevelTimer* getJACDACTimer()
 SAMDTCTimer jacdacTimer(TC0, TC0_IRQn);
 SAMDTCTimer lowTimer(TC2, TC2_IRQn);
 
-LowLevelTimer* getJACDACTimer()
-{
+LowLevelTimer *getJACDACTimer() {
     jacdacTimer.setIRQPriority(1);
     return &jacdacTimer;
 }
 #endif
 #endif // CODAL_JACDAC_WIRE_SERIAL
 
-__attribute__((used))
-CODAL_TIMER devTimer(lowTimer);
+__attribute__((used)) CODAL_TIMER devTimer(lowTimer);
 
 static void initRandomSeed() {
     int seed = 0xC0DA1;
@@ -43,7 +40,6 @@ static void initRandomSeed() {
 }
 
 void platformSendSerial(const char *data, int len) {}
-
 
 #ifdef SAMD21
 static void remapSwdPin(int pinCfg, int fallback) {

--- a/libs/infrared/ir.cpp
+++ b/libs/infrared/ir.cpp
@@ -6,10 +6,10 @@
 namespace network {
 
 class IrWrap : public PulseBase {
-public:
+  public:
     IrWrap()
-    : PulseBase(PULSE_IR_COMPONENT_ID, PIN(IR_OUT), PIN(IR_IN),
-        new SAMDTCCTimer(TCC2, TCC2_IRQn)) {
+        : PulseBase(PULSE_IR_COMPONENT_ID, PIN(IR_OUT), PIN(IR_IN),
+                    new SAMDTCTimer(TC4, TC4_IRQn)) {
         setupGapEvents();
     }
 };
@@ -49,4 +49,4 @@ void onInfraredError(Action body) {
     getIrWrap();
     registerWithDal(PULSE_IR_COMPONENT_ID, PULSE_PACKET_ERROR_EVENT, body);
 }
-}
+} // namespace network


### PR DESCRIPTION
Move second IR timer to TC4 (because TCC2 is also used by jacdac)

Test program
```
input.buttonA.onEvent(ButtonEvent.Click, function () {
    network.infraredSendNumber(Math.randomRange(0, 10))
})
input.buttonB.onEvent(ButtonEvent.Click, function () {
    music.baDing.play();
})
network.onInfraredReceivedNumber(function (num) {
    light.graph(num, 10)
})
forever(function () {
    basic.pause(1000)
    pins.LED.digitalWrite(true)
    basic.pause(1000)
    pins.LED.digitalWrite(false)
})
```