### PR TITLE
fix center camera at / setting camera offsets issue with tmaps

### DIFF
--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -1,23 +1,47 @@
 namespace scene {
     export class Camera {
         // coordinate used for all physics computation
-        offsetX: number;
-        offsetY: number;
+        protected _offsetX: number;
+        protected _offsetY: number;
+
         // coordinate used for draw sprites, may including shaking
         drawOffsetX: number;
         drawOffsetY: number;
         sprite: Sprite;
 
-        private shakeStartTime: number;
-        private shakeDuration: number;
-        private shakeAmplitude: number;
+        protected shakeStartTime: number;
+        protected shakeDuration: number;
+        protected shakeAmplitude: number;
 
         constructor() {
-            this.offsetX = 0;
-            this.offsetY = 0;
+            this._offsetX = 0;
+            this._offsetY = 0;
 
             this.drawOffsetX = 0;
             this.drawOffsetY = 0;
+        }
+
+        get offsetX() {
+            return this._offsetX;
+        }
+        set offsetX(v: number) {
+            const scene = game.currentScene();
+            if (scene.tileMap && scene.tileMap.enabled) {
+                this._offsetX = scene.tileMap.offsetX(v);
+            } else {
+                this._offsetX = v;
+            }
+        }
+        get offsetY() {
+            return this._offsetY;
+        }
+        set offsetY(v: number) {
+            const scene = game.currentScene();
+            if (scene.tileMap && scene.tileMap.enabled) {
+                this._offsetY = scene.tileMap.offsetY(v);
+            } else {
+                this._offsetY = v;
+            }
         }
 
         shake(amplitude: number = 4, duration: number = 1000) {
@@ -33,18 +57,10 @@ namespace scene {
         }
 
         update() {
-            const scene = game.currentScene();
-
             // if sprite, follow sprite
             if (this.sprite) {
                 this.offsetX = this.sprite.x - (screen.width >> 1);
                 this.offsetY = this.sprite.y - (screen.height >> 1);
-            }
-
-            // don't escape tile map
-            if (scene.tileMap && scene.tileMap.enabled) {
-                this.offsetX = scene.tileMap.offsetX(this.offsetX);
-                this.offsetY = scene.tileMap.offsetY(this.offsetY);
             }
 
             // normalize offset


### PR DESCRIPTION
Fix issue where ``centerCameraAt`` breaks when used in events with tile maps. 

In my case, an `on game update` event that was being used to move the camera between sprites smoothly caused the screen to flash seemingly randomly / things to be positioned incorrectly as the 'fix' with respect to the tile map was being deferred to the next update and immediately getting overwritten with the un-tilemapped value each frame.

It seems kind of not-ideally set up currently, though; can't call the setters from the constructor as it will result in a stack overflow when the scene is created (and similarly, if the scene constructor were to try to set an offset it would break). Maybe camera should store the current tile map explicitly as a field  to not have the weird lookup behavior?