### PR TITLE
make clear particle effects allow sprites in blocks

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -135,7 +135,7 @@ namespace effects {
     //% blockNamespace=sprites
     //% group="Effects" weight=89
     //% help=effects/clear-particles
-    export function clearParticles(anchor: particles.ParticleAnchor) {
+    export function clearParticles(anchor: Sprite | particles.ParticleAnchor) {
         const sources = game.currentScene().particleSources;
         if (!sources) return;
         sources


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1254

won't do anything without https://github.com/microsoft/pxt/pull/5871, but that should be in whatever bump this gets included in anyways