### PR TITLE
Pull legacy 'music' docs into 'mixer'

### DIFF
--- a/libs/mixer/docs/reference/music.md
+++ b/libs/mixer/docs/reference/music.md
@@ -1,0 +1,35 @@
+# Music
+
+Make music and play tones.
+
+## Melodies
+
+```cards
+music.playMelody("", 120);
+music.baDing.play()
+music.baDing.playUntilDone()
+music.baDing.loop()
+music.baDing.stop()
+```
+
+## Sound
+
+```cards
+music.playTone(0, 0);
+music.ringTone(0);
+music.rest(0);
+music.noteFrequency(Note.C);
+music.beat(BeatFraction.Whole);
+music.tempo();
+music.changeTempoBy(20);
+music.setTempo(120);
+music.setVolume(0)
+music.stopAllSounds()
+```
+
+## See Also
+
+[play melody](/reference/music/play-melody), [play tone](/reference/music/play-tone),
+[ring tone](/reference/music/ring-tone), [rest](/reference/music/rest),
+[beat](/reference/music/beat), [tempo](/reference/music/tempo),
+[change tempo by](/reference/music/change-tempo-by),[set tempo](/reference/music/set-tempo)

--- a/libs/mixer/docs/reference/music/beat.md
+++ b/libs/mixer/docs/reference/music/beat.md
@@ -1,0 +1,27 @@
+# beat
+
+Get the length of time for a musical beat.
+
+```sig
+music.beat(BeatFraction.Whole)
+```
+
+## Parameters
+
+* ``fraction`` means fraction of a beat (BeatFraction.Whole, BeatFraction.Sixteenth, etc.) 
+
+## Returns
+
+* a [number](/types/number) that is the amount of time in milliseconds (one-thousandth of a second) for the beat fraction.
+
+## Example #example
+
+```blocks
+music.playTone(Note.C, music.beat(BeatFraction.Quarter))
+```
+
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)

--- a/libs/mixer/docs/reference/music/change-tempo-by.md
+++ b/libs/mixer/docs/reference/music/change-tempo-by.md
@@ -1,0 +1,36 @@
+# Change Tempo By
+
+Makes the [tempo](/reference/music/tempo) (speed of a piece of music)
+faster or slower by the amount you say.
+
+```sig
+music.changeTempoBy(20)
+```
+
+## Simulator
+
+This function only works on the @boardname@ and in some browsers.
+
+## Parameters
+
+* ``bpm`` is a [number](/types/number) that says how much to
+  change the bpm (beats per minute, or number of beats in a minute of
+  the music that the @boardname@ is playing).
+
+## Example #example
+
+This program makes the music faster by 12 bpm.
+
+```blocks
+music.changeTempoBy(12)
+```
+
+This program makes the music _slower_ by 12 bpm.
+
+```blocks
+music.changeTempoBy(-12)
+```
+
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone) 

