### PR TITLE
make projectile from side respect camera offset

### DIFF
--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -115,6 +115,9 @@ namespace sprites {
 
         const xOff = sc.tileMap ? -(s.width >> 1) : (s.width >> 1) - 1;
         const yOff = sc.tileMap ? -(s.height >> 1) : (s.height >> 1) - 1;
+        const cam = game.currentScene().camera;
+        s.x = cam.offsetX;
+        s.y = cam.offsetY;
 
         while(vx == 0 && vy == 0) {
             vx = Math.randomRange(-100, 100);
@@ -122,14 +125,14 @@ namespace sprites {
         }
 
         if (vx < 0)
-            s.x = screen.width + xOff
+            s.x += screen.width + xOff
         else if (vx > 0)
-            s.x = -xOff
+            s.x += -xOff
 
         if (vy < 0)
-            s.y = screen.height + yOff
+            s.y += screen.height + yOff
         else if (vy > 0)
-            s.y = -yOff
+            s.y += -yOff
 
         s.flags |= sprites.Flag.AutoDestroy;
         s.flags |= sprites.Flag.DestroyOnWall;


### PR DESCRIPTION
projectile from side should always send project from the side, not just from original screen width / height

fix game like https://makecode.com/_2fcbJC5Mabh6

![2019-10-04 14 17 03](https://user-images.githubusercontent.com/5615930/66240507-b2826280-e6b1-11e9-8fa5-871872e6933f.gif)

(they still zoom off screen immediately as the speed is not relative to the player, but it works. Here's a slightly more complicated version that works slightly more nicely: https://makecode.com/_YURWqhEwfEfz)