### PR TITLE
fix neopixel light gradient

### DIFF
--- a/libs/light/defaultlights.ts
+++ b/libs/light/defaultlights.ts
@@ -22,9 +22,9 @@ namespace light {
      * @param endColor the end color
      */
     //% blockId="builtinlightsetgradient" block="set gradient from %startRgb=colorNumberPicker to %endRgb=colorNumberPicker"
-    //% weight=78 blockGap=8
-    export function setGradient(startRgb: number, endRgb: number, easing?: (t: number) => number) {
-        light.pixels.setGradient(startRgb, endRgb, easing);
+    //% weight=78 blockGap=8 blockHidden=true
+    export function setGradient(startRgb: number, endRgb: number) {
+        light.pixels.setGradient(startRgb, endRgb);
     }
 
     /**

--- a/libs/light/neopixel.ts
+++ b/libs/light/neopixel.ts
@@ -162,8 +162,8 @@ namespace light {
          */
         //% blockId=lightsetgradient block="set %strip gradient from %startColor=colorNumberPicker to %endColor=colorNumberPicker"
         //% weight=79 blockGap=8
-        //% group="More" advanced=true blockHidden=true
-        setGradient(startColor: number, endColor: number, easing?: (t: number) => number) {
+        //% group="More" advanced=true
+        setGradient(startColor: number, endColor: number) {
             const sr = color.unpackR(startColor);
             const sg = color.unpackG(startColor);
             const sb = color.unpackB(startColor);
@@ -176,7 +176,6 @@ namespace light {
             const stride = this.stride();
             for (let i = this._start; i < end; ++i) {
                 let x = (i - this._start) / n1;
-                if (easing) x = easing(x);
                 const ox = 1 - x;
                 const r = (sr * ox + er * x) | 0;
                 const g = (sg * ox + eg * x) | 0;


### PR DESCRIPTION
Not sure there's an easy way to add a different color for endColor? .defl / eg / etc don't work immediately, seems like it would need either an extra color picker https://github.com/microsoft/pxt/blob/33806faf215ce233b4cf946f0ce8f750f5f924a6/libs/pxt-common/pxt-helpers.ts#L468, or something of the sort. Will look into that separately