### PR TITLE
webusb is enabled if-and-only-if HID isnt

### DIFF
--- a/libs/core/hf2.h
+++ b/libs/core/hf2.h
@@ -49,7 +49,7 @@ class HF2 : public CodalUSBInterface {
     virtual const InterfaceInfo *getInterfaceInfo();
     int sendSerial(const void *data, int size, int isError = 0);
 
-    virtual bool enableWebUSB() { return true; }
+    virtual bool enableWebUSB() { return !useHID; }
 };
 
 class DummyIface : public CodalUSBInterface {


### PR DESCRIPTION
This was a bug that's been there for a while, but was covered up due to another bug. We fixed both :)

This fixes the Win10 app issue on adafruit