### PR TITLE
Fix sprite say positioning

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -530,12 +530,13 @@ class Sprite extends sprites.BaseSprite {
                     }
                 }
 
+                this.sayBubbleSprite.y = this.top + bubbleOffset - ((font.charHeight + bubblePadding) >> 1) - 2;
+                this.sayBubbleSprite.x = this.x;
+
                 if (needsRedraw) {
                     needsRedraw = false;
                     this.sayBubbleSprite.image.fill(textBoxColor);
                     // The minus 2 is how much transparent padding there is under the sayBubbleSprite
-                    this.sayBubbleSprite.y = this.top + bubbleOffset - ((font.charHeight + bubblePadding) >> 1) - 2;
-                    this.sayBubbleSprite.x = this.x;
                     // If maxOffset is negative it won't scroll
                     if (maxOffset < 0) {
                         this.sayBubbleSprite.image.print(text, startX, startY, textColor, font);

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -530,13 +530,13 @@ class Sprite extends sprites.BaseSprite {
                     }
                 }
 
+                // The minus 2 is how much transparent padding there is under the sayBubbleSprite
                 this.sayBubbleSprite.y = this.top + bubbleOffset - ((font.charHeight + bubblePadding) >> 1) - 2;
                 this.sayBubbleSprite.x = this.x;
 
                 if (needsRedraw) {
                     needsRedraw = false;
                     this.sayBubbleSprite.image.fill(textBoxColor);
-                    // The minus 2 is how much transparent padding there is under the sayBubbleSprite
                     // If maxOffset is negative it won't scroll
                     if (maxOffset < 0) {
                         this.sayBubbleSprite.image.print(text, startX, startY, textColor, font);


### PR DESCRIPTION
Fix sprite say - e.g. https://makecode.com/_ReT0YeYVcHhe has it trailing / not following right away. It needs to update position continuously, not just when it needs to be redrawn

![2019-11-20 15 30 07](https://user-images.githubusercontent.com/5615930/69287374-e0146400-0baa-11ea-913c-79e5e23834e5.gif)
