### PR TITLE
Adjust block colors to align with WCAG 2.0 Level AA standard

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -33,7 +33,7 @@ enum ControllerEvent {
 /**
  * Access to game controls
  */
-//% weight=98 color="#e15f41" icon="\uf11b"
+//% weight=98 color="#D54322" icon="\uf11b"
 //% groups='["Single Player", "Multiplayer"]'
 //% blockGap=8
 namespace controller {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -40,7 +40,7 @@ enum FlipOption {
 /**
  * A sprite on the screen
  **/
-//% blockNamespace=sprites color="#4B7BEC" blockGap=8
+//% blockNamespace=sprites color="#3B6FEA" blockGap=8
 class Sprite extends sprites.BaseSprite {
     _x: Fx8
     _y: Fx8


### PR DESCRIPTION
Tweak colors of blocks to align them with WCAG 2.0 Level AA standards to address accessibility concerns.

Additional details can be found in https://github.com/microsoft/pxt-arcade/pull/1288
