### PR TITLE
make default follow acceleration faster

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -793,7 +793,7 @@ class Sprite extends sprites.BaseSprite {
      * @param target the sprite this one should follow
      * @param speed the rate at which this sprite should move, eg: 100
      * @param turnRate how quickly the sprite should turn while following.
-     *      The default (100) will cause the sprite to reach max speed after approximately 125 ms when standing still,
+     *      The default (400) will cause the sprite to reach max speed after approximately 125 ms when standing still,
      *      and turn around 180 degrees when at max speed after approximately 250 ms.
      */
     //% group="Physics" weight=10

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -793,13 +793,13 @@ class Sprite extends sprites.BaseSprite {
      * @param target the sprite this one should follow
      * @param speed the rate at which this sprite should move, eg: 100
      * @param turnRate how quickly the sprite should turn while following.
-     *      The default (100) will cause the sprite to reach max speed after approximately 500 ms when standing still,
-     *      and turn around 180 degrees when at max speed after approximately 1000 ms.
+     *      The default (100) will cause the sprite to reach max speed after approximately 125 ms when standing still,
+     *      and turn around 180 degrees when at max speed after approximately 250 ms.
      */
     //% group="Physics" weight=10
     //% blockId=spriteFollowOtherSprite
     //% block="set %sprite(myEnemy) follow %target=variables_get(mySprite) || with speed %speed"
-    follow(target: Sprite, speed = 100, turnRate = 100) {
+    follow(target: Sprite, speed = 100, turnRate = 400) {
         if (target === this) return;
 
         const sc = game.currentScene();


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1505; make the default turn rate faster so that it turns around at a rate close to that in the live site.