### PR TITLE
[stable6.15]Revert "make clear particle effects allow sprites in blocks (#960)"

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -135,7 +135,7 @@ namespace effects {
     //% blockNamespace=sprites
     //% group="Effects" weight=89
     //% help=effects/clear-particles
-    export function clearParticles(anchor: Sprite | particles.ParticleAnchor) {
+    export function clearParticles(anchor: particles.ParticleAnchor) {
         const sources = game.currentScene().particleSources;
         if (!sources) return;
         sources


### PR DESCRIPTION
cherry picking to stable branch
This reverts commit d7f76f0a8f91cead5c0388e73b6a31c62ab613ae.