### PR TITLE
don't let player go faster by moving diagonally

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -436,8 +436,9 @@ namespace controller {
 
             let deadSprites = false;
             const corner =  Math.SQRT2 / 2;
-            this._controlledSprites.forEach(sprite => {
-                if (sprite.s.flags & sprites.Flag.Destroyed) {
+            this._controlledSprites.forEach(controlledSprite => {
+                const {s, vx, vy} = controlledSprite;
+                if (s.flags & sprites.Flag.Destroyed) {
                     deadSprites = true;
                     return;
                 }
@@ -445,39 +446,39 @@ namespace controller {
                 let svx = 0;
                 let svy = 0;
 
-                if (sprite.vx) {
+                if (vx) {
                     if (this.right.isPressed())
-                        svx += sprite.vx;
+                        svx += vx;
                     if (this.left.isPressed())
-                        svx -= sprite.vx;
+                        svx -= vx;
                 }
 
-                if (sprite.vy) {
+                if (vy) {
                     if (this.down.isPressed())
-                        svy += sprite.vy;
+                        svy += vy;
                     if (this.up.isPressed())
-                        svy -= sprite.vy;
+                        svy -= vy;
                 }
 
-                if (sprite._inputLastFrame) {
-                    if (sprite.vx) sprite.s.vx = 0;
-                    if (sprite.vy) sprite.s.vy = 0;
+                if (controlledSprite._inputLastFrame) {
+                    if (vx) s.vx = 0;
+                    if (vy) s.vy = 0;
                 }
 
                 if (svx || svy) {
-                    if (sprite.vx && sprite.vy) {
-                        sprite.s.vx = svx * (svy ? corner : 1);
-                        sprite.s.vy = svy * (svx ? corner : 1);
-                    } else if (sprite.vx) {
-                        sprite.s.vx = svx;
-                    } else if (sprite.vy) {
-                        sprite.s.vy = svy;
+                    if (vx && vy) {
+                        s.vx = svx * (svy ? corner : 1);
+                        s.vy = svy * (svx ? corner : 1);
+                    } else if (vx) {
+                        s.vx = svx;
+                    } else if (controlledSprite.vy) {
+                        s.vy = svy;
                     }
 
-                    sprite._inputLastFrame = true;
+                    controlledSprite._inputLastFrame = true;
                 }
                 else {
-                    sprite._inputLastFrame = false;
+                    controlledSprite._inputLastFrame = false;
                 }
             });
 

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -435,7 +435,7 @@ namespace controller {
             if (!this._controlledSprites) return;
 
             let deadSprites = false;
-            const corner =  Math.SQRT2 / 2;
+            const corner = Math.SQRT2 / 2;
             this._controlledSprites.forEach(controlledSprite => {
                 const {s, vx, vy} = controlledSprite;
                 if (s.flags & sprites.Flag.Destroyed) {
@@ -471,7 +471,7 @@ namespace controller {
                         s.vy = svy * (svx ? corner : 1);
                     } else if (vx) {
                         s.vx = svx;
-                    } else if (controlledSprite.vy) {
+                    } else if (vy) {
                         s.vy = svy;
                     }
 

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -67,7 +67,7 @@ namespace controller {
             this._repeatCount = 0;
             if (id > 0) {
                 // this is to deal with the "anyButton" hack, which creates a button that is not visible
-                // in the UI, but used in event-handler to simulate the wildcard ANY for matching. As 
+                // in the UI, but used in event-handler to simulate the wildcard ANY for matching. As
                 // this button can't actually be pressed, we don't want it to propagate events
                 control.internalOnEvent(INTERNAL_KEY_UP, this.id, () => this.setPressed(false), 16)
                 control.internalOnEvent(INTERNAL_KEY_DOWN, this.id, () => this.setPressed(true), 16)
@@ -435,33 +435,28 @@ namespace controller {
             if (!this._controlledSprites) return;
 
             let deadSprites = false;
-            let svx: number;
-            let svy: number;
+            const corner =  Math.sqrt(2) / 2;
             this._controlledSprites.forEach(sprite => {
                 if (sprite.s.flags & sprites.Flag.Destroyed) {
                     deadSprites = true;
                     return;
                 }
 
-                svx = 0;
-                svy = 0;
+                let svx = 0;
+                let svy = 0;
 
                 if (sprite.vx) {
-                    if (this.right.isPressed()) {
+                    if (this.right.isPressed())
                         svx += sprite.vx;
-                    }
-                    if (this.left.isPressed()) {
-                        svx -=sprite.vx;
-                    }
+                    if (this.left.isPressed())
+                        svx -= sprite.vx;
                 }
 
                 if (sprite.vy) {
-                    if (this.down.isPressed()) {
+                    if (this.down.isPressed())
                         svy += sprite.vy;
-                    }
-                    if (this.up.isPressed()) {
+                    if (this.up.isPressed())
                         svy -= sprite.vy;
-                    }
                 }
 
                 if (sprite._inputLastFrame) {
@@ -470,8 +465,15 @@ namespace controller {
                 }
 
                 if (svx || svy) {
-                    if (sprite.vx) sprite.s.vx = svx;
-                    if (sprite.vy) sprite.s.vy = svy;
+                    if (sprite.vx && sprite.vy) {
+                        sprite.s.vx = svx * (svy ? corner : 1);
+                        sprite.s.vy = svy * (svx ? corner : 1);
+                    } else if (sprite.vx) {
+                        sprite.s.vx = svx;
+                    } else if (sprite.vy) {
+                        sprite.s.vy = svy;
+                    }
+
                     sprite._inputLastFrame = true;
                 }
                 else {

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -435,7 +435,8 @@ namespace controller {
             if (!this._controlledSprites) return;
 
             let deadSprites = false;
-            const corner = Math.SQRT2 / 2;
+            const corner = Fx.rightShift(Fx8(Math.SQRT2), 1);
+            const side = Fx8(1);
             this._controlledSprites.forEach(controlledSprite => {
                 const {s, vx, vy} = controlledSprite;
                 if (s.flags & sprites.Flag.Destroyed) {
@@ -467,8 +468,14 @@ namespace controller {
 
                 if (svx || svy) {
                     if (vx && vy) {
-                        s.vx = svx * (svy ? corner : 1);
-                        s.vy = svy * (svx ? corner : 1);
+                        s._vx = Fx.mul(
+                            Fx8(svx),
+                            svy ? corner : side
+                        );
+                        s._vy = Fx.mul(
+                            Fx8(svy),
+                            svx ? corner : side
+                        );
                     } else if (vx) {
                         s.vx = svx;
                     } else if (vy) {

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -435,7 +435,7 @@ namespace controller {
             if (!this._controlledSprites) return;
 
             let deadSprites = false;
-            const corner =  Math.sqrt(2) / 2;
+            const corner =  Math.SQRT2 / 2;
             this._controlledSprites.forEach(sprite => {
                 if (sprite.s.flags & sprites.Flag.Destroyed) {
                     deadSprites = true;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1421

I just did atan2 + sin / cos at first, but then I thought about it for a minute and remembered my [unit circle](https://www.google.com/search?q=unit+circle&sxsrf=ACYBGNTs9VZs9a1vjRh2TWNtEE8WhP8avg:1571952022606&tbm=isch&source=iu&ictx=1&fir=Oeo5GOQ0YHmFvM%253A%252CQG4XqAmcN5dozM%252C_&vet=1&usg=AI4_-kT2bBY3Gkqh_5Z0n1oh3ZmIvjXZOQ&sa=X&ved=2ahUKEwi5gaXP6bXlAhVJJzQIHWlvDL0Q9QEwAHoECAUQAw#imgrc=Oeo5GOQ0YHmFvM:) instead of doing those relatively expensive operations

![2019-10-24 14 22 43](https://user-images.githubusercontent.com/5615930/67526497-ca725400-f669-11e9-86f0-0bff5c2f64d1.gif)
