### PR TITLE
use identifier for A/B buttons

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -9,9 +9,9 @@ enum ControllerButtonEvent {
 
 
 enum ControllerButton {
-    //% block="A"
+    //% block="{id:controller}A"
     A = 5,
-    //% block="B"
+    //% block="{id:controller}B"
     B = 6,
     //% block="left"
     Left = 1,


### PR DESCRIPTION
A,B already used in melodies. Leads to confusing translations.