--- a/libs/mixer/docs/reference/music/composing-sounds.md
+++ b/libs/mixer/docs/reference/music/composing-sounds.md
@@ -1,0 +1,71 @@
+# Composing sounds
+
+Composing some sound, or maybe some music, is done by putting tones to together, one after another.
+
+## Musical notes
+
+A _note_ is a tone that is recognized as part of music. A note has a name like '**C**'. A note is
+played for an amount of time called its _duration_. 
+
+On your @boardname@, a note is played on the speaker by sending a signal to a it with a certain _frequency_ called [Hertz](http://wikipedia.org/Hertz). Frequency is how fast something vibrates during one second. If you ring a bell that was
+made to play an '**A**' note, the bell will vibrate at 440 Hertz (440 times per second). So, notes are just certain frequencies
+that have special names.
+
+In history, music came from tones that seemed nice to hear. The tones were played on wood, strings, metal, and skins.
+These tones were given names and they became what we know today as musical notes. Notes were named so we could write them
+down and remember how to play them again later.
+
+## How are notes named?
+
+Basic notes have names that use one of the first nine letters of the alphabet. They are:
+
+``|A|``, ``|B|``, ``|C|``, ``|D|``, ``|E|``, ``|F|``, ``|G|``
+
+Ther are other notes named like the basic notes but have extra parts to the name called _sharp_ and _flat_. These other
+notes are just a bit different from the basic notes and have frequencies a little higher or lower than the
+basic note. This makes music a little more complicated but much more interesting!
+
+Some of these other notes look like:
+
+``|C#|``, ``|Eb|``
+
+When a small amount music or even a song is written down it is called [sheet music](https://wikipedia.org/wiki/Sheet_music).
+
+## Sounds and music in code
+
+Of course, we can't use written music in our code. We can make music another way. The way to do it is to
+put names of notes together as a [string](/types/string). We make our notes using letters, symbols, and
+numbers. Notes put together in our code look like:
+```block
+"E3:3 R:1 D#:3 R:1 D:4 R:1 C#:8"
+```
+
+What you see is not some alien language but a bunch of notes with their duration. The form of a single
+note is **note : duration** or ``C:2``. This means play the '**C**' note for **2** beats of time.
+The notes are placed one after the other with a _space_ between them, like ``"B:2 C#:6"``. If you want
+a note to play for **4** beats, you don't need to use any duration number (a note with 4 beats is called a _whole_ note).
+Just say something like ``"E"`` with no colon (leave out the ``':'``) and no duration number.
+
+You might notice that the sound string has an ``R:1`` in it. The '**R**` means _rest_ and to rest for one beat.
+A rest is a pause, or a time of silence, in the sound.
+
+
+#### ~hint
+**Duration**
+
+The amount of time a note is played (duration) is measured as _beats_. The standard number
+_beats per minute_ (bpm) in music is 120 bpm which is one-half of a second of time. A _whole_ note lasts
+for 4 beats and a _quarter_ note takes just one beat.
+#### ~
+
+## Example
+
+Compose the first few notes of Beethoven's 5th symphony.
+
+```blocks
+let beet5 = "G:1 G:1 G:1 Eb F:1 F:1 F:1 D"
+```
+
+## See also
+
+[Tempo](https://wikipedia.org/wiki/Tempo)

--- a/libs/mixer/docs/reference/music/composing-sounds.md
+++ b/libs/mixer/docs/reference/music/composing-sounds.md
@@ -46,7 +46,7 @@ The notes are placed one after the other with a _space_ between them, like ``"B:
 a note to play for **4** beats, you don't need to use any duration number (a note with 4 beats is called a _whole_ note).
 Just say something like ``"E"`` with no colon (leave out the ``':'``) and no duration number.
 
-You might notice that the sound string has an ``R:1`` in it. The '**R**` means _rest_ and to rest for one beat.
+You might notice that the sound string has an ``R:1`` in it. The `**R**` means _rest_ and to rest for one beat.
 A rest is a pause, or a time of silence, in the sound.
 
 

--- a/libs/mixer/docs/reference/music/composing-sounds.md
+++ b/libs/mixer/docs/reference/music/composing-sounds.md
@@ -46,17 +46,19 @@ The notes are placed one after the other with a _space_ between them, like ``"B:
 a note to play for **4** beats, you don't need to use any duration number (a note with 4 beats is called a _whole_ note).
 Just say something like ``"E"`` with no colon (leave out the ``':'``) and no duration number.
 
-You might notice that the sound string has an ``R:1`` in it. The `**R**` means _rest_ and to rest for one beat.
+You might notice that the sound string has an ``R:1`` in it. The '**R**' means _rest_ and to rest for one beat.
 A rest is a pause, or a time of silence, in the sound.
 
 
-#### ~hint
-**Duration**
+### ~hint
+
+#### Duration
 
 The amount of time a note is played (duration) is measured as _beats_. The standard number
 _beats per minute_ (bpm) in music is 120 bpm which is one-half of a second of time. A _whole_ note lasts
 for 4 beats and a _quarter_ note takes just one beat.
-#### ~
+
+### ~
 
 ## Example
 

--- a/libs/mixer/docs/reference/music/note-frequency.md
+++ b/libs/mixer/docs/reference/music/note-frequency.md
@@ -1,0 +1,29 @@
+# note Frequency
+
+Get the frequency of a musical note.
+
+```sig
+music.noteFrequency(Note.C)
+```
+## Parameters
+
+* ``name`` is the name of the **Note** you want a frequency value for.
+
+## Returns
+* a [number](/types/number) that is the frequency (in [Hertz](https://wikipedia.org/wiki/Hertz))
+of a note you chose.
+
+## Example #example
+
+Play a 'C' note for one second, rest for one second, and then play an 'A' note for one second.
+
+```blocks
+music.playTone(music.noteFrequency(Note.C), 1000)
+music.rest(1000)
+music.playTone(music.noteFrequency(Note.A), 1000)
+```
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [tempo](/reference/music/tempo),
+[change tempo by](/reference/music/change-tempo-by)

--- a/libs/mixer/docs/reference/music/note-frequency.md
+++ b/libs/mixer/docs/reference/music/note-frequency.md
@@ -5,11 +5,13 @@ Get the frequency of a musical note.
 ```sig
 music.noteFrequency(Note.C)
 ```
+
 ## Parameters
 
 * ``name`` is the name of the **Note** you want a frequency value for.
 
 ## Returns
+
 * a [number](/types/number) that is the frequency (in [Hertz](https://wikipedia.org/wiki/Hertz))
 of a note you chose.
 

--- a/libs/mixer/docs/reference/music/play-tone.md
+++ b/libs/mixer/docs/reference/music/play-tone.md
@@ -7,9 +7,13 @@ music.playTone(Note.C, 10)
 ```
 
 ## #simnote
-#### ~hint
-**Simulator**: ``||music:play tone||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~hint
+
+#### Simulator
+
+``||music:play tone||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 

--- a/libs/mixer/docs/reference/music/play-tone.md
+++ b/libs/mixer/docs/reference/music/play-tone.md
@@ -1,0 +1,36 @@
+# play Tone
+
+Play a musical tone on the speaker for some amount of time.
+
+```sig
+music.playTone(Note.C, 10)
+```
+
+## #simnote
+#### ~hint
+**Simulator**: ``||music:play tone||`` works on the @boardname@. It might not work in the simulator on every browser.
+#### ~
+
+## Parameters
+
+* ``frequency`` is the [number](/types/number) of [Hertz](https://wikipedia.org/wiki/Hertz) (how high or low the tone is, also known as _pitch_).
+* ``ms`` is the [number](/types/number) of milliseconds (one-thousandth of a second) that the tone lasts for.
+
+## Special handling of values
+
+* If ``frequency`` is less or equal to zero, the sound is stopped.
+* If ``ms`` is negative or zero, the sound is not stopped and will keep beeping.
+
+## Example #example
+
+Store the musical note 'C' in the variable `freq` and play that note for 1000 milliseconds (one second).
+
+```blocks
+let freq = music.noteFrequency(Note.C);
+music.playTone(freq, 1000)
+```
+
+## See also #seealso
+
+[rest](/reference/music/rest), [ring tone](/reference/music/ring-tone) , [tempo](/reference/music/tempo),
+[set tempo](/reference/music/set-tempo), [change tempo by](/reference/music/change-tempo-by)

--- a/libs/mixer/docs/reference/music/rest.md
+++ b/libs/mixer/docs/reference/music/rest.md
@@ -1,0 +1,38 @@
+# rest
+
+Give the speaker a period of time to not play any sound.
+
+```sig
+music.rest(400);
+```
+
+## #simnote
+### ~hint
+
+**Simulator**: ``||music:rest||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
+
+## Parameters
+
+* ``ms`` is a [number](/types/number) saying how many
+  milliseconds the @boardname@ should rest. One second is 1000
+  milliseconds.
+
+## Example #example
+
+Play a 'C' note for one second and then rest for one second. Do it again, and again...
+
+```blocks
+let frequency = music.noteFrequency(Note.C)
+while (true) {
+    music.playTone(frequency, 1000)
+    music.rest(1000)
+}
+```
+
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)

--- a/libs/mixer/docs/reference/music/rest.md
+++ b/libs/mixer/docs/reference/music/rest.md
@@ -9,7 +9,9 @@ music.rest(400);
 ## #simnote
 ### ~hint
 
-**Simulator**: ``||music:rest||`` works on the @boardname@. It might not work in the simulator on every browser.
+#### Simulator
+
+``||music:rest||`` works on the @boardname@. It might not work in the simulator on every browser.
 
 ### ~
 

--- a/libs/mixer/docs/reference/music/ring-tone.md
+++ b/libs/mixer/docs/reference/music/ring-tone.md
@@ -1,0 +1,48 @@
+# ring Tone
+
+Play a musical tone on the speaker. The tone has a pitch (frequency) as high or low as you say.
+The tone will keep playing until tell it to stop.
+
+```sig
+music.ringTone(0);
+```
+
+## #simnote
+### ~hint
+**Simulator**: ``||music:ring tone||`` works on the @boardname@. It might not work in the simulator on every browser.
+### ~
+
+The tone will keep playing until you stop it with [``||music:stop all sounds||``](/reference/music/stop-all-sounds).
+
+## Parameters
+
+* ``frequency`` is a [number](/types/number) that says
+how high-pitched or low-pitched the tone is.  This
+number is in **Hz** (**Hertz**), which is a measurement of frequency (_pitch_).
+
+## Example #example
+
+Play a tone with a base frequency of ``440`` but change it by ``20`` Hertz steps both up and down.
+
+```blocks
+let offset = 0
+offset = -100
+while (true) {
+    while (offset < 100) {
+        offset += 20
+        music.ringTone(440 + offset)
+        pause(300)
+    }
+    while (offset > -100) {
+        offset += -20
+        music.ringTone(440 + offset)
+        pause(300)
+    }
+}
+```
+
+## See also #seealso
+
+[rest](/reference/music/rest), [play tone](/reference/music/play-tone),
+[tempo](/reference/music/tempo), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)

--- a/libs/mixer/docs/reference/music/ring-tone.md
+++ b/libs/mixer/docs/reference/music/ring-tone.md
@@ -9,7 +9,11 @@ music.ringTone(0);
 
 ## #simnote
 ### ~hint
-**Simulator**: ``||music:ring tone||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+#### Simulator
+
+``||music:ring tone||`` works on the @boardname@. It might not work in the simulator on every browser.
+
 ### ~
 
 The tone will keep playing until you stop it with [``||music:stop all sounds||``](/reference/music/stop-all-sounds).

--- a/libs/mixer/docs/reference/music/set-tempo.md
+++ b/libs/mixer/docs/reference/music/set-tempo.md
@@ -1,0 +1,31 @@
+# set Tempo 
+
+Make the tempo (speed) of the music playing go faster or slower.
+
+```sig
+music.setTempo(60)
+```
+
+## #simnote
+#### ~hint
+**Simulator**: ``||music:set tempo||`` works on the @boardname@. It might not work in the simulator on every browser.
+#### ~
+
+## Parameters
+
+* ``bpm`` is a [number](/types/number) that means the amount _beats per minute_ you want. This is how fast
+you want @boardname@ to play music.
+
+## Example #example
+
+Set the music tempo to 240 beats per minute.
+
+```blocks
+music.setTempo(240)
+```
+
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [tempo](/reference/music/tempo),
+[change tempo by](/reference/music/change-tempo-by)

--- a/libs/mixer/docs/reference/music/set-tempo.md
+++ b/libs/mixer/docs/reference/music/set-tempo.md
@@ -7,9 +7,12 @@ music.setTempo(60)
 ```
 
 ## #simnote
-#### ~hint
-**Simulator**: ``||music:set tempo||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~hint
+
+#### Simulator
+
+``||music:set tempo||`` works on the @boardname@. It might not work in the simulator on every browser.
+### ~
 
 ## Parameters
 

--- a/libs/mixer/docs/reference/music/set-volume.md
+++ b/libs/mixer/docs/reference/music/set-volume.md
@@ -1,0 +1,33 @@
+# set Volume
+
+Set the volume for the sound synthesizer.
+
+The synthesizer volume controls the
+level of the sound playing on current sound output of the board (speaker or pin).
+
+```sig
+music.setVolume(128)
+```
+
+## #simnote
+#### ~hint
+**Simulator**: ``||music:set volume||`` works on the @boardname@. It might not work in the simulator on every browser.
+#### ~
+
+## Parameters
+
+* ``volume``: the volume of of the sounds played to the sound output. The volume [number](/types/number) can be between `0` for silent and `255` for the loudest sound.
+
+## Example #example
+
+Set the synthesizer volume to something quieter.
+
+```blocks
+music.setVolume(50)
+let freq = music.noteFrequency(Note.C);
+music.playTone(freq, 1000)
+```
+
+## See also #seealso
+
+[play tone](/reference/music/play-tone)

--- a/libs/mixer/docs/reference/music/set-volume.md
+++ b/libs/mixer/docs/reference/music/set-volume.md
@@ -10,9 +10,13 @@ music.setVolume(128)
 ```
 
 ## #simnote
-#### ~hint
-**Simulator**: ``||music:set volume||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~hint
+
+#### Simulator
+
+``||music:set volume||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
 
 ## Parameters
 

--- a/libs/mixer/docs/reference/music/stop-all-sounds.md
+++ b/libs/mixer/docs/reference/music/stop-all-sounds.md
@@ -1,0 +1,29 @@
+# stop All Sounds
+
+Stop all the sounds that are playing right now and any others waiting to play.
+
+```sig
+music.stopAllSounds()
+```
+
+If you play sounds or sound effects more than once, the sounds you asked to play later have to wait until the sounds played earlier finish. You can stop the sound that is playing now and all the sounds waiting to play with ``||music:stop all sounds||``.
+
+## #simnote
+#### ~hint
+**Simulator**: ``||music:stop all sounds||`` works on the @boardname@. It might not work in the simulator on every browser.
+#### ~
+
+## Example #example
+
+Play a tone but stop it right away.
+
+```blocks
+let freq = music.noteFrequency(Note.C);
+music.playTone(freq, 1000)
+music.stopAllSounds()
+```
+
+## See also #seealso
+
+[play melody](/reference/music/play-melody), [play](/reference/music/melody/play),
+[play tone](/reference/music/play-tone)

--- a/libs/mixer/docs/reference/music/stop-all-sounds.md
+++ b/libs/mixer/docs/reference/music/stop-all-sounds.md
@@ -9,9 +9,13 @@ music.stopAllSounds()
 If you play sounds or sound effects more than once, the sounds you asked to play later have to wait until the sounds played earlier finish. You can stop the sound that is playing now and all the sounds waiting to play with ``||music:stop all sounds||``.
 
 ## #simnote
-#### ~hint
-**Simulator**: ``||music:stop all sounds||`` works on the @boardname@. It might not work in the simulator on every browser.
-#### ~
+### ~hint
+
+#### Simulator
+
+``||music:stop all sounds||`` works on the @boardname@. It might not work in the simulator on every browser.
+
+### ~
 
 ## Example #example
 

--- a/libs/mixer/docs/reference/music/tempo.md
+++ b/libs/mixer/docs/reference/music/tempo.md
@@ -1,0 +1,20 @@
+# tempo
+
+Find the tempo (speed) of the music that is playing right now.
+
+```sig
+music.tempo()
+```
+
+## #example
+
+## Returns
+
+* a [number](/types/number) that means the count of beats per minute (number of
+  beats in a minute of the music that the @boardname@ is playing right now).
+
+## See also #seealso
+
+[play tone](/reference/music/play-tone), [ring tone](/reference/music/ring-tone),
+[rest](/reference/music/rest), [set tempo](/reference/music/set-tempo),
+[change tempo by](/reference/music/change-tempo-by)


### PR DESCRIPTION
Bring over the older `music` reference pages to match corresponding APIs in `mixer`.

Fixes https://github.com/microsoft/pxt-arcade/issues/1460