### PR TITLE
fix forever timeout to match loops.forever

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -276,7 +276,7 @@ namespace game {
                             });
                         }
                     });
-                    pause(30);
+                    pause(20);
                 }
             });
         }


### PR DESCRIPTION
@riknoll was right

make game.forever (used in arcade to tie forever to the game loop)'s timeout match the default of loops.forever