### PR TITLE
don't ignore collisions of sprites that move off screen

### DIFF
--- a/libs/game/spritemap.ts
+++ b/libs/game/spritemap.ts
@@ -14,8 +14,6 @@ namespace sprites {
          * Returns a potential list of neighbors
          */
         neighbors(sprite: Sprite): Sprite[] {
-            if (this.isOob(sprite)) return [];
-
             const n: Sprite[] = [];
             const layer = sprite.layer;
             this.mergeAtKey(sprite.left, sprite.top, layer, n)
@@ -91,19 +89,7 @@ namespace sprites {
                 bucket.push(sprite);
         }
 
-        private isOob(sprite: Sprite): boolean {
-            const tMap = game.currentScene().tileMap;
-
-            const areaWidth = tMap ? tMap.areaWidth() : screen.width;
-            const areaHeight = tMap ? tMap.areaHeight() : screen.height;
-            return sprite.right < 0 || sprite.left > areaWidth || sprite.bottom < 0 || sprite.top > areaHeight;
-        }
-
         insertAABB(sprite: Sprite) {
-            // is object not collidable?
-            if (this.isOob(sprite))
-                return;
-
             const left = sprite.left;
             const top = sprite.top;
             const xn = Math.idiv(sprite.width + this.cellWidth - 1, this.cellWidth);


### PR DESCRIPTION
fix collisions for this game https://makecode.com/_HXL1Tc7YJeik

But really just any game with camera follow sprite that isn't in a tile map.

I could keep the OOB checking and constrain to just the visible screen instead of hardcode , but that's inconsistent between tilemap and no tile map (all collisions are checked if there is a tile map, otherwise just in the screen) and just have inconsistent behavior.

Maybe we can revisit this file as a whole at some point and clean it up a bit, for example I don't think sprite.layer has ever been used. It might also be good to base the key off of the screens current position, so it will be more likely to have things around the action in different chunks