### PR TITLE
do not automatically use serial with edge connector

### DIFF
--- a/libs/edge-connector/pxt.json
+++ b/libs/edge-connector/pxt.json
@@ -8,7 +8,6 @@
     ],
     "public": true,
     "dependencies": {
-        "core": "file:../core",
-        "serial": "file:../serial"
+        "core": "file:../core"
     }
 }


### PR DESCRIPTION
Fix for https://github.com/microsoft/pxt-arcade/issues/1406. serial not impl on stm