### PR TITLE
Classify some interfaces

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -196,11 +196,13 @@ namespace controller {
         return _players.filter(ctrl => !!ctrl);
     }
 
-    export interface ControlledSprite {
-        s: Sprite;
-        vx: number;
-        vy: number;
-        _inputLastFrame: boolean;
+    export class ControlledSprite {
+        public _inputLastFrame: boolean;
+        constructor(
+            public s: Sprite,
+            public vx: number,
+            public vy: number
+        ) { }
     }
 
     export function _moveSprites() {
@@ -327,7 +329,7 @@ namespace controller {
             if (!this._controlledSprites) this._controlledSprites = [];
             let cp = this._controlledSprites.find(cp => cp.s.id == sprite.id);
             if (!cp) {
-                cp = { s: sprite, vx: vx, vy: vy, _inputLastFrame: false }
+                cp = new ControlledSprite(sprite, vx, vy);
                 this._controlledSprites.push(cp);
             }
             if (cp.vx && vx == 0) {

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -282,10 +282,7 @@ namespace game {
         }
 
         game.currentScene().gameForeverHandlers.push(
-            new scene.GameForeverHandlers(
-                action,
-                false
-            )
+            new scene.GameForeverHandler(action)
         );
     }
 

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -281,10 +281,12 @@ namespace game {
             });
         }
 
-        game.currentScene().gameForeverHandlers.push({
-            handler: action,
-            lock: false
-        });
+        game.currentScene().gameForeverHandlers.push(
+            new scene.GameForeverHandlers(
+                action,
+                false
+            )
+        );
     }
 
     /**

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -10,9 +10,11 @@ namespace scene {
         NeedsSorting = 1 << 1,
     }
 
-    export interface SpriteHandler {
-        kind: number;
-        handler: (sprite: Sprite) => void;
+    export class SpriteHandler {
+        constructor(
+            public kind: number,
+            public handler: (sprite: Sprite) => void
+        ) { }
     }
 
     export class OverlapHandler {
@@ -23,14 +25,11 @@ namespace scene {
         ) { }
     }
 
-    export interface CollisionHandler {
-        kind: number;
-        handler: (sprite: Sprite) => void
-    }
-
-    export interface GameForeverHandlers {
-        lock: boolean;
-        handler: () => void;
+    export class GameForeverHandlers {
+        constructor(
+            public handler: () => void,
+            public lock: boolean
+        ) { }
     }
 
     // frame handler priorities
@@ -67,7 +66,7 @@ namespace scene {
         createdHandlers: SpriteHandler[];
         overlapHandlers: OverlapHandler[];
         overlapMap: SparseArray<number[]>;
-        collisionHandlers: CollisionHandler[][];
+        collisionHandlers: SpriteHandler[][];
         gameForeverHandlers: GameForeverHandlers[];
         particleSources: particles.ParticleSource[];
         controlledSprites: controller.ControlledSprite[][];

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -15,10 +15,12 @@ namespace scene {
         handler: (sprite: Sprite) => void;
     }
 
-    export interface OverlapHandler {
-        kind: number;
-        otherKind: number;
-        handler: (sprite: Sprite, otherSprite: Sprite) => void;
+    export class OverlapHandler {
+        constructor(
+            public kind: number,
+            public otherKind: number,
+            public handler: (sprite: Sprite, otherSprite: Sprite) => void
+        ) { }
     }
 
     export interface CollisionHandler {

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -25,10 +25,10 @@ namespace scene {
         ) { }
     }
 
-    export class GameForeverHandlers {
+    export class GameForeverHandler {
+        public lock: boolean;
         constructor(
-            public handler: () => void,
-            public lock: boolean
+            public handler: () => void
         ) { }
     }
 
@@ -67,7 +67,7 @@ namespace scene {
         overlapHandlers: OverlapHandler[];
         overlapMap: SparseArray<number[]>;
         collisionHandlers: SpriteHandler[][];
-        gameForeverHandlers: GameForeverHandlers[];
+        gameForeverHandlers: GameForeverHandler[];
         particleSources: particles.ParticleSource[];
         controlledSprites: controller.ControlledSprite[][];
 

--- a/libs/game/spriteevents.ts
+++ b/libs/game/spriteevents.ts
@@ -10,11 +10,13 @@ namespace sprites {
     export function onCreated(kind: number, handler: (sprite: Sprite) => void): void {
         if (!handler || kind == undefined) return;
 
-        const scene = game.currentScene();
-        scene.createdHandlers.push({
-            kind: kind,
-            handler: handler
-        })
+        const sc = game.currentScene();
+        sc.createdHandlers.push(
+            new scene.SpriteHandler(
+                kind,
+                handler
+            )
+        )
     }
 
     /**
@@ -29,11 +31,13 @@ namespace sprites {
     export function onDestroyed(kind: number, handler: (sprite: Sprite) => void) {
         if (!handler || kind == undefined) return;
 
-        const scene = game.currentScene();
-        scene.destroyedHandlers.push({
-            kind: kind,
-            handler: handler
-        })
+        const sc = game.currentScene();
+        sc.destroyedHandlers.push(
+            new scene.SpriteHandler(
+                kind,
+                handler
+            )
+        );
     }
 
     /**
@@ -61,11 +65,13 @@ namespace sprites {
         associate(kind, otherKind);
         associate(otherKind, kind);
 
-        overlapHandlers.push(new scene.OverlapHandler(
-            kind,
-            otherKind,
-            handler
-        ));
+        overlapHandlers.push(
+            new scene.OverlapHandler(
+                kind,
+                otherKind,
+                handler
+            )
+        );
     }
 }
 
@@ -88,9 +94,11 @@ namespace scene {
             collisionHandlers[tile] = [];
         }
 
-        collisionHandlers[tile].push({
-            kind: kind,
-            handler: handler
-        });
+        collisionHandlers[tile].push(
+            new scene.SpriteHandler(
+                kind,
+                handler
+            )
+        );
     }
 }

--- a/libs/game/spriteevents.ts
+++ b/libs/game/spriteevents.ts
@@ -46,9 +46,9 @@ namespace sprites {
     //% blockGap=8
     export function onOverlap(kind: number, otherKind: number, handler: (sprite: Sprite, otherSprite: Sprite) => void) {
         if (kind == undefined || otherKind == undefined || !handler) return;
-        const scene = game.currentScene();
-        const overlapHandlers = scene.overlapHandlers;
-        const overlapMap = scene.overlapMap;
+        const sc = game.currentScene();
+        const overlapHandlers = sc.overlapHandlers;
+        const overlapMap = sc.overlapMap;
 
         function associate(a: number, b: number) {
             if (!overlapMap[a]) {
@@ -61,11 +61,11 @@ namespace sprites {
         associate(kind, otherKind);
         associate(otherKind, kind);
 
-        overlapHandlers.push({
-            kind: kind,
-            otherKind: otherKind,
-            handler: handler
-        });
+        overlapHandlers.push(new scene.OverlapHandler(
+            kind,
+            otherKind,
+            handler
+        ));
     }
 }
 


### PR DESCRIPTION
Make some interfaces into classes for minor performance gains / memory efficiency; shouldn't make too much of a difference, but some of these end up being used each frame (ControlledSprite, GameForeverHandler) / in parts that may be perf-sensitive (SpriteHandler and OverlapHandler are used in physics), and there tend to be a decent amount of these in larger programs