### PR TITLE
Add block to make one sprite follow another

### DIFF
--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -33,9 +33,10 @@ namespace scene {
 
     // frame handler priorities
     export const CONTROLLER_PRIORITY = 8;
+    export const UPDATE_CONTROLLER_PRIORITY = 13;
+    export const FOLLOW_SPRITE_PRIORITY = 14;
     export const PHYSICS_PRIORITY = 15;
     export const ANIMATION_UPDATE_PRIORITY = 15;
-    export const UPDATE_CONTROLLER_PRIORITY = 13;
     export const CONTROLLER_SPRITES_PRIORITY = 13;
     export const UPDATE_INTERVAL_PRIORITY = 19;
     export const UPDATE_PRIORITY = 20;
@@ -69,6 +70,7 @@ namespace scene {
         gameForeverHandlers: GameForeverHandlers[];
         particleSources: particles.ParticleSource[];
         controlledSprites: controller.ControlledSprite[][];
+        followingSprites: sprites.FollowingSprite[]
 
         private _millis: number;
         private _data: any;
@@ -108,6 +110,7 @@ namespace scene {
             })
             // controller update 13
             this.eventContext.registerFrameHandler(CONTROLLER_SPRITES_PRIORITY, controller._moveSprites);
+            // sprite following 14
             // apply physics and collisions 15
             this.eventContext.registerFrameHandler(PHYSICS_PRIORITY, () => {
                 control.enablePerfCounter("physics and collisions")

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -787,6 +787,81 @@ class Sprite extends sprites.BaseSprite {
             .forEach(h => h.handler(this));
     }
 
+    /**
+     * Make this sprite follow the target sprite.
+     *
+     * @param target the sprite this one should follow
+     * @param rate The rate at which this sprite should move, eg: 100
+     */
+    //% group="Physics" weight=10
+    //% blockId=spriteFollowOOtherSprite block="make %sprite(mySprite) follow %target(otherSprite) || with rate %rate"
+    follow(target: Sprite, rate = 100) {
+        if (target === this) return;
+
+        const scene = game.currentScene();
+        if (!scene.followingSprites) {
+            scene.followingSprites = [];
+            game.currentScene().eventContext.registerFrameHandler(14, function () {
+                let deadSprites = false;
+                scene.followingSprites.forEach(fs => {
+                    if ((fs.self.flags | fs.target.flags) & sprites.Flag.Destroyed) {
+                        deadSprites = true;
+                        return;
+                    }
+
+                    let dx = Fx.sub(fs.target._x, fs.self._x);
+                    let dy = Fx.sub(fs.target._y, fs.self._y);
+
+                    if (Fx.toInt(Fx.abs(dx)) < 1 && Fx.toInt(Fx.abs(dy)) < 1) {
+                        fs.self.vx = 0;
+                        fs.self.vy = 0;
+                        return;
+                    }
+
+                    let dist: number = Math.sqrt(
+                        Fx.toInt(
+                            Fx.add(
+                                Fx.mul(dx, dx),
+                                Fx.mul(dy, dy)
+                            )
+                        )
+                    );
+
+                    fs.self._vx = Fx.idiv(
+                        Fx.mul(fs.rate, dx),
+                        dist
+                    );
+
+                    fs.self._vy = Fx.idiv(
+                        Fx.mul(fs.rate, dy),
+                        dist
+                    );
+                });
+
+                if (deadSprites) {
+                    scene.followingSprites = scene.followingSprites
+                        .filter(fs => !((fs.self.flags | fs.target.flags) & sprites.Flag.Destroyed));
+                }
+            })
+        }
+
+        if (target == undefined || rate == 0) {
+            scene.followingSprites = scene.followingSprites.filter(fs => fs.self.id === this.id);
+        }
+
+        const fs = scene.followingSprites.find(fs => fs.self.id == this.id);
+        if (!fs) {
+            scene.followingSprites.push(new sprites.FollowingSprite(
+                this,
+                target,
+                Fx8(rate)
+            ));
+        } else {
+            fs.target = target;
+            fs.rate = Fx8(rate);
+        }
+    }
+
     toString() {
         return `${this.id}(${this.x},${this.y})->(${this.vx},${this.vy})`;
     }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -799,7 +799,7 @@ class Sprite extends sprites.BaseSprite {
      */
     //% group="Physics" weight=10
     //% blockId=spriteFollowOtherSprite
-    //% block="set %sprite(myEnemy) follow %target=variables_get(mySprite) || with speed %speed turn rate %turnRate"
+    //% block="set %sprite(myEnemy) follow %target=variables_get(mySprite) || with speed %speed"
     follow(target: Sprite, speed = 100, turnRate = 3) {
         if (target === this) return;
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -638,7 +638,7 @@ class Sprite extends sprites.BaseSprite {
             this.lifespan -= dt * 1000;
             if (this.lifespan <= 0) {
                 this.lifespan = undefined;
-                this.destroy();
+                this._destroyCore();
             }
         }
         if ((this.flags & sprites.Flag.AutoDestroy)
@@ -764,13 +764,16 @@ class Sprite extends sprites.BaseSprite {
     destroy(effect?: effects.ParticleEffect, duration?: number) {
         if (this.flags & sprites.Flag.Destroyed)
             return;
+        this.flags |= sprites.Flag.Destroyed;
 
-        if (effect) {
+        if (effect)
             effect.destroy(this, duration);
-            return;
-        }
+        else
+            this._destroyCore();
+    }
 
-        this.flags |= sprites.Flag.Destroyed
+    _destroyCore() {
+        this.flags |= sprites.Flag.Destroyed;
         const scene = game.currentScene();
         // When current sprite is destroyed, destroys sayBubbleSprite if defined
         if (this.sayBubbleSprite) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -830,7 +830,7 @@ class Sprite extends sprites.BaseSprite {
                     }
 
                     const distance = Math.sqrt(dx * dx + dy * dy);
-                    const turnPercentage = Math.min(fs.turnRate * timeDiff, 1);
+                    const turnPercentage = Math.clamp(0, 1, fs.turnRate * timeDiff);
 
                     fs.self.vx += (fs.rate * dx / distance - fs.self.vx) * turnPercentage;
                     fs.self.vy += (fs.rate * dy / distance - fs.self.vy) * turnPercentage;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -823,21 +823,17 @@ class Sprite extends sprites.BaseSprite {
                     const dy = fs.target.y - fs.self.y;
 
                     // already right on top of target; stop moving
-                    if (Math.abs(dx) < 1 && Math.abs(dy) < 1) {
+                    if (Math.abs(dx) < 2 && Math.abs(dy) < 2) {
                         fs.self.vx = 0;
                         fs.self.vy = 0;
                         return;
                     }
 
                     const distance = Math.sqrt(dx * dx + dy * dy);
-
                     const turnPercentage = Math.min(fs.turnRate * timeDiff, 1);
-                    
-                    const targetVx = fs.rate * dx / distance;
-                    const targetVy = fs.rate * dy / distance;
 
-                    fs.self.vx += (targetVx - fs.self.vx) * turnPercentage;
-                    fs.self.vy += (targetVy - fs.self.vy) * turnPercentage;
+                    fs.self.vx += (fs.rate * dx / distance - fs.self.vx) * turnPercentage;
+                    fs.self.vy += (fs.rate * dy / distance - fs.self.vy) * turnPercentage;
                 });
 
                 lastTime = currTime;

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -19,7 +19,8 @@ namespace sprites {
         constructor(
             public self: Sprite,
             public target: Sprite,
-            public rate: Fx8
+            public rate: number,
+            public turnRate: number
         ) { }
     }
 

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -15,6 +15,13 @@ Frame handlers:
 //% weight=99 color="#4B7BEC" icon="\uf1d8"
 //% groups='["Create", "Physics", "Effects", "Projectiles", "Overlaps", "Lifecycle"]'
 namespace sprites {
+    export class FollowingSprite {
+        constructor(
+            public self: Sprite,
+            public target: Sprite,
+            public rate: Fx8
+        ) { }
+    }
 
     /**
      * Create a new sprite from an image


### PR DESCRIPTION
add a block for making a sprite follow another one

![2019-08-21 20 56 01](https://user-images.githubusercontent.com/5615930/63484942-4ed00d00-c456-11e9-80b5-ad57eea80c74.gif)

~Had a version where turnRate was in degrees, but it slowed things down pretty significantly; this version the turnRate is very much arbitrary, but it has a pretty decent range of behaviors as written between 'orbit around player a bit before hitting' at 0.1 and 'immediately turn towards player' at ~ 5+; not sure that behaviors worth exposing, maybe better to just set it as a constant for now and revisit / add a parameter later. I guess it could also just use an enum (TurnSpeed.VerySlow, ...) and still be able to adjust it later~ dropping turnRate from the block, leaving as a javascript only option and we can adjust it later if we want to give it some more meaningful value

Couple quick examples

### pizza bouncing a pineapple away

https://makecode.com/_JbWix6U3e2du

![arcade-screenshot (1)](https://user-images.githubusercontent.com/5615930/63484745-95713780-c455-11e9-81e9-3973ef24de8e.png)

![2019-08-21 20 52 07](https://user-images.githubusercontent.com/5615930/63484750-999d5500-c455-11e9-911b-1ccf934bf6c2.gif)

### duck and soap

https://makecode.com/_PDCiFA6hm1kj

![arcade-screenshot (2)](https://user-images.githubusercontent.com/5615930/63484823-dc5f2d00-c455-11e9-9e75-a452d2eb49f8.png)

![2019-08-21 20 53 33](https://user-images.githubusercontent.com/5615930/63484853-f993fb80-c455-11e9-84a1-6419235ac8f7.gif)

### circling the drain

https://makecode.com/_4vC95zhtYbau

![arcade-screenshot (3)](https://user-images.githubusercontent.com/5615930/63485263-74114b00-c457-11e9-8d78-7c263a78380d.png)

![2019-08-21 21 04 38](https://user-images.githubusercontent.com/5615930/63485268-7a072c00-c457-11e9-8716-e3b46de9c974.gif)
