### PR TITLE
fix translations for single player buttons

### DIFF
--- a/libs/game/controlleroverrides.ts
+++ b/libs/game/controlleroverrides.ts
@@ -1,7 +1,7 @@
 namespace controller {
-    //% fixedInstance whenUsed block="A"
+    //% fixedInstance whenUsed block="{id:controller}A"
     export const A = new Button(ControllerButton.A, -1);
-    //% fixedInstance whenUsed block="B"
+    //% fixedInstance whenUsed block="{id:controller}B"
     export const B = new Button(ControllerButton.B, -1);
     //% fixedInstance whenUsed block="left"
     export const left = new Button(ControllerButton.Left, -1);


### PR DESCRIPTION
make the single player buttons have the same annotations as the multiplayer buttons, so they don't get translated differently. Requires https://github.com/microsoft/pxt/pull/6303 or an equivalent fix to show up properly.