### PR TITLE
Update 'animation' ref pages

### DIFF
--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -508,6 +508,7 @@ namespace animation {
     //% block="animate $sprite=variables_get(mySprite) frames $frames=lists_create_with interval (ms) $frameInterval=timePicker loop $loop=toggleOnOff"
     //% frames.defl=screen_image_picker
     //% group="Animate"
+    //% help=animation/run-image-animation
     export function runImageAnimation(sprite: Sprite, frames: Image[], frameInterval?: number, loop?: boolean) {
         const anim = new ImageAnimation(sprite, frames, frameInterval || 500, !!loop);
         anim.init();
@@ -523,6 +524,7 @@ namespace animation {
     //% block="animate $sprite=variables_get(mySprite) with $pathString=animation_path for (ms) $duration=timePicker loop $loop=toggleOnOff"
     //% duration.defl=2000
     //% group="Animate"
+    //% help=animation/run-movement-animation
     export function runMovementAnimation(sprite: Sprite, pathString: string, duration?: number, loop?: boolean) {
         const path = Path.parse(new Point(sprite.x, sprite.y), pathString);
         const anim = new MovementAnimation(sprite, path, duration / path.length, !!loop);
@@ -539,13 +541,14 @@ namespace animation {
     }
     
     /**
-     * Stops all animations (simple and looping) of the specified type on a sprite
+     * Stop one type or all animations (simple and looping) on a sprite
      * @param type the animation type to stop
      * @param sprite the sprite to filter animations by
      */
     //% blockId=stop_animations
     //% block="stop %type animations on %sprite=variables_get(mySprite)"
     //% group="Animate"
+    //% help=animation/stop-animation
     export function stopAnimation(type: AnimationTypes, sprite: Sprite) {
         let state: AnimationState = game.currentScene().data[stateNamespace];
         if (state && state.animations) {

--- a/libs/animation/docs/reference/animation.md
+++ b/libs/animation/docs/reference/animation.md
@@ -1,6 +1,19 @@
 # Animation
 
-Create and activate sprite animations.
+## Sprite animations
+
+Create and run animations on sprites. You can create image frame animations or 
+use animated movements on an existing sprite.
+
+```cards
+animation.runImageAnimation(null, null)
+animation.runMovementAnimation(null, "")
+animation.stopAnimation(0, null)
+```
+
+## Older animations
+
+These blocks are available to support programs using older animation methods.
 
 ```cards
 animation.createAnimation(0, 0)
@@ -11,7 +24,10 @@ animation.setAction(null, 0)
 
 ## See also #seealso
 
-[create animations](/reference/animation/create-animations)
+[run image animation](/reference/animation/run-image-animation),
+[run movement animation](/reference/animation/run-movement-animation),
+[stop animation](/reference/animation/stop-animation),
+[create animations](/reference/animation/create-animations),
 [add animation frame](/reference/animation/add-animation-frame),
 [attach animation](/reference/animation/attach-animation),
 [set action](/reference/animation/set-action)

--- a/libs/animation/docs/reference/animation/run-image-animation.md
+++ b/libs/animation/docs/reference/animation/run-image-animation.md
@@ -1,0 +1,220 @@
+# run Image Animation
+
+Run an animation of frames from an array of images in a sprite.
+
+```sig
+animation.runImageAnimation(null, null)
+```
+
+An animation creates an effect of an object moving within the area of a _frame_.
+A single frame is a still image of an object at some point in time during its movement.
+Showing different frames with a brief pause between them will create the effect of movement of an object.
+
+## Sprite animations
+
+Animations are shown in a [sprite](/types/sprite). So, wherever the sprite is placed,
+the animation will run there. You create your animation by setting two or more images into the **frames** array assigned to the sprite. You can set the amount of time between frames to make the animation run fast or slow. If you want the animation to repeat itself continously, you can make it _loop_.
+
+### ~ hint
+
+#### Frame and image sizes
+
+The size of the frame is adjusted to show the contents of every frame. If some of the images in the frames array don't match each other, the frame size of the animation
+is expanded so that it can show each one.
+
+It's best to make all of the images in your frames array be the same size so that
+your object's position changes and movement will look correct.
+
+### ~
+
+## Parameters
+
+* **sprite**: the sprite that the animation will run in.
+* **frames**: an array of images that create the animation.
+* **frameInterval**: the [number](/types/number) of milliseconds to wait before the next frame is shown.
+* **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the animation to repeat. If ``false``, the animation runs only once.
+
+## Example #example
+
+### Walker animation
+
+Create and run an animation of a person walking. Set the animation frames as an array
+of images with a person at different positions of movement.
+
+```blocks
+scene.setBackgroundColor(13)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+`, SpriteKind.Player)
+animation.runImageAnimation(
+mySprite,
+[img`
+    . . . . f f f f . . . .
+    . . f f e e e e f f . .
+    . f f e e e e e e f f .
+    f f f f 4 e e e f f f f
+    f f f 4 4 4 e e f f f f
+    f f f 4 4 4 4 e e f f f
+    f 4 e 4 4 4 4 4 4 e 4 f
+    f 4 4 f f 4 4 f f 4 4 f
+    f e 4 d d d d d d 4 e f
+    . f e d d b b d d e f .
+    . f f e 4 4 4 4 e f f .
+    e 4 f b 1 1 1 1 b f 4 e
+    4 d f 1 1 1 1 1 1 f d 4
+    4 4 f 6 6 6 6 6 6 f 4 4
+    . . . f f f f f f . . .
+    . . . f f . . f f . . .
+`, img`
+    . . . . . . . . . . . .
+    . . . f f f f f f . . .
+    . f f f e e e e f f f .
+    f f f e e e e e e f f f
+    f f f f 4 e e e f f f f
+    f f f 4 4 4 e e f f f f
+    f f f 4 4 4 4 e e f f f
+    f 4 e 4 4 4 4 4 4 e 4 f
+    f 4 4 f f 4 4 f f 4 4 f
+    f e 4 d d d d d d 4 e f
+    . f e d d b b d 4 e f e
+    f f f e 4 4 4 4 d d 4 e
+    e 4 f b 1 1 1 e d d e .
+    . . f 6 6 6 6 f e e . .
+    . . f f f f f f f . . .
+    . . f f f . . . . . . .
+`, img`
+    . . . . . . . . . . . .
+    . . . f f f f f f . . .
+    . f f f e e e e f f f .
+    f f f e e e e e e f f f
+    f f f f 4 e e e f f f f
+    f f f 4 4 4 e e f f f f
+    f f f 4 4 4 4 e e f f f
+    f 4 e 4 4 4 4 4 4 e 4 f
+    f 4 4 f f 4 4 f f 4 4 f
+    f e 4 d d d d d d 4 e f
+    e f e 4 d b b d d e f .
+    e 4 d d 4 4 4 4 e f f f
+    . e d d e 1 1 1 b f 4 e
+    . . e e f 6 6 6 6 f . .
+    . . . f f f f f f f . .
+    . . . . . . . f f f . .
+`, img`
+    . . . f f f f f . . . .
+    . . f e e e e e f f . .
+    . f e e e e e e e f f .
+    f e e e e e e e f f f f
+    f e e 4 e e e f f f f f
+    f e e 4 4 e e e f f f f
+    f f e 4 4 4 4 4 f f f f
+    f f e 4 4 f f 4 e 4 f f
+    . f f d d d d 4 d 4 f .
+    . . f b b d d 4 f f f .
+    . . f e 4 4 4 e e f . .
+    . . f 1 1 1 e d d 4 . .
+    . . f 1 1 1 e d d e . .
+    . . f 6 6 6 f e e f . .
+    . . . f f f f f f . . .
+    . . . . . f f f . . . .
+`],
+500,
+true
+)
+```
+
+### Trampoline
+
+Run a movement animation on a sprite that also an image animation. Create an
+effect of a person jumping on a trampoline.
+
+```blocks
+scene.setBackgroundColor(1)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+`, SpriteKind.Player)
+animation.runImageAnimation(
+mySprite,
+[img`
+    . . . . . . . . . . . . .
+    . . . . . f f f f . . . .
+    . . . f f f f f f f f . .
+    . . f f f f f f c f f f .
+    f f f f f f f c c f f f c
+    f f f f c f f f f f f f c
+    . c c c f f f e e f f c c
+    . f f f f f e e f f c c f
+    . f f f b f e e f b f f f
+    . f f 4 1 f 4 4 f 1 4 f f
+    . . f e 4 4 4 4 4 e e f e
+    . f e f b 7 7 7 e 4 4 4 e
+    . e 4 f 7 7 7 7 e 4 4 e .
+    . . . f 6 6 6 6 6 e e . .
+    . . . f f f f f f f . . .
+    . . . f f f . . . . . . .
+`, img`
+    . . . . . . . . . . . . .
+    . . . . f f f f . . . . .
+    . . f f f f f f f f . . .
+    . f f f c f f f f f f . .
+    c f f f c c f f f f f f f
+    c f f f f f f f c f f f f
+    c c f f e e f f f c c c .
+    f c c f f e e f f f f f .
+    f f f b f e e f b f f f .
+    f f 4 1 f 4 4 f 1 4 f f .
+    e f e e 4 4 4 4 4 e f . .
+    e 4 4 4 e 7 7 7 b f e f .
+    . e 4 4 e 7 7 7 7 f 4 e .
+    . . e e 6 6 6 6 6 f . . .
+    . . . f f f f f f f . . .
+    . . . . . . . f f f . . .
+`],
+500,
+true
+)
+animation.runMovementAnimation(
+mySprite,
+animation.animationPresets(animation.bobbing),
+1000,
+true
+)
+```
+
+## See Also #seealso
+
+[run movement animation](/reference/animation/run-movement-animation),
+[stop animation](/reference/animation/stop-animation)
+
+```package
+animation
+```

--- a/libs/animation/docs/reference/animation/run-movement-animation.md
+++ b/libs/animation/docs/reference/animation/run-movement-animation.md
@@ -1,0 +1,78 @@
+# run Movement Animation
+
+Apply a movement animation effect to a sprite.
+
+```sig
+animation.runMovementAnimation(null, "")
+```
+
+A movement animation is motion effect applied to a sprite. The image in the
+sprite will appear to move with the type of motion that you select. You have several
+movement types to choose from and you can select them from the list in the block.
+
+The animation runs for the amount of time you set for it. When the animation finishes, the sprite returns to its original position. You can make the animation repeat by setting the **loop** parameter to **ON**.
+
+## Parameters
+
+* **sprite**: a sprite to attach the animation to.
+* **pathString**: an name of a movement path to apply to a sprite.
+* **duration**: the [number](/types/number) of milleseconds to run the animation for.
+* **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the animation to repeat. If ``false``, the animation runs only once.
+
+## Example #example
+
+Create a large taco sprite. Run a movement animation on the taco to make it "bob"
+to the right of the screen for `5` seconds.
+
+```blocks
+scene.setBackgroundColor(1)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . e e e e e e e . . . . . . . . . . .
+    . . . . . . . . . . . . e e 4 5 5 6 6 2 e 2 e . . . . . . . . .
+    . . . . . . . . . . e e 4 5 5 5 6 7 2 3 e 2 6 8 8 . . . . . . .
+    . . . . . . . . . e 4 6 7 7 6 6 7 7 2 3 2 e 7 7 7 6 6 8 . . . .
+    . . . . . . . . e 4 6 7 4 5 5 5 4 7 7 2 2 2 7 7 7 6 7 7 8 . . .
+    . . . . . . . 4 4 4 8 7 4 4 4 4 4 7 7 7 7 6 6 7 7 7 6 7 8 . . .
+    . . . . . . 4 5 2 2 e 7 7 7 7 7 7 6 7 7 7 7 6 6 6 7 6 6 6 8 . .
+    . . . . . 4 5 2 3 2 2 7 7 6 6 7 2 2 e 6 6 6 e e e e e 8 8 8 . .
+    . . . . 4 5 5 2 3 2 e 7 6 6 7 2 3 2 2 e 4 5 5 5 d d d d 4 8 . .
+    . . . 4 4 5 6 7 7 7 7 5 5 4 6 2 3 e 4 5 5 d d d d d d d d d 4 .
+    . . . e 6 6 7 7 4 5 5 4 4 7 7 e 4 5 5 d d d d 5 5 5 5 4 d d 4 4
+    . . e 4 6 7 7 7 4 4 4 6 7 7 e 5 5 d d 5 5 5 5 5 d 5 5 d d d d 4
+    . . e 5 6 6 8 6 7 7 6 6 6 e 5 d d 5 5 5 5 5 5 5 5 5 5 5 5 d d e
+    . e 4 5 5 4 4 e 8 7 7 6 e 5 d 5 5 5 5 5 4 5 5 5 5 5 5 5 5 5 d e
+    . e 5 5 4 e e e e 6 6 e 5 d 5 5 5 5 d 5 5 5 5 5 d d d d 5 4 d e
+    . e 5 5 e e 4 4 f e e 5 d 5 d 5 5 5 5 5 5 d 5 d 5 d d d d d d e
+    e 4 5 4 e e e e f e 4 5 d 5 5 5 5 5 5 5 5 5 5 5 d d 4 d d d e .
+    e 5 e 4 e e f f f e 5 d 5 5 5 5 5 5 5 5 d 5 5 5 5 d d d d e . .
+    e 5 e e 4 e e f f 4 5 d 5 5 5 5 5 5 5 5 5 5 5 5 d d d d e . . .
+    e 5 e e e e f f e 5 d 5 5 d 5 5 5 d 5 5 5 5 d 5 d d d e . . . .
+    e 5 f f e f e e e 5 d 5 5 5 4 5 5 5 5 5 5 5 d d d 4 e . . . . .
+    e 5 f f f f f f e 5 4 5 5 5 5 5 5 5 d 5 d 4 d d e e . . . . . .
+    e 5 4 e f e f f 4 5 d 5 5 d 5 5 5 5 5 d d d d e . . . . . . . .
+    e 5 e e e f f e 5 d d 5 5 5 5 5 4 5 d d d e e . . . . . . . . .
+    e 4 e e e f f f 5 d 5 5 5 5 d 5 5 d d d e . . . . . . . . . . .
+    e 4 e f e f f f 5 d 5 d 5 5 5 5 5 d 4 e . . . . . . . . . . . .
+    . e 4 e f f f e 5 d 5 5 5 5 5 5 d e e . . . . . . . . . . . . .
+    . e 5 4 e e e e 5 d 5 4 5 d d 4 e . . . . . . . . . . . . . . .
+    . . e 5 5 4 e e 5 d d d d d e e . . . . . . . . . . . . . . . .
+    . . . e e 5 5 4 4 d d d e e . . . . . . . . . . . . . . . . . .
+    . . . . . e e e e e e e . . . . . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+`, SpriteKind.Player)
+animation.runMovementAnimation(
+mySprite,
+animation.animationPresets(animation.bobbingRight),
+5000,
+true
+)
+```
+
+## See Also #seealso
+
+[run image animation](/reference/animation/run-image-animation),
+[stop animation](/reference/animation/stop-animation)
+
+```package
+animation
+```

--- a/libs/animation/docs/reference/animation/run-movement-animation.md
+++ b/libs/animation/docs/reference/animation/run-movement-animation.md
@@ -17,7 +17,7 @@ The animation runs for the amount of time you set for it. When the animation fin
 * **sprite**: a sprite to attach the animation to.
 * **pathString**: an name of a movement path to apply to a sprite.
 * **duration**: the [number](/types/number) of milleseconds to run the animation for.
-* **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the sprite to return to its original position. If ``false``, the animation runs only once.
+* **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the sprite to return to its original position and restart the animation. If ``false``, the animation runs only once and the sprite remains at the last location of the animation.
 
 ## Example #example
 

--- a/libs/animation/docs/reference/animation/run-movement-animation.md
+++ b/libs/animation/docs/reference/animation/run-movement-animation.md
@@ -17,7 +17,7 @@ The animation runs for the amount of time you set for it. When the animation fin
 * **sprite**: a sprite to attach the animation to.
 * **pathString**: an name of a movement path to apply to a sprite.
 * **duration**: the [number](/types/number) of milleseconds to run the animation for.
-* **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the animation to repeat. If ``false``, the animation runs only once.
+* **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the sprite to return to its original position. If ``false``, the animation runs only once.
 
 ## Example #example
 

--- a/libs/animation/docs/reference/animation/stop-animation.md
+++ b/libs/animation/docs/reference/animation/stop-animation.md
@@ -1,0 +1,109 @@
+# stop Animation
+
+Stop an animation from running on a sprite.
+
+```sig
+animation.stopAnimation(0, null)
+```
+
+You can run an image or movement animation on a sprite. A sprite can even have both types running at the same time. The one type of animation, or all types, can be stopped. You might want to stop an animation if it's looped or runs for a long time.
+
+## Parameters
+
+* **type**: the type of animation to stop: ``all``, ``frame``, or ``path``.
+* **sprite**: the [sprite](types/strite) to stop running the animation on.
+
+## Example #example
+
+Create and run an animation of a person walking. Loop the animation and then
+stop it by pressing button **A**.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    animation.stopAnimation(animation.AnimationTypes.All, mySprite)
+})
+scene.setBackgroundColor(1)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+    . . . . . . . . . . . . . . . .
+`, SpriteKind.Player)
+animation.runImageAnimation(
+mySprite,
+[img`
+    . . . . f f f f . . . . .
+    . . f f f f f f f f . . .
+    . f f f f f f c f f f . .
+    f f f f f f c c f f f c .
+    f f f c f f f f f f f c .
+    c c c f f f e e f f c c .
+    f f f f f e e f f c c f .
+    f f f b f e e f b f f f .
+    . f 4 1 f 4 4 f 1 4 f . .
+    . f e 4 4 4 4 4 4 e f . .
+    . f f f e e e e f f f . .
+    f e f b 7 7 7 7 b f e f .
+    e 4 f 7 7 7 7 7 7 f 4 e .
+    e e f 6 6 6 6 6 6 f e e .
+    . . . f f f f f f . . . .
+    . . . f f . . f f . . . .
+`, img`
+    . . . . . . . . . . . . .
+    . . . . f f f f . . . . .
+    . . f f f f f f f f . . .
+    . f f f c f f f f f f . .
+    c f f f c c f f f f f f f
+    c f f f f f f f c f f f f
+    c c f f e e f f f c c c .
+    f c c f f e e f f f f f .
+    f f f b f e e f b f f f .
+    f f 4 1 f 4 4 f 1 4 f f .
+    e f e e 4 4 4 4 4 e f . .
+    e 4 4 4 e 7 7 7 b f e f .
+    . e 4 4 e 7 7 7 7 f 4 e .
+    . . e e 6 6 6 6 6 f . . .
+    . . . f f f f f f f . . .
+    . . . . . . . f f f . . .
+`, img`
+    . . . . . . . . . . . . .
+    . . . . . f f f f . . . .
+    . . . f f f f f f f f . .
+    . . f f f f f f c f f f .
+    f f f f f f f c c f f f c
+    f f f f c f f f f f f f c
+    . c c c f f f e e f f c c
+    . f f f f f e e f f c c f
+    . f f f b f e e f b f f f
+    . f f 4 1 f 4 4 f 1 4 f f
+    . . f e 4 4 4 4 4 e e f e
+    . f e f b 7 7 7 e 4 4 4 e
+    . e 4 f 7 7 7 7 e 4 4 e .
+    . . . f 6 6 6 6 6 e e . .
+    . . . f f f f f f f . . .
+    . . . f f f . . . . . . .
+`],
+500,
+true
+)```
+
+## See Also #seealso
+
+[run image animation](/reference/animation/run-image-animation),
+[run movement animation](/reference/animation/run-movement-animation)
+
+```package
+animation
+```


### PR DESCRIPTION
Add the pages for the new style animation APIs.

RE: https://github.com/microsoft/pxt-arcade/issues/1350

Notes:

* **stopAnimation()** seems to have trouble decompiling back into blocks

![stop-animation-decomp](https://user-images.githubusercontent.com/27789908/65920024-c1f06b80-e392-11e9-864a-cdab1739392d.gif)

*  why is ``sprite`` set as the second param in **stopAnimation()**?