### PR TITLE
Disable screen brightness setting on Kitronik

### DIFF
--- a/libs/core---samd/platform.cpp
+++ b/libs/core---samd/platform.cpp
@@ -81,9 +81,7 @@ LowLevelTimer *allocateTimer() {
     // if BL is on a known pin, don't use its PWM TC
     // this is a hack for legacy boards that don't have CFG_TIMERS_TO_USE
     auto blPin = PIN(DISPLAY_BL);
-    if (blPin == PA06)
-        blTC = 0x11;
-    else if (blPin == PA01)
+    if (blPin == PA01)
         blTC = 0x12;
 
     for (int shift = 24; shift >= 0; shift -= 8) {

--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -317,13 +317,20 @@ namespace scene.systemMenu {
         }
     }
 
+    //% shim=pxt::setScreenBrightnessSupported
+    function setScreenBrightnessSupported() {
+        return 0 // default to no, in simulator
+    }
+
     export function buildOptionList(): MenuOption[] {
         let options: MenuOption[] = [];
 
         options.push(new MenuOption(VOLUME_DOWN_ICON, () => `VOLUME DOWN (${music.volume()})`, volumeDown));
         options.push(new MenuOption(VOLUME_UP_ICON, () => `VOLUME UP (${music.volume()})`, volumeUp));
-        options.push(new MenuOption(BRIGHTNESS_DOWN_ICON, () => `BRIGHTNESS DOWN (${screen.brightness()})`, brightnessDown));
-        options.push(new MenuOption(BRIGHTNESS_UP_ICON, () => `BRIGHTNESS UP (${screen.brightness()})`, brightnessUp));
+        if (setScreenBrightnessSupported()) {
+            options.push(new MenuOption(BRIGHTNESS_DOWN_ICON, () => `BRIGHTNESS DOWN (${screen.brightness()})`, brightnessDown));
+            options.push(new MenuOption(BRIGHTNESS_UP_ICON, () => `BRIGHTNESS UP (${screen.brightness()})`, brightnessUp));
+        }
         options.push(new MenuOption(STATS_ICON, () => game.stats ? "HIDE STATS" : "SHOW STATS", toggleStats));
         options.push(new MenuOption(CONSOLE_ICON, () => game.consoleOverlay.isVisible() ? "HIDE CONSOLE" : "SHOW CONSOLE", toggleConsole));
         options.push(new MenuOption(SLEEP_ICON, () => "SLEEP", sleep));

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -115,6 +115,18 @@ class WDisplay {
 SINGLETON_IF_PIN(WDisplay, DISPLAY_MOSI);
 
 //%
+int setScreenBrightnessSupported() {
+    auto bl = LOOKUP_PIN(DISPLAY_BL);
+    if (!bl)
+        return 0;
+#ifdef SAMD51
+    if (bl->name == PA06)
+        return 0;
+#endif
+    return 1;
+}
+
+//%
 void setScreenBrightness(int level) {
     auto bl = LOOKUP_PIN(DISPLAY_BL);
     if (!bl)
@@ -130,8 +142,10 @@ void setScreenBrightness(int level) {
     else if (level == 100)
         bl->setDigitalValue(1);
     else {
-        bl->setAnalogPeriodUs(1000);
-        bl->setAnalogValue(level * level * 1023 / 10000);
+        if (setScreenBrightnessSupported()) {
+            bl->setAnalogPeriodUs(1000);
+            bl->setAnalogValue(level * level * 1023 / 10000);
+        }
     }
 }
 


### PR DESCRIPTION
This makes the API no-op and removes buttons from the menu.

This also removes buttons from the menu in simulator. Any objections to that?