### PR TITLE
Revert "Revert "make clear particle effects allow sprites in blocks""

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -135,7 +135,7 @@ namespace effects {
     //% blockNamespace=sprites
     //% group="Effects" weight=89
     //% help=effects/clear-particles
-    export function clearParticles(anchor: particles.ParticleAnchor) {
+    export function clearParticles(anchor: Sprite | particles.ParticleAnchor) {
         const sources = game.currentScene().particleSources;
         if (!sources) return;
         sources


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1254

reverts https://github.com/microsoft/pxt-common-packages/pull/961, which fixed a random break in the compiler at the time (but unfixed another problem).

This no longer seems to be broken, which would indicate either the underlying bug got fixed in one of the many recent compiler changes, or it was a random break at the time along the lines of https://github.com/microsoft/pxt-arcade/issues/1118 and enough of the surrounding code has changed to make it not break anymore.