### PR TITLE
Add Image.blitRow and optimize get/setPixel

### DIFF
--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -72,6 +72,12 @@ interface Image {
      */
     //% helper=imageRotated
     rotated(deg: number): Image;
+
+    /**
+     * Scale and copy a row of pixels from a texture.
+     */
+    //% helper=imageBlitRow
+    blitRow(dstX: number, dstY: number, from: Image, fromX: number, fromH: number): void;
 }
 
 interface ScreenImage extends Image {
@@ -107,10 +113,17 @@ namespace helpers {
     function _drawIcon(img: Image, icon: Buffer, xy: number, c: color): void { }
 
     //% shim=ImageMethods::_fillCircle
-    function _fillCircle(img: Image, cxy: number, r: number, c: color): void { }
+    declare function _fillCircle(img: Image, cxy: number, r: number, c: color): void;
+
+    //% shim=ImageMethods::_blitRow
+    declare function _blitRow(img:Image, xy: number, from: Image, xh: number): void;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
+    }
+
+    export function imageBlitRow(img:Image, dstX: number, dstY: number, from: Image, fromX: number, fromH: number): void {
+        _blitRow(img, pack(dstX, dstY), from, pack(fromX, fromH))
     }
 
     export function imageDrawIcon(img: Image, icon: Buffer, x: number, y: number, c: color): void {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -496,7 +496,7 @@ namespace pxsim.ImageMethods {
             return
         if (img2[1] != 1)
             return // only mono
-        let w = image.bufW(img2)        
+        let w = image.bufW(img2)
         let h = image.bufH(img2)
         let byteH = image.byteHeight(h, 1)
 
@@ -576,6 +576,33 @@ namespace pxsim.ImageMethods {
 
     export function _fillCircle(img: RefImage, cxy: number, r: number, c: number) {
         fillCircle(img, XX(cxy), YY(cxy), r, c);
+    }
+
+    export function _blitRow(img: RefImage, xy: number, from: RefImage, xh: number) {
+        blitRow(img, XX(xy), YY(xy), from, XX(xh), YY(xh))
+    }
+
+    export function blitRow(img: RefImage, x: number, y: number, from: RefImage, fromX: number, fromH: number) {
+        x |= 0
+        y |= 0
+        fromX |= 0
+        fromH |= 0
+        if (!img.inRange(x, 0) || !img.inRange(fromX, 0) || fromH <= 0)
+            return
+        let fy = 0
+        let stepFY = from._width / fromH
+        let endY = y + fromH
+        if (endY > img._height)
+            endY = img._height
+        if (y < 0) {
+            fy += -y * stepFY
+            y = 0
+        }
+        while (y < endY) {
+            img.data[img.pix(x, y)] = from.data[from.pix(fromX, fy | 0)]
+            y++
+            fy += stepFY
+        }
     }
 }
 


### PR DESCRIPTION
This makes get/setCore non-inline, but the stuff they call is now inline

Now also adds Image.blitRow method which scales a copies a row of pixel from one image to another, for example to speed up this: https://makecode.com/_KgyAkARse6Hm