### PR TITLE
resolve clipping when possible by bumping sprite to other tiles

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -546,14 +546,87 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 );
                 this.tilemapCollisions(ms, tm);
             // otherwise, accept movement...
-            } else if (tm.isOnWall(s)) {
-            // and flag if now clipping into a wall
+            } else if (tm.isOnWall(s) && !this.canResolveClipping(s, tm)) {
+                // if no luck, flag as clipping into a wall
                 s.flags |= sprites.Flag.IsClipping;
-            // and clear clipping if not
             } else {
+                // or clear clipping if no longer clipping
                 s.flags &= ~sprites.Flag.IsClipping;
             }
         }
+    }
+
+    // Attempt to resolve clipping by moving the sprite slightly up / down / left / right
+    protected canResolveClipping(s: Sprite, tm: tiles.TileMap) {
+        const hbox = s._hitbox;
+        const sz = 1 << tm.scale;
+        const maxMove = this.maxStep;
+        const origY = s._y;
+        const origX = s._x;
+        const l = Fx.toInt(hbox.left);
+        const r = Fx.toInt(hbox.right);
+        const t = Fx.toInt(hbox.top);
+        const b = Fx.toInt(hbox.bottom);
+
+        {   // bump up and test;
+            const offset = (b + 1) % sz;
+            if (offset <= maxMove) {
+                s._y = Fx.sub(
+                    s._y,
+                    Fx8(offset)
+                );
+                if (!tm.isOnWall(s)) {
+                    return true;
+                } else {
+                    s._y = origY;
+                }
+            }
+        }
+        {   // bump down and test;
+            const offset = (Math.floor(t / sz) + 1) * sz - t;
+            if (offset <= maxMove) {
+                s._y = Fx.add(
+                    s._y,
+                    Fx8(offset)
+                );
+                if (!tm.isOnWall(s)) {
+                    return true;
+                } else {
+                    s._y = origY;
+                }
+            }
+        }
+        {   // bump left and test;
+            const offset = (r + 1) % sz;
+            if (offset <= maxMove) {
+                s._x = Fx.sub(
+                    s._x,
+                    Fx8(offset)
+                );
+                if (!tm.isOnWall(s)) {
+                    return true;
+                } else {
+                    s._x = origX;
+                }
+            }
+        }
+        {   // bump right and test;
+            const offset = (Math.floor(l / sz) + 1) * sz - l;
+            if (offset <= maxMove) {
+                s._x = Fx.add(
+                    s._x,
+                    Fx8(offset)
+                );
+                if (!tm.isOnWall(s)) {
+                    return true;
+                } else {
+                    s._x = origX;
+                }
+            }
+        }
+
+        // no trivial adjustment worked; it's going to clip for now
+        return false;
     }
 
     private constrain(v: Fx8) {

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -257,7 +257,7 @@ namespace tiles {
         }
 
         public isOnWall(s: Sprite) {
-            const hbox = s._hitbox
+            const hbox = s._hitbox;
 
             const left = Fx.toIntShifted(hbox.left, this.scale);
             const right = Fx.toIntShifted(hbox.right, this.scale);


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1518

I used an extra closure for each case (up / down / left / right) to try to make it extra clear that they're four distinct cases / four distinct offsets. By default this will move the sprite up to 4px in a single direction to avoid clipping.

Tested on sim and pygamer.

sample game: https://makecode.com/_2Um08FgJeJUP - move sprite into the horizontal wall and press a to fire to the right and see that the sprite is offset, and do the same with the vertical wall and b. 