### PR TITLE
only collide once in each direction per tile color

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -340,7 +340,10 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
 
                 if (tm.isObstacle(x0, y0)) {
-                    collidedTiles.push(tm.getObstacle(x0, y0));
+                    const obstacle = tm.getObstacle(x0, y0);
+                    if (!collidedTiles.some(o => o.tileIndex === obstacle.tileIndex)) {
+                        collidedTiles.push(obstacle);
+                    }
                 }
             }
 
@@ -416,7 +419,10 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
 
                 if (tm.isObstacle(x0, y0)) {
-                    collidedTiles.push(tm.getObstacle(x0, y0));
+                    const obstacle = tm.getObstacle(x0, y0);
+                    if (!collidedTiles.some(o => o.tileIndex === obstacle.tileIndex)) {
+                        collidedTiles.push(obstacle);
+                    }
                 }
             }
 


### PR DESCRIPTION
fixes  https://github.com/microsoft/pxt-arcade/issues/1242 

Issue was that it was hitting the same tile in some circumstances in both corner checks; this makes it so we only trigger collision events once per tile type per direction per frame (which has a more consistent behavior if you're e.g. standing on lava, as it won't trigger collisions with the two separate lava tiles)

test case https://makecode.com/_9UaUkePyTDhe