### PR TITLE
Resurrect old tilemap

### DIFF
--- a/libs/color-coded-tilemap/tilemap.ts
+++ b/libs/color-coded-tilemap/tilemap.ts
@@ -15,11 +15,10 @@ namespace scene {
     //% help=scene/set-tile-map
     export function setTileMap(map: Image, scale = TileScale.Sixteen) {
         const scene = game.currentScene();
-        if (!scene.tileMap) {
-            scene.tileMap = new tiles.TileMap(scale);
-            scene.tileMap._legacyInit();
+        if (!scene.tileMap || !(scene.tileMap as tiles.legacy.LegacyTilemap).isLegacy) {
+            scene.tileMap = new tiles.legacy.LegacyTilemap();
         }
-        scene.tileMap.setMap(map);
+        (scene.tileMap as tiles.legacy.LegacyTilemap).setMap(map);
         scene.tileMap.scale = scale;
     }
 
@@ -33,11 +32,10 @@ namespace scene {
     //% help=scene/set-tile
     export function setTile(index: number, img: Image, wall?: boolean) {
         const scene = game.currentScene();
-        if (!scene.tileMap) {
-            scene.tileMap = new tiles.TileMap();
-            scene.tileMap._legacyInit();
+        if (!scene.tileMap || !(scene.tileMap as tiles.legacy.LegacyTilemap).isLegacy) {
+            scene.tileMap = new tiles.legacy.LegacyTilemap();
         }
-        scene.tileMap.setTile(index, img, !!wall);
+        (scene.tileMap as tiles.legacy.LegacyTilemap).setTile(index, img, !!wall);
     }
 
     /**
@@ -50,11 +48,10 @@ namespace scene {
     //% help=scene/get-tile
     export function getTile(col: number, row: number): tiles.Tile {
         const scene = game.currentScene();
-        if (!scene.tileMap) {
-            scene.tileMap = new tiles.TileMap();
-            scene.tileMap._legacyInit();
+        if (!scene.tileMap || !(scene.tileMap as tiles.legacy.LegacyTilemap).isLegacy) {
+            scene.tileMap = new tiles.legacy.LegacyTilemap();
         }
-        return scene.tileMap._getTile(col, row);
+        return (scene.tileMap as tiles.legacy.LegacyTilemap).getTileLegacy(col, row);
     }
 
     /**
@@ -66,11 +63,10 @@ namespace scene {
     //% help=scene/get-tiles-by-type
     export function getTilesByType(index: number): tiles.Tile[] {
         const scene = game.currentScene();
-        if (!scene.tileMap) {
-            scene.tileMap = new tiles.TileMap();
-            scene.tileMap._legacyInit();
+        if (!scene.tileMap || !(scene.tileMap as tiles.legacy.LegacyTilemap).isLegacy) {
+            scene.tileMap = new tiles.legacy.LegacyTilemap();
         }
-        return scene.tileMap._getTilesByType(index);
+        return (scene.tileMap as tiles.legacy.LegacyTilemap).getTilesByTypeLegacy(index);
     }
 
     /**
@@ -99,13 +95,13 @@ namespace scene {
     //% help=scene/set-tile-at
     export function setTileAt(tile: tiles.Tile, index: number) {
         const scene = game.currentScene();
-        if (!scene.tileMap) {
-            scene.tileMap = new tiles.TileMap();
-            scene.tileMap._legacyInit();
+        if (!scene.tileMap || !(scene.tileMap as tiles.legacy.LegacyTilemap).isLegacy) {
+            scene.tileMap = new tiles.legacy.LegacyTilemap();
         }
-        const scale = scene.tileMap.scale;
-        scene.tileMap.setTileAt(tile.x >> scale, tile.y >> scale, index);
-        scene.tileMap.setWallAt(tile.x >> scale, tile.y >> scale, scene.tileMap.data._isWall(index));
+
+        const tm: tiles.legacy.LegacyTilemap = scene.tileMap as tiles.legacy.LegacyTilemap;
+        const scale = tm.scale;
+        tm.setTileAt(tile.x >> scale, tile.y >> scale, index);
     }
 
     /**
@@ -156,5 +152,258 @@ namespace scene {
     export function tileHitFrom(sprite: Sprite, direction: CollisionDirection): number {
         if (!sprite) return 0;
         return sprite.tileHitFrom(direction);
+    }
+}
+
+namespace tiles.legacy {
+    class TileSet {
+        obstacle: boolean;
+        private map: TileMap;
+        private originalImage: Image;
+        private cachedImage: Image;
+
+        constructor(image: Image, collisions: boolean, map: tiles.TileMap) {
+            this.originalImage = image;
+            this.obstacle = collisions;
+            this.map = map;
+        }
+
+        get image(): Image {
+            const size = 1 << this.map.scale;
+            if (!this.cachedImage || this.cachedImage.width != size || this.cachedImage.height != size) {
+                if (this.originalImage.width == size && this.originalImage.height == size) {
+                    this.cachedImage = this.originalImage;
+                } else {
+                    this.cachedImage = image.create(size, size);
+                    this.cachedImage.drawImage(this.originalImage, 0, 0);
+                }
+            }
+            return this.cachedImage;
+        }
+    }
+
+    export class LegacyTilemap extends tiles.TileMap {
+        private _mapImage: Image;
+        private _tileSets: TileSet[];
+
+        public isLegacy: boolean;
+
+        constructor(scale: TileScale = TileScale.Sixteen) {
+            super(scale);
+            this._tileSets = [];
+            this.isLegacy = true;
+        }
+
+        get data(): TileMapData {
+            return null;
+        }
+
+        get image(): Image {
+            return this._mapImage;
+        }
+
+        offsetX(value: number) {
+            return Math.clamp(0, Math.max(this.areaWidth() - screen.width, 0), value);
+        }
+
+        offsetY(value: number) {
+            return Math.clamp(0, Math.max(this.areaHeight() - screen.height, 0), value);
+        }
+
+        areaWidth() {
+            return this._mapImage ? (this._mapImage.width << this.scale) : 0;
+        }
+
+        areaHeight() {
+            return this._mapImage ? (this._mapImage.height << this.scale) : 0;
+        }
+
+        get layer(): number {
+            return this._layer;
+        }
+
+        set layer(value: number) {
+            if (this._layer != value) {
+                this._layer = value;
+            }
+        }
+
+        get enabled(): boolean {
+            return !!this._mapImage;
+        }
+
+        setTile(index: number, img: Image, collisions?: boolean) {
+            if (this.isInvalidIndex(index)) return;
+            this._tileSets[index] = new TileSet(img, collisions, this);
+        }
+
+        setMap(map: Image) {
+            this._mapImage = map;
+        }
+
+        public getTileLegacy(col: number, row: number): Tile {
+            return new Tile(col, row, this);
+        }
+
+        public getTile(col: number, row: number): Location {
+            return new Location(col, row, this);
+        }
+
+        public setTileAt(col: number, row: number, index: number): void {
+            if (!this.isOutsideMap(col, row) && !this.isInvalidIndex(index))
+                this._mapImage.setPixel(col, row, index);
+        }
+
+        public getTilesByType(index: number): Location[] {
+            if (this.isInvalidIndex(index) || !this.enabled) return [];
+
+            let output: Location[] = [];
+            for (let col = 0; col < this._mapImage.width; ++col) {
+                for (let row = 0; row < this._mapImage.height; ++row) {
+                    let currTile = this._mapImage.getPixel(col, row);
+                    if (currTile === index) {
+                        output.push(new Location(col, row, this));
+                    }
+                }
+            }
+            return output;
+        }
+
+        public getTilesByTypeLegacy(index: number): Tile[] {
+            if (this.isInvalidIndex(index) || !this.enabled) return [];
+
+            let output: Tile[] = [];
+            for (let col = 0; col < this._mapImage.width; ++col) {
+                for (let row = 0; row < this._mapImage.height; ++row) {
+                    let currTile = this._mapImage.getPixel(col, row);
+                    if (currTile === index) {
+                        output.push(new Tile(col, row, this));
+                    }
+                }
+            }
+            return output;
+        }
+
+        private generateTile(index: number): TileSet {
+            const size = 1 << this.scale
+
+            const i = image.create(size, size);
+            i.fill(index);
+            return this._tileSets[index] = new TileSet(i, false, this);
+        }
+
+        private isOutsideMap(col: number, row: number): boolean {
+            return !this.enabled || col < 0 || col >= this._mapImage.width
+                || row < 0 || row >= this._mapImage.height;
+        }
+
+        protected isInvalidIndex(index: number): boolean {
+            return index < 0 || index > 0xf;
+        }
+
+        protected draw(target: Image, camera: scene.Camera) {
+            if (!this.enabled) return;
+
+            // render tile map
+            const bitmask = (0x1 << this.scale) - 1;
+            const offsetX = camera.drawOffsetX & bitmask;
+            const offsetY = camera.drawOffsetY & bitmask;
+
+            const x0 = Math.max(0, camera.drawOffsetX >> this.scale);
+            const xn = Math.min(this._mapImage.width, ((camera.drawOffsetX + target.width) >> this.scale) + 1);
+            const y0 = Math.max(0, camera.drawOffsetY >> this.scale);
+            const yn = Math.min(this._mapImage.height, ((camera.drawOffsetY + target.height) >> this.scale) + 1);
+
+            for (let x = x0; x <= xn; ++x) {
+                for (let y = y0; y <= yn; ++y) {
+                    const index = this._mapImage.getPixel(x, y);
+                    const tile = this._tileSets[index] || this.generateTile(index);
+                    if (tile) {
+                        target.drawTransparentImage(
+                            tile.image,
+                            ((x - x0) << this.scale) - offsetX,
+                            ((y - y0) << this.scale) - offsetY
+                        );
+                    }
+                }
+            }
+
+            if (game.debug) {
+                // render debug grid overlay
+                for (let x = x0; x <= xn; ++x) {
+                    const xLine = ((x - x0) << this.scale) - offsetX;
+                    if (xLine >= 0 && xLine <= screen.width) {
+                        target.drawLine(
+                            xLine,
+                            0,
+                            xLine,
+                            target.height,
+                            1
+                        );
+                    }
+                }
+
+                for (let y = y0; y <= yn; ++y) {
+                    const yLine = ((y - y0) << this.scale) - offsetY;
+                    if (yLine >= 0 && yLine <= screen.height) {
+                        target.drawLine(
+                            0,
+                            yLine,
+                            target.width,
+                            yLine,
+                            1
+                        );
+                    }
+                }
+            }
+        }
+
+        public isObstacle(col: number, row: number) {
+            if (!this.enabled) return false;
+            if (this.isOutsideMap(col, row)) return true;
+
+            let t = this._tileSets[this._mapImage.getPixel(col, row)];
+            return t && t.obstacle;
+        }
+
+        public getObstacle(col: number, row: number) {
+            const index = this.isOutsideMap(col, row) ? 0 : this._mapImage.getPixel(col, row);
+            const tile = this._tileSets[index] || this.generateTile(index);
+            return new sprites.StaticObstacle(
+                tile.image,
+                row << this.scale,
+                col << this.scale,
+                this.layer,
+                index
+            );
+        }
+
+        public isOnWall(s: Sprite) {
+            const hbox = s._hitbox
+
+            const left = Fx.toIntShifted(hbox.left, this.scale);
+            const right = Fx.toIntShifted(hbox.right, this.scale);
+            const top = Fx.toIntShifted(hbox.top, this.scale);
+            const bottom = Fx.toIntShifted(hbox.bottom, this.scale);
+
+            for (let col = left; col <= right; ++col) {
+                for (let row = top; row <= bottom; ++row) {
+                    if (this.isObstacle(col, row)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public getTileIndex(col: number, row: number) {
+            return this._mapImage.getPixel(col, row);
+        }
+
+        public getTileImage(index: number) {
+            if (!this._tileSets[index]) this.generateTile(index);
+            return this._tileSets[index].image;
+        }
     }
 }

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -34,7 +34,7 @@ namespace tiles {
         }
 
         get tileSet(): number {
-            return this.tileMap.data.getTile(this._col, this._row);
+            return this.tileMap.getTileIndex(this._col, this._row);
         }
 
         /**
@@ -78,7 +78,7 @@ namespace tiles {
         }
 
         get tileSet(): number {
-            return this.tileMap.data.getTile(this._col, this._row);
+            return this.tileMap.getTileIndex(this._col, this._row);
         }
 
         /**
@@ -113,9 +113,6 @@ namespace tiles {
         protected _width: number;
         protected _height: number;
 
-        // ## LEGACY: DO NOT USE ##
-        protected _walls: boolean[];
-
         constructor(data: Buffer, layers: Image, tileset: Image[], scale: TileScale) {
             this.data = data;
             this.layers = layers;
@@ -124,9 +121,6 @@ namespace tiles {
 
             this._width = data.getNumber(NumberFormat.UInt16LE, 0);
             this._height = data.getNumber(NumberFormat.UInt16LE, 2);
-
-            // ## LEGACY: DO NOT USE ##
-            this._walls = tileset.map(t => false);
         }
 
         get width(): number {
@@ -189,43 +183,6 @@ namespace tiles {
         isOutsideMap(col: number, row: number) {
             return col < 0 || col >= this.width || row < 0 || row >= this.height;
         }
-
-        /*
-         *  ##########################################
-         *  ##         LEGACY: DO NOT USE           ##
-         *  ##    Functions below are to support    ##
-         *  ##        old tilemap blocks only       ##
-         *  ##########################################
-         */
-        _setTileImage(index: number, img: Image, collisions: boolean) {
-            this.tileset[index] = img;
-            this.cachedTileView[index] = undefined;
-            this._walls[index] = collisions;
-            for (let col = 0; col < this.width; ++col) {
-                for (let row = 0; row < this.height; ++row) {
-                    let currTile = this.getTile(col, row);
-                    if (currTile === index) {
-                        this.layers.setPixel(col, row, collisions ? TM_WALL : 0);
-                    }
-                }
-            }
-        }
-
-        _setWall(index: number, collisions: boolean) {
-            this._walls[index] = collisions;
-        }
-
-        _isWall(index: number) {
-            return this._walls[index];
-        }
-
-        _setMap(data: Buffer, layers: Image) {
-            this.data = data;
-            this.layers = layers;
-
-            this._width = data.getNumber(NumberFormat.UInt16LE, 0);
-            this._height = data.getNumber(NumberFormat.UInt16LE, 2);
-        }
     }
 
     export class TileMap {
@@ -255,19 +212,7 @@ namespace tiles {
             }
         }
 
-        // ## LEGACY: DO NOT USE ##
-        _legacyInit() {
-            let buffer = control.createBuffer(TM_DATA_PREFIX_LENGTH);
-            let layer = image.create(2, 2);
-            let tiles = [];
-            for (let i = 0; i < 16; ++i) {
-                tiles.push(mkColorTile(i, this.scale))
-            }
-
-            this._map = new TileMapData(buffer, layer, tiles, this.scale);
-        }
-
-        get data(): TileMapData {
+        protected get data(): TileMapData {
             return this._map;
         }
 
@@ -301,35 +246,16 @@ namespace tiles {
             return !!this._map;
         }
 
-        // ## LEGACY: DO NOT USE ##
-        setTile(index: number, img: Image, collisions?: boolean) {
-            this._map._setTileImage(index, img, collisions);
-        }
-
-        // ## LEGACY: DO NOT USE ##
-        setMap(map: Image) {
-            let buffer = control.createBuffer(TM_DATA_PREFIX_LENGTH + (map.width * map.height));
-            let layer = image.create(map.width, map.height);
-
-            buffer.setNumber(NumberFormat.UInt16LE, 0, map.width);
-            buffer.setNumber(NumberFormat.UInt16LE, TM_DATA_PREFIX_LENGTH / 2, map.height);
-            for (let i = 0; i < map.width; i++) {
-                for (let j = 0; j < map.height; j++) {
-                    let p = map.getPixel(i, j);
-                    if (this._map._isWall(p)) layer.setPixel(i, j, TM_WALL);
-                    buffer.setUint8(TM_DATA_PREFIX_LENGTH + (i | 0) + (j | 0) * map.width, p);
-                }
-            }
-
-            this._map._setMap(buffer, layer);
-        }
-
         setData(map: TileMapData) {
             this._map = map;
         }
 
         public getTile(col: number, row: number): Location {
             return new Location(col, row, this);
+        }
+
+        public getTileIndex(col: number, row: number) {
+            return this.data.getTile(col, row);
         }
 
         public setTileAt(col: number, row: number, index: number): void {
@@ -362,16 +288,6 @@ namespace tiles {
                 }
             }
             return output;
-        }
-
-        // ## LEGACY: DO NOT USE ##
-        public _getTile(col: number, row: number): Tile {
-            return new Tile(col, row, this);
-        }
-
-        // ## LEGACY: DO NOT USE ##
-        public _getTilesByType(index: number): Tile[] {
-            return this.getTilesByType(index).map(loc => loc._toTile());
         }
 
         protected isInvalidIndex(index: number): boolean {
@@ -472,6 +388,10 @@ namespace tiles {
 
             return false;
         }
+
+        public getTileImage(index: number) {
+            return this.data.getTileImage(index);
+        }
     }
 
     function mkColorTile(index: number, scale: TileScale): Image {
@@ -553,7 +473,7 @@ namespace tiles {
     export function getTileImage(loc: Location): Image {
         const scene = game.currentScene();
         if (!loc || !scene.tileMap) return img``;
-        return scene.tileMap.data.getTileImage(loc.tileSet);
+        return scene.tileMap.getTileImage(loc.tileSet);
     }
 
     /**
@@ -563,7 +483,7 @@ namespace tiles {
     export function getTileAt(col: number, row: number): Image {
         const scene = game.currentScene();
         if (col == undefined || row == undefined || !scene.tileMap) return img``;
-        return scene.tileMap.data.getTileImage(tiles.getTileLocation(col, row).tileSet);
+        return scene.tileMap.getTileImage(tiles.getTileLocation(col, row).tileSet);
     }
 
     /**


### PR DESCRIPTION
We can take this if there is a need, or drop it. I did this to try and fix https://github.com/microsoft/pxt-arcade/issues/1622, but it seems like that issue is unrelated.

Anyways, this at least gets rid of the legacy code in the new tilemap implementation.