### PR TITLE
Use 021 not 844 for allocations not fitting in a block

### DIFF
--- a/libs/base/gc.cpp
+++ b/libs/base/gc.cpp
@@ -763,7 +763,8 @@ void *gcAllocate(int numbytes) {
         else if (i == 1)
             allocateBlock();
         else
-            oops(44);
+            // the block allocated was apparently too small
+            target_panic(PANIC_GC_OOM);
     }
 }
 


### PR DESCRIPTION
844 happens on microbit where the first block is 7k or so, but the rest are much smaller. This really means out of memory, so let's use 021.