### PR TITLE
fix some projectile + tilemap interactions

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -548,6 +548,8 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             } else if (tm.isOnWall(s)) {
                 // otherwise, accept movement and flag if now clipping into a wall.
                 s.flags |= sprites.Flag.IsClipping;
+            } else {
+                s.flags &= ~sprites.Flag.IsClipping;
             }
         }
     }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -277,7 +277,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             dy,
             xStep,
             yStep,
-
         );
     }
 

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -372,6 +372,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             return;
         }
         const sprite = movingSprite.sprite;
+        const hbox = sprite._hitbox;
         const tileScale = tm.scale;
         const tileSize = 1 << tileScale;
 
@@ -390,9 +391,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             const x0 = Fx.toIntShifted(
                 Fx.add(
                     right ?
-                        Fx.iadd(1, sprite._hitbox.right)
+                        Fx.iadd(1, hbox.right)
                         :
-                        Fx.iadd(-1, sprite._hitbox.left),
+                        Fx.iadd(-1, hbox.left),
                     Fx.oneHalfFx8
                 ),
                 tileScale
@@ -401,8 +402,8 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
             // check collisions with tiles sprite is moving towards horizontally
             for (
-                let y = Fx.sub(sprite._hitbox.top, yDiff);
-                y < Fx.iadd(tileSize, Fx.sub(sprite._hitbox.bottom, yDiff));
+                let y = Fx.sub(hbox.top, yDiff);
+                y < Fx.iadd(tileSize, Fx.sub(hbox.bottom, yDiff));
                 y = Fx.iadd(tileSize, y)
             ) {
                 const y0 = Fx.toIntShifted(
@@ -410,7 +411,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         Fx.min(
                             y,
                             Fx.sub(
-                                sprite._hitbox.bottom,
+                                hbox.bottom,
                                 yDiff
                             )
                         ),
@@ -430,11 +431,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             if (collidedTiles.length) {
                 const collisionDirection = right ? CollisionDirection.Right : CollisionDirection.Left;
                 sprite._x = Fx.iadd(
-                    -sprite._hitbox.ox,
+                    -hbox.ox,
                     right ?
                         Fx.sub(
                             Fx8(x0 << tileScale),
-                            Fx8(sprite._hitbox.width)
+                            Fx8(hbox.width)
                         )
                         :
                         Fx8((x0 + 1) << tileScale)
@@ -472,9 +473,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             const y0 = Fx.toIntShifted(
                 Fx.add(
                     down ?
-                        Fx.iadd(1, sprite._hitbox.bottom)
+                        Fx.iadd(1, hbox.bottom)
                         :
-                        Fx.iadd(-1, sprite._hitbox.top),
+                        Fx.iadd(-1, hbox.top),
                     Fx.oneHalfFx8
                 ),
                 tileScale
@@ -483,15 +484,15 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
             // check collisions with tiles sprite is moving towards vertically
             for (
-                let x = sprite._hitbox.left;
-                x < Fx.iadd(tileSize, sprite._hitbox.right);
+                let x = hbox.left;
+                x < Fx.iadd(tileSize, hbox.right);
                 x = Fx.iadd(tileSize, x)
             ) {
                 const x0 = Fx.toIntShifted(
                     Fx.add(
                         Fx.min(
                             x,
-                            sprite._hitbox.right
+                            hbox.right
                         ),
                         Fx.oneHalfFx8
                     ),
@@ -509,11 +510,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             if (collidedTiles.length) {
                 const collisionDirection = down ? CollisionDirection.Bottom : CollisionDirection.Top;
                 sprite._y = Fx.iadd(
-                    -sprite._hitbox.oy,
+                    -hbox.oy,
                     down ?
                         Fx.sub(
                             Fx8(y0 << tileScale),
-                            Fx8(sprite._hitbox.height)
+                            Fx8(hbox.height)
                         )
                         :
                         Fx8((y0 + 1) << tileScale)

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -534,7 +534,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
             const maxDist = Fx.toInt(this.maxSingleStep);
             // only check tile map if moving within a single step
-            if (Math.abs(Fx.toInt(dx)) < maxDist && Math.abs(Fx.toInt(dy)) < maxDist) {
+            if (Math.abs(Fx.toInt(dx)) <= maxDist && Math.abs(Fx.toInt(dy)) <= maxDist) {
                 const ms = new MovingSprite(
                     s,
                     s._vx,

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -532,9 +532,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             const tm = game.currentScene().tileMap;
             if (!(tm && tm.enabled)) return;
 
-            const tileSize = 1 << tm.scale;
-            // only check tile map if moving within a single tile
-            if (Math.abs(Fx.toInt(dx)) < tileSize && Math.abs(Fx.toInt(dy)) < tileSize) {
+            const maxDist = Fx.toInt(this.maxSingleStep);
+            // only check tile map if moving within a single step
+            if (Math.abs(Fx.toInt(dx)) < maxDist && Math.abs(Fx.toInt(dy)) < maxDist) {
                 const ms = new MovingSprite(
                     s,
                     s._vx,
@@ -545,9 +545,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     dy
                 );
                 this.tilemapCollisions(ms, tm);
+            // otherwise, accept movement...
             } else if (tm.isOnWall(s)) {
-                // otherwise, accept movement and flag if now clipping into a wall.
+            // and flag if now clipping into a wall
                 s.flags |= sprites.Flag.IsClipping;
+            // and clear clipping if not
             } else {
                 s.flags &= ~sprites.Flag.IsClipping;
             }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -120,7 +120,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
         const tileMap = scene.tileMap;
         const movingSprites = this.sprites
-            .map(sprite => this.createMovingSprite(sprite, dtSec, dt2, tileMap));
+            .map(sprite => this.createMovingSprite(sprite, dtSec, dt2));
 
         // clear obstacles if moving on that axis
         this.sprites.forEach(s => {
@@ -209,7 +209,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         }
     }
 
-    private createMovingSprite(sprite: Sprite, dtSec: Fx8, dt2: Fx8, tm: tiles.TileMap): MovingSprite {
+    private createMovingSprite(sprite: Sprite, dtSec: Fx8, dt2: Fx8): MovingSprite {
         const ovx = this.constrain(sprite._vx);
         const ovy = this.constrain(sprite._vy);
         sprite._lastX = sprite._x;

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -276,7 +276,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             dx,
             dy,
             xStep,
-            yStep,
+            yStep
         );
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -165,8 +165,8 @@ class Sprite extends sprites.BaseSprite {
     constructor(img: Image) {
         super(scene.SPRITE_Z);
 
-        this._x = Fx8(screen.width - img.width >> 1);
-        this._y = Fx8(screen.height - img.height >> 1);
+        this._x = Fx.zeroFx8;
+        this._y = Fx.zeroFx8;
         this._lastX = this._x;
         this._lastY = this._y;
         this.vx = 0

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -165,8 +165,8 @@ class Sprite extends sprites.BaseSprite {
     constructor(img: Image) {
         super(scene.SPRITE_Z);
 
-        this._x = Fx.zeroFx8;
-        this._y = Fx.zeroFx8;
+        this._x = Fx8(screen.width - img.width >> 1);
+        this._y = Fx8(screen.height - img.height >> 1);
         this._lastX = this._x;
         this._lastY = this._y;
         this.vx = 0

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -141,7 +141,6 @@ namespace sprites {
             }
 
             s.setPosition(initialX, initialY);
-
         }
 
         s.flags |= sprites.Flag.AutoDestroy | sprites.Flag.DestroyOnWall;
@@ -152,12 +151,13 @@ namespace sprites {
     export enum Flag {
         None = 0, // no flags are set
         Ghost = 1 << 0, // doesn't collide with other sprites
-        Destroyed = 1 << 1,
+        Destroyed = 1 << 1, // whether the sprite has been destroyed or not
         AutoDestroy = 1 << 2, // remove the sprite when no longer visible
         StayInScreen = 1 << 3, // sprite cannot move outside the camera region
         DestroyOnWall = 1 << 4, // destroy sprite on contact with wall
         BounceOnWall = 1 << 5, // Bounce on walls
         ShowPhysics = 1 << 6, // display position, velocity, acc
         Invisible = 1 << 7, // makes the sprite invisible, so it does not show up on the screen
+        IsClipping = 1 << 8, // whether the sprite is currently clipping into a wall. This can happen when a sprite is created or moved explicitly.
     }
 }

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -37,7 +37,6 @@ namespace sprites {
         const scene = game.currentScene();
         const sprite = new Sprite(img)
         sprite.setKind(kind);
-        sprite.setPosition(screen.width >> 1, screen.height >> 1);
         scene.physicsEngine.addSprite(sprite);
 
         // run on created handlers

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -37,7 +37,7 @@ namespace sprites {
         const scene = game.currentScene();
         const sprite = new Sprite(img)
         sprite.setKind(kind);
-        sprite.setPosition((screen.width - img.width) >> 1, (screen.height - img.height) >> 1);
+        sprite.setPosition(screen.width >> 1, screen.height >> 1);
         scene.physicsEngine.addSprite(sprite);
 
         // run on created handlers

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -107,42 +107,46 @@ namespace sprites {
     export function createProjectile(img: Image, vx: number, vy: number, kind?: number, sprite?: Sprite) {
         const s = sprites.create(img, kind || SpriteKind.Projectile);
         const sc = game.currentScene();
-        s.vx = vx
-        s.vy = vy
 
-        // put it at the edge of the screen so that it moves towards the middle
-        // If the scene has a tile map, place the sprite fully on the screen
-
-        const xOff = sc.tileMap ? -(s.width >> 1) : (s.width >> 1) - 1;
-        const yOff = sc.tileMap ? -(s.height >> 1) : (s.height >> 1) - 1;
-        const cam = game.currentScene().camera;
-        s.x = cam.offsetX;
-        s.y = cam.offsetY;
-
-        while(vx == 0 && vy == 0) {
+        while (vx == 0 && vy == 0) {
             vx = Math.randomRange(-100, 100);
             vy = Math.randomRange(-100, 100);
         }
 
-        if (vx < 0)
-            s.x += screen.width + xOff
-        else if (vx > 0)
-            s.x += -xOff
-
-        if (vy < 0)
-            s.y += screen.height + yOff
-        else if (vy > 0)
-            s.y += -yOff
-
-        s.flags |= sprites.Flag.AutoDestroy;
-        s.flags |= sprites.Flag.DestroyOnWall;
+        s.vx = vx;
+        s.vy = vy;
 
         if (sprite) {
-            s.x = sprite.x;
-            s.y = sprite.y;
+            s.setPosition(sprite.x, sprite.y);
+        } else {
+            // put it at the edge of the screen so that it moves towards the middle
+            // If the scene has a tile map, place the sprite fully on the screen
+            const xOff = sc.tileMap ? -(s.width >> 1) : (s.width >> 1) - 1;
+            const yOff = sc.tileMap ? -(s.height >> 1) : (s.height >> 1) - 1;
+            const cam = game.currentScene().camera;
+
+            let initialX = cam.offsetX;
+            let initialY = cam.offsetY;
+
+            if (vx < 0) {
+                initialX += screen.width + xOff;
+            } else if (vx > 0) {
+                initialX += -xOff;
+            }
+
+            if (vy < 0) {
+                initialY += screen.height + yOff;
+            } else if (vy > 0) {
+                initialY += -yOff;
+            }
+
+            s.setPosition(initialX, initialY);
+
         }
 
-        return s
+        s.flags |= sprites.Flag.AutoDestroy | sprites.Flag.DestroyOnWall;
+
+        return s;
     }
 
     export enum Flag {

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -37,6 +37,7 @@ namespace sprites {
         const scene = game.currentScene();
         const sprite = new Sprite(img)
         sprite.setKind(kind);
+        sprite.setPosition((screen.width - img.width) >> 1, (screen.height - img.height) >> 1);
         scene.physicsEngine.addSprite(sprite);
 
         // run on created handlers

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -255,5 +255,24 @@ namespace tiles {
                 index
             );
         }
+
+        public isOnWall(s: Sprite) {
+            const hbox = s._hitbox
+
+            const left = Fx.toIntShifted(hbox.left, this.scale);
+            const right = Fx.toIntShifted(hbox.right, this.scale);
+            const top = Fx.toIntShifted(hbox.top, this.scale);
+            const bottom = Fx.toIntShifted(hbox.bottom, this.scale);
+
+            for (let col = left; col <= right; ++col) {
+                for (let row = top; row <= bottom; ++row) {
+                    if (this.isObstacle(col, row)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -259,9 +259,9 @@ namespace tiles {
         public isOnWall(s: Sprite) {
             const hbox = s._hitbox
 
-            const left = Fx.toIntShifted(hbox.left, this.scale);
+            const left = Fx.toIntShifted(Fx.add(hbox.left, Fx.oneFx8), this.scale);
             const right = Fx.toIntShifted(hbox.right, this.scale);
-            const top = Fx.toIntShifted(hbox.top, this.scale);
+            const top = Fx.toIntShifted(Fx.add(hbox.top, Fx.oneFx8), this.scale);
             const bottom = Fx.toIntShifted(hbox.bottom, this.scale);
 
             for (let col = left; col <= right; ++col) {

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -73,9 +73,7 @@ namespace tiles {
         //% help=scene/place
         place(mySprite: Sprite): void {
             if (!mySprite) return;
-
-            mySprite.x = this.x;
-            mySprite.y = this.y;
+            mySprite.setPosition(this.x, this.y);
         }
     }
 

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -259,9 +259,9 @@ namespace tiles {
         public isOnWall(s: Sprite) {
             const hbox = s._hitbox
 
-            const left = Fx.toIntShifted(Fx.add(hbox.left, Fx.oneFx8), this.scale);
+            const left = Fx.toIntShifted(hbox.left, this.scale);
             const right = Fx.toIntShifted(hbox.right, this.scale);
-            const top = Fx.toIntShifted(Fx.add(hbox.top, Fx.oneFx8), this.scale);
+            const top = Fx.toIntShifted(hbox.top, this.scale);
             const bottom = Fx.toIntShifted(hbox.bottom, this.scale);
 
             for (let col = left; col <= right; ++col) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1393
fixes issue reported on discord: https://makecode.com/_bhqJj74qjY0J has sprites moving only vertically, but they should have vx too (they were hitting the bounds of the tmap)
fixes https://github.com/microsoft/pxt-arcade/issues/1104
fixes https://github.com/microsoft/pxt-arcade/issues/1323

also fixes a few minor things in projectiles / sprites
* actually use the velocity that is chosen when randomly picking
* only set position once, to get rid of some unnecessary tilemap interactions
* defer setting position to ~sprites.create~ and Tile.place (same reason)

If a sprite is created or is moved more than a single step away, and the new position for the sprite is a wall, this disables tilemap interactions with that sprite (clipping and preventing movement) until the sprite 'unclips' itself by moving out of the way. 