### PR TITLE
add filters for a few image types

### DIFF
--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -608,7 +608,7 @@ namespace game {
      * @param frame A square image with a width and height divisible by three
      */
     //% blockId=game_dialog_set_frame group="Dialogs"
-    //% block="set dialog frame to %frame=screen_image_picker"
+    //% block="set dialog frame to %frame=dialog_image_picker"
     //% help=game/set-dialog-frame
     export function setDialogFrame(frame: Image) {
         dialogFrame = frame;

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -9,6 +9,7 @@ namespace images {
     //% img.fieldEditor="sprite"
     //% img.fieldOptions.taggedTemplate="img"
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
+    //% img.fieldOptions.filter="!tile !dialog"
     //% weight=100 group="Create" duplicateShadowOnDrag
     export function _spriteImage(img: Image) {
         return img
@@ -44,9 +45,23 @@ namespace images {
     //% img.fieldOptions.taggedTemplate="img"
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
     //% img.fieldOptions.sizes="16,16;32,32;8,8"
+    //% img.fieldOptions.filter="tile"
     //% weight=100 group="Create"
     //% blockHidden=1 duplicateShadowOnDrag
     export function _tileImage(img: Image) {
+        return img
+    }
+
+    //% blockId=dialog_image_picker block="%img"
+    //% shim=TD_ID
+    //% img.fieldEditor="sprite"
+    //% img.fieldOptions.taggedTemplate="img"
+    //% img.fieldOptions.decompileIndirectFixedInstances="true"
+    //% img.fieldOptions.sizes="15,15;18,18;6,6;9,9;12,12"
+    //% img.fieldOptions.filter="dialog"
+    //% weight=100 group="Create"
+    //% blockHidden=1 duplicateShadowOnDrag
+    export function _dialogImage(img: Image) {
         return img
     }
 

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -57,7 +57,7 @@ namespace images {
     //% img.fieldEditor="sprite"
     //% img.fieldOptions.taggedTemplate="img"
     //% img.fieldOptions.decompileIndirectFixedInstances="true"
-    //% img.fieldOptions.sizes="15,15;18,18;6,6;9,9;12,12"
+    //% img.fieldOptions.sizes="15,15;18,18;21,21;24,24;9,9;12,12"
     //% img.fieldOptions.filter="dialog"
     //% weight=100 group="Create"
     //% blockHidden=1 duplicateShadowOnDrag


### PR DESCRIPTION
add some filters; make dialog frame and tile blocks only show frames / tiles in gallery, and exclude those from the create sprite gallery (except for the ones that make sense to have in both, e.g. rocks  / trees / flowers)