### PR TITLE
Revert "make clear particle effects allow sprites in blocks"

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -135,7 +135,7 @@ namespace effects {
     //% blockNamespace=sprites
     //% group="Effects" weight=89
     //% help=effects/clear-particles
-    export function clearParticles(anchor: Sprite | particles.ParticleAnchor) {
+    export function clearParticles(anchor: particles.ParticleAnchor) {
         const sources = game.currentScene().particleSources;
         if (!sources) return;
         sources


### PR DESCRIPTION
This reverts commit d7f76f0a8f91cead5c0388e73b6a31c62ab613ae from #960.

Seems to be exposing a weird compilation bug when targeting hardware, reverting until that is identified / fixed. Will unfix https://github.com/microsoft/pxt-arcade/issues/1254 for now