### PR TITLE
fix category recoloring issue by fixing dependency from game to "device" pkg instead

### DIFF
--- a/libs/animation/pxt.json
+++ b/libs/animation/pxt.json
@@ -12,6 +12,6 @@
     ],
     "public": true,
     "dependencies": {
-        "game": "file:../game"
+        "device": "file:../device"
     }
 }

--- a/libs/controller---none/pxt.json
+++ b/libs/controller---none/pxt.json
@@ -3,6 +3,6 @@
     "additionalFilePath": "../controller",
     "dependencies": {
         "core": "file:../core",
-        "game": "file:../game"
+        "device": "file:../device"
     }
 }

--- a/libs/controller/pxt.json
+++ b/libs/controller/pxt.json
@@ -19,7 +19,7 @@
         "accelerometer": "file:../accelerometer",
         "lightsensor": "file:../lightsensor",
         "thermometer": "file:../thermometer",
-        "game": "file:../game",
+        "device": "file:../device",
         "light": "file:../light",
         "rotary-encoder": "file:../rotary-encoder"
     }

--- a/libs/jacdac-game/pxt.json
+++ b/libs/jacdac-game/pxt.json
@@ -5,11 +5,10 @@
         "debugger.ts",
         "controllerservice.ts"
     ],
-    "testFiles": [
-    ],
+    "testFiles": [],
     "public": true,
     "dependencies": {
-        "game": "file:../game",
+        "device": "file:../device",
         "jacdac": "file:../jacdac"
     }
 }

--- a/libs/net-game/pxt.json
+++ b/libs/net-game/pxt.json
@@ -8,6 +8,6 @@
     "dependencies": {
         "core": "file:../core",
         "settings": "file:../settings",
-        "game": "file:../game"
+        "device": "file:../device"
     }
 }

--- a/libs/palette/pxt.json
+++ b/libs/palette/pxt.json
@@ -12,6 +12,6 @@
     "weight": 10,
     "dependencies": {
         "color": "file:../color",
-        "game": "file:../game"
+        "device": "file:../device"
     }
 }

--- a/libs/storyboard/pxt.json
+++ b/libs/storyboard/pxt.json
@@ -12,7 +12,7 @@
     "public": true,
     "weight": 10,
     "dependencies": {
-        "game": "file:../game",
+        "device": "file:../device",
         "color": "file:../color",
         "palette": "file:../storyboard"
     }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/pxt-arcade/issues/1489
along with this PR: https://github.com/microsoft/pxt-arcade/pull/1528