### PR TITLE
add 'see through' scene flag

### DIFF
--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -628,7 +628,7 @@ namespace animation {
     //% shim=TD_ID
     //% frames.fieldEditor="animation"
     //% frames.fieldOptions.decompileLiterals="true"
-    //% frames.fieldOptions.filter="!tile !dialog"
+    //% frames.fieldOptions.filter="!tile !dialog !background"
     //% group="Animate" duplicateShadowOnDrag
     export function _animationFrames(frames: Image[]) {
         return frames

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -43,8 +43,10 @@ namespace game {
         return _scene.eventContext;
     }
 
-    function init() {
-        if (!_scene) _scene = new scene.Scene(control.pushEventContext());
+    function init(forceNewScene ?: boolean) {
+        if (!_scene || forceNewScene) {
+            _scene = new scene.Scene(control.pushEventContext(), _scene);
+        }
         _scene.init();
 
         if (!winEffect)
@@ -64,8 +66,7 @@ namespace game {
         particles.disableAll();
         if (!_sceneStack) _sceneStack = [];
         _sceneStack.push(_scene);
-        _scene = undefined;
-        init();
+        init(/** forceNewScene **/ true);
 
         if (_scenePushHandlers) {
             _scenePushHandlers.forEach(cb => cb(oldScene));

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -197,7 +197,7 @@ namespace scene {
             this.flags |= scene.Flag.IsRendering;
 
             control.enablePerfCounter("render background")
-            if (this.flags & scene.Flag.SeeThrough && this.previousScene) {
+            if ((this.flags & scene.Flag.SeeThrough) && this.previousScene) {
                 this.previousScene.render();
             } else {
                 this.background.draw();

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -7,7 +7,8 @@ interface SparseArray<T> {
  */
 namespace scene {
     export enum Flag {
-        NeedsSorting = 1 << 1,
+        NeedsSorting = 1 << 0, // indicates the sprites in the scene need to be sorted before rendering
+        SeeThrough = 1 << 1, // if set, render the previous scene 'below' this one as the background
     }
 
     export class SpriteHandler {
@@ -71,7 +72,7 @@ namespace scene {
         gameForeverHandlers: GameForeverHandler[];
         particleSources: particles.ParticleSource[];
         controlledSprites: controller.ControlledSprite[][];
-        followingSprites: sprites.FollowingSprite[]
+        followingSprites: sprites.FollowingSprite[];
 
         private _millis: number;
         private _data: any;
@@ -79,7 +80,7 @@ namespace scene {
         // a set of functions that need to be called when a scene is being initialized
         static initializers: ((scene: Scene) => void)[] = [];
 
-        constructor(eventContext: control.EventContext) {
+        constructor(eventContext: control.EventContext, protected previousScene?: Scene) {
             this.eventContext = eventContext;
             this.flags = 0;
             this.physicsEngine = new ArcadePhysicsEngine();
@@ -144,8 +145,6 @@ namespace scene {
                 if (game.debug)
                     this.physicsEngine.draw();
                 game.consoleOverlay.draw();
-                // clear flags
-                this.flags = 0;
                 // check for power deep sleep
                 power.checkDeepSleep();
             });
@@ -206,11 +205,16 @@ namespace scene {
 
         private renderCore() {
             control.enablePerfCounter("render background")
-            this.background.draw();
+            if (this.flags & scene.Flag.SeeThrough && this.previousScene) {
+                this.previousScene.render();
+            } else {
+                this.background.draw();
+            }
 
             control.enablePerfCounter("sprite sort")
             if (this.flags & Flag.NeedsSorting) {
                 this.allSprites.sort(function (a, b) { return a.z - b.z || a.id - b.id; })
+                this.flags &= ~scene.Flag.NeedsSorting;
             }
 
             control.enablePerfCounter("sprite draw")

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -130,9 +130,8 @@ namespace scene {
 
             // render 90
             this.eventContext.registerFrameHandler(RENDER_SPRITES_PRIORITY, () => {
-                control.enablePerfCounter("sprite_draw")
-                this.cachedRender = undefined;
-                this.renderCore();
+                control.enablePerfCounter("scene_draw");
+                this.render();
             });
             // render diagnostics
             this.eventContext.registerFrameHandler(RENDER_DIAGNOSTICS_PRIORITY, () => {
@@ -188,22 +187,10 @@ namespace scene {
             this._data = undefined;
         }
 
-        protected cachedRender: Image;
         /**
          * Renders the current frame as an image
          */
-        render(): Image {
-            if (this.cachedRender) {
-                return this.cachedRender;
-            }
-
-            this.renderCore();
-
-            this.cachedRender = screen.clone();
-            return this.cachedRender;
-        }
-
-        private renderCore() {
+        render() {
             control.enablePerfCounter("render background")
             if (this.flags & scene.Flag.SeeThrough && this.previousScene) {
                 this.previousScene.render();

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -9,6 +9,7 @@ namespace scene {
     export enum Flag {
         NeedsSorting = 1 << 0, // indicates the sprites in the scene need to be sorted before rendering
         SeeThrough = 1 << 1, // if set, render the previous scene 'below' this one as the background
+        IsRendering = 1 << 2, // if set, the scene is currently being rendered to the screen
     }
 
     export class SpriteHandler {
@@ -191,6 +192,10 @@ namespace scene {
          * Renders the current frame as an image
          */
         render() {
+            // bail out from recursive or parallel call.
+            if (this.flags & scene.Flag.IsRendering) return;
+            this.flags |= scene.Flag.IsRendering;
+
             control.enablePerfCounter("render background")
             if (this.flags & scene.Flag.SeeThrough && this.previousScene) {
                 this.previousScene.render();
@@ -208,6 +213,8 @@ namespace scene {
             for (const s of this.allSprites) {
                 s.__draw(this.camera);
             }
+
+            this.flags &= ~scene.Flag.IsRendering;
         }
     }
 }

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -436,16 +436,9 @@ namespace game {
     //% block="show long text %str %layout"
     //% help=game/show-long-text
     export function showLongText(str: string, layout: DialogLayout) {
-        // Pause to cede control from this fiber just in case the user code created
-        // sprites and they haven't had a chance to render yet.
-        pause(1);
-
-        // Clone the current screen so that it shows up behind the dialog
-        let temp = screen.clone();
         controller._setUserEventsEnabled(false);
         game.pushScene();
-        scene.setBackgroundImage(temp);
-        temp = null;
+        game.currentScene().flags |= scene.Flag.SeeThrough;
 
         let width: number;
         let height: number;
@@ -656,10 +649,9 @@ namespace game {
     //% blockId=gameSplash block="splash %title||%subtitle"
     //% group="Prompt"
     export function splash(title: string, subtitle?: string) {
-        const temp = screen.clone();
         controller._setUserEventsEnabled(false);
         game.pushScene();
-        scene.setBackgroundImage(temp);
+        game.currentScene().flags |= scene.Flag.SeeThrough;
 
         const dialog = new SplashDialog(screen.width, subtitle ? 42 : 35);
         dialog.setText(title);

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -649,10 +649,6 @@ namespace game {
     //% blockId=gameSplash block="splash %title||%subtitle"
     //% group="Prompt"
     export function splash(title: string, subtitle?: string) {
-<<<<<<< HEAD
-=======
-        const temp = game.currentScene().render();
->>>>>>> bbbd462874f8c832cb9fd6e18e2b9d70917fef1f
         controller._setUserEventsEnabled(false);
         game.pushScene();
         game.currentScene().flags |= scene.Flag.SeeThrough;


### PR DESCRIPTION
Make it so you can set a scene as 'see through' - if set, it will render the scene below it as the background instead of using a normal background.

This lets you create scenes 'on top' of other scenes (menus, splash screens, other temporary overlays like tutorials) without explicitly managing a snapshot of the image from the previous scene as the background image.