### PR TITLE
restrict tiles to only show up to the current tile size

### DIFF
--- a/libs/color-coded-tilemap/tilemap.ts
+++ b/libs/color-coded-tilemap/tilemap.ts
@@ -16,7 +16,7 @@ namespace scene {
     export function setTileMap(map: Image, scale = TileScale.Sixteen) {
         const scene = game.currentScene();
         if (!scene.tileMap) {
-            scene.tileMap = new tiles.TileMap();
+            scene.tileMap = new tiles.TileMap(scale);
             scene.tileMap._legacyInit();
         }
         scene.tileMap.setMap(map);

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -109,7 +109,7 @@ namespace tiles {
         protected tileset: Image[];
         protected cachedTileView: Image[];
 
-        scale: TileScale;
+        protected _scale: TileScale;
         protected _width: number;
         protected _height: number;
 
@@ -138,6 +138,15 @@ namespace tiles {
             return this._height;
         }
 
+        get scale(): TileScale {
+            return this._scale;
+        }
+
+        set scale(s: TileScale) {
+            this._scale = s;
+            this.cachedTileView = [];
+        }
+
         getTile(col: number, row: number) {
             if (this.isOutsideMap(col, row)) return 0;
 
@@ -157,9 +166,9 @@ namespace tiles {
         getTileImage(index: number) {
             const size = 1 << this.scale;
             let cachedImage = this.cachedTileView[index];
-            if (!cachedImage || cachedImage.width != size || cachedImage.height != size) {
+            if (!cachedImage || cachedImage.width > size || cachedImage.height > size) {
                 const originalImage = this.tileset[index];
-                if (originalImage.width == size && originalImage.height == size) {
+                if (originalImage.width <= size && originalImage.height <= size) {
                     cachedImage = originalImage;
                 } else {
                     cachedImage = image.create(size, size);

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -236,15 +236,15 @@ namespace tiles {
             );
         }
 
+        get scale() {
+            return this._scale;
+        }
+
         set scale(s: TileScale) {
             this._scale = s;
             if (this._map) {
                 this._map.scale = s;
             }
-        }
-
-        get scale() {
-            return this._scale;
         }
 
         // ## LEGACY: DO NOT USE ##

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -120,7 +120,6 @@ namespace tiles {
             this.data = data;
             this.layers = layers;
             this.tileset = tileset;
-            this.cachedTileView = [];
             this.scale = scale;
 
             this._width = data.getNumber(NumberFormat.UInt16LE, 0);
@@ -166,7 +165,7 @@ namespace tiles {
         getTileImage(index: number) {
             const size = 1 << this.scale;
             let cachedImage = this.cachedTileView[index];
-            if (!cachedImage || cachedImage.width > size || cachedImage.height > size) {
+            if (!cachedImage) {
                 const originalImage = this.tileset[index];
                 if (originalImage.width <= size && originalImage.height <= size) {
                     cachedImage = originalImage;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/1578 - bring back behavior of restricting tile size to the scale of the tilemap.

(slightly smarter than the old version; it only creates new images when the tile is smaller than the image, not larger)

https://makecode.com/_0bbE9xfkqfCJ

![2019-12-17 11 10 47](https://user-images.githubusercontent.com/5615930/71026418-12d44e00-20be-11ea-8ab8-cec5edbf1006.gif)
