### PR TITLE
only clear particles explicitly attached to sprite / anchor

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -128,7 +128,7 @@ namespace effects {
     }
 
     /**
-     * Removes all effects at anchor's location
+     * Removes all effects attached to the given anchor
      * @param anchor the anchor to remove effects from
      */
     //% blockId=particlesclearparticles block="clear effects on %anchor=variables_get(mySprite)"
@@ -139,7 +139,7 @@ namespace effects {
         const sources = game.currentScene().particleSources;
         if (!sources) return;
         sources
-            .filter(ps => ps.anchor == anchor || ps.anchor.x == anchor.x && ps.anchor.y == anchor.y)
+            .filter(ps => ps.anchor === anchor)
             .forEach(ps => ps.destroy());
     }
 


### PR DESCRIPTION
clear only the effects attached to the given sprite, rather than any attached to an anchor at the same position. Fixes situations like https://makecode.com/_2fffuuL8PWpf, where the clear effect accidentally destroys the background, too