### PR TITLE
Add 'play Melody' reference page

### DIFF
--- a/libs/mixer/docs/reference/music/play-melody.md
+++ b/libs/mixer/docs/reference/music/play-melody.md
@@ -1,0 +1,38 @@
+# play Melody
+
+Play a short melody of notes composed in a string.
+
+```sig
+music.playMelody("", 120);
+```
+
+The melody is short series of notes composed in a string. The melody is played at a rate set by the **tempo** value you give. The melody string contains a sequence of notes formatted like this:
+
+``"E B C5 A B G A F "``
+
+The melody is shown in the ``||music:play melody||`` block as note symbols which also appear in the Melody Editor.
+
+```block
+music.playMelody("E B C5 A B G A F ", 120);
+```
+
+The medlodies are most often created in the Melody Editor from the block so that valid notes are chosen and the correct melody length is set.
+
+## Parameters
+
+* **melody**: a [string](/types/string) which contains the notes of the melody.
+* **tempo**: a [number](/types/number) which is the rate to play the melody at in beats per minute.
+
+## Example #example
+
+Play the ``Mystery`` melody continuously.
+
+```blocks
+forever(function () {
+    music.playMelody("E F G F E G B C5 ", 120)
+})
+```
+
+## See also #seealso
+
+[set tempo](/reference/music/set-tempo), [play](/reference/music/melody/play), [play until done](/reference/music/melody/play-until-done)

--- a/libs/mixer/docs/reference/music/play-melody.md
+++ b/libs/mixer/docs/reference/music/play-melody.md
@@ -16,7 +16,7 @@ The melody is shown in the ``||music:play melody||`` block as note symbols which
 music.playMelody("E B C5 A B G A F ", 120);
 ```
 
-The medlodies are most often created in the Melody Editor from the block so that valid notes are chosen and the correct melody length is set.
+The melodies are most often created in the Melody Editor from the block so that valid notes are chosen and the correct melody length is set.
 
 ## Parameters
 

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -118,7 +118,7 @@ namespace music {
      */
     //% block="play melody $melody at tempo $tempo|(bpm)" blockId=playMelody
     //% blockNamespace=music
-    //% weight=85 blockGap=8
+    //% weight=85 blockGap=8 help=music/play-melody
     //% group="Melody"
     //% melody.shadow="melody_editor"
     //% tempo.min=40 tempo.max=500


### PR DESCRIPTION
Add a page for the new **playMelody()** function.

RE: https://github.com/microsoft/pxt-adafruit/issues/1118, https://github.com/microsoft/pxt-arcade/issues/1276