### PR TITLE
Adding decompiler annotation to tile arguments

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -468,6 +468,7 @@ namespace tiles {
      */
     //% blockId=mapsettileat block="set %loc=mapgettile to %tile"
     //% tile.shadow=tileset_tile_picker
+    //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tiles" blockGap=8
     //% help=tiles/set-tile-at
     export function setTileAt(loc: Location, tile: Image): void {
@@ -525,6 +526,7 @@ namespace tiles {
      */
     //% blockId=mapgettilestype block="array of all %tile locations"
     //% tile.shadow=tileset_tile_picker
+    //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tiles" blockGap=8 blockSetVariable="location list"
     //% help=tiles/get-tiles-by-type
     export function getTilesByType(tile: Image): Location[] {
@@ -555,6 +557,7 @@ namespace tiles {
      */
     //% blockId=mapplaceonrandomtile block="place %sprite=variables_get(mySprite) on top of random %tile"
     //% tile.shadow=tileset_tile_picker
+    //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tiles" blockGap=8
     //% help=tiles/place-on-random-tile
     export function placeOnRandomTile(sprite: Sprite, tile: Image): void {

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -56,6 +56,7 @@ namespace images {
     //% blockId=tileset_tile_picker block="%tile"
     //% shim=TD_ID
     //% tile.fieldEditor="tileset"
+    //% tile.fieldOptions.decompileIndirectFixedInstances="true"
     //% weight=10 blockNamespace="scene" group="Tiles"
     //% blockHidden=1 duplicateShadowOnDrag
     export function _tile(tile: Image) {


### PR DESCRIPTION
The annotation we always forget to add to all image arguments. This is part of the fix for https://github.com/microsoft/pxt-arcade/issues/1575