### PR TITLE
Disable seeding PRNG from accelerometer

### DIFF
--- a/libs/core---stm32/platform.cpp
+++ b/libs/core---stm32/platform.cpp
@@ -80,8 +80,12 @@ extern "C" void apply_clock_init(RCC_OscInitTypeDef *oscInit, RCC_ClkInitTypeDef
 }
 #endif
 
+// Disable seeding random from accelerometer. We now store random
+// seed in internal flash, so it's different on every reset, and
+// accelerometer sometimes have bugs, so better not enable them unless
+// requested.
 static void initRandomSeed() {
-#ifdef STM32F4
+#if 0
     if (getConfig(CFG_ACCELEROMETER_TYPE, -1) != -1) {
         initAccelRandom();
     }

--- a/libs/settings/SAMDFlash.cpp
+++ b/libs/settings/SAMDFlash.cpp
@@ -175,6 +175,8 @@ int ZFlash::writeBytes(uintptr_t dst, const void *src, uint32_t len) {
 
     CHECK_ECC();
 
+    lock();
+
     return 0;
 }
 } // namespace codal


### PR DESCRIPTION
Accelerometer on meowbit locks up after a while. Sometimes. Better not use it unless requested.

Also, add forgotten call to reanable flash on samd (without cache SAMD is about 3x slower)