### PR TITLE
Adding a camera sprite flag and getters for the camera position

### DIFF
--- a/libs/game/docs/reference/scene/camera-left.md
+++ b/libs/game/docs/reference/scene/camera-left.md
@@ -1,0 +1,13 @@
+# camera left
+
+Returns the x coordinate of the camera (the left side of the screen).
+
+```sig
+scene.cameraLeft()
+```
+
+## See also #seealso
+
+[camera follow sprite](/reference/scene/camera-follow-sprite)
+[center camera at](/reference/scene/center-camera-at)
+[camera left](/reference/scene/camera-left)

--- a/libs/game/docs/reference/scene/camera-top.md
+++ b/libs/game/docs/reference/scene/camera-top.md
@@ -1,0 +1,13 @@
+# camera top
+
+Returns the y coordinate of the camera (the top of the screen).
+
+```sig
+scene.cameraTop()
+```
+
+## See also #seealso
+
+[camera follow sprite](/reference/scene/camera-follow-sprite)
+[center camera at](/reference/scene/center-camera-at)
+[camera top](/reference/scene/camera-top)

--- a/libs/game/docs/reference/sprites/sprite/set-flag.md
+++ b/libs/game/docs/reference/sprites/sprite/set-flag.md
@@ -1,4 +1,4 @@
-# set Flag 
+# set Flag
 
 Set a sprite flag to ``on`` or ``off``.
 
@@ -14,6 +14,11 @@ Sprite flags are settings that change the way a sprite reacts on the screen. Whe
 >* ``stay in screen``: the sprite is forced to stay on the screen when it reaches a screen edge
 >* ``ghost``: the sprite never overlaps other sprites and won't collide with obstacles
 >* ``auto destroy``: the sprite is automatically destroyed when it moves off the screen
+>* ``destroy on wall``: the sprite is automatically destroyed when it collides with a wall tile
+>* ``bounce on wall``: the sprite will deflect when it collides with a wall tile
+>* ``show physics``: the sprite will display its position, velocity, and acceleration below it
+>* ``invisible``: the sprite will not be drawn to the screen
+>* ``relative to camera``: the sprite is drawn relative to the camera rather than relative to the world and the sprite never overlaps other sprites or collide with obstacles. This is useful for drawing static elements to the screen (scores, dialog boxes, etc.) that shouldn't move when the camera pans
 
 ## ~hint
 
@@ -35,22 +40,22 @@ enum SpriteKind {
 }
 let ghost: Sprite = null
 ghost = sprites.create(img`
-. . . . . . d d d d d . . . . . 
-. . . d d d d 1 1 1 d d d . . . 
-. . d d 1 1 1 1 1 1 1 1 d d . . 
-. . d 1 1 1 1 1 1 1 1 1 1 d . . 
-. . d 1 1 1 1 1 1 1 1 1 1 d d . 
-. d d 1 1 1 f 1 1 1 f 1 1 1 d . 
-. d 1 1 1 1 1 1 1 1 1 1 1 1 d d 
-. d 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
-. d 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
-d d 1 1 1 1 1 1 f f 1 1 1 1 1 d 
-d 1 1 1 1 1 1 1 f f 1 1 1 1 1 d 
-d 1 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
-d 1 1 1 1 1 1 1 d 1 1 1 1 1 1 d 
-d 1 d d d 1 1 d d d d 1 d 1 1 d 
-d d d . d d d d . . d d d d d d 
-d d . . . d d . . . . d . . d d 
+. . . . . . d d d d d . . . . .
+. . . d d d d 1 1 1 d d d . . .
+. . d d 1 1 1 1 1 1 1 1 d d . .
+. . d 1 1 1 1 1 1 1 1 1 1 d . .
+. . d 1 1 1 1 1 1 1 1 1 1 d d .
+. d d 1 1 1 f 1 1 1 f 1 1 1 d .
+. d 1 1 1 1 1 1 1 1 1 1 1 1 d d
+. d 1 1 1 1 1 1 1 1 1 1 1 1 1 d
+. d 1 1 1 1 1 1 1 1 1 1 1 1 1 d
+d d 1 1 1 1 1 1 f f 1 1 1 1 1 d
+d 1 1 1 1 1 1 1 f f 1 1 1 1 1 d
+d 1 1 1 1 1 1 1 1 1 1 1 1 1 1 d
+d 1 1 1 1 1 1 1 d 1 1 1 1 1 1 d
+d 1 d d d 1 1 d d d d 1 d 1 1 d
+d d d . d d d d . . d d d d d d
+d d . . . d d . . . . d . . d d
 `, SpriteKind.Example)
 let tileMap: Image = null
 let orangeBlock: Image = null

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -24,7 +24,7 @@ class PhysicsEngine {
 }
 
 const MAX_TIME_STEP = Fx8(100); // milliseconds
-const SPRITE_CANNOT_COLLIDE = sprites.Flag.Ghost | sprites.Flag.Destroyed;
+const SPRITE_CANNOT_COLLIDE = sprites.Flag.Ghost | sprites.Flag.Destroyed | sprites.Flag.RelativeToCamera;
 const MIN_MOVE_GAP = Fx8(0.1);
 
 class MovingSprite {

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -223,4 +223,26 @@ namespace scene {
         scene.camera.offsetX = x - (screen.width >> 1);
         scene.camera.offsetY = y - (screen.height >> 1);
     }
+
+    /**
+     * Returns the x coordinate of the camera (the left of the screen)
+     */
+    //% blockId=cameraleft block="camera left"
+    //% group="Camera"
+    //% help=scene/camera-left
+    export function cameraLeft() {
+        const scene = game.currentScene();
+        return scene.camera.drawOffsetX;
+    }
+
+    /**
+     * Returns the y coordinate of the camera (the top of the screen)
+     */
+    //% blockId=cameratop block="camera top"
+    //% group="Camera"
+    //% help=scene/camera-top
+    export function cameraTop() {
+        const scene = game.currentScene();
+        return scene.camera.drawOffsetY;
+    }
 }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -694,9 +694,9 @@ class Sprite extends sprites.BaseSprite {
     overlapsWith(other: Sprite) {
         control.enablePerfCounter("overlapsCPP")
         if (other == this) return false;
-        if (this.flags & sprites.Flag.Ghost)
+        if (this.flags & (sprites.Flag.Ghost | sprites.Flag.RelativeToCamera))
             return false
-        if (other.flags & sprites.Flag.Ghost)
+        if (other.flags & (sprites.Flag.Ghost | sprites.Flag.RelativeToCamera))
             return false
         return other._image.overlapsWith(this._image, this.left - other.left, this.top - other.top)
     }

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -159,5 +159,6 @@ namespace sprites {
         ShowPhysics = 1 << 6, // display position, velocity, acc
         Invisible = 1 << 7, // makes the sprite invisible, so it does not show up on the screen
         IsClipping = 1 << 8, // whether the sprite is currently clipping into a wall. This can happen when a sprite is created or moved explicitly.
+        RelativeToCamera = 1 << 9 // draw relative to the camera, not the world (e.g. HUD elements)
     }
 }


### PR DESCRIPTION
Adding two new blocks for getting camera left/top and a new sprite flag for HUD elements.


This is in response to https://forum.makecode.com/t/overlay-help/807/3 and https://forum.makecode.com/t/hud-and-inventory-for-large-tile-maps/644