### PR TITLE
Make buffer writable for tilemap data

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -155,6 +155,10 @@ namespace tiles {
         setTile(col: number, row: number, tile: number) {
             if (this.isOutsideMap(col, row)) return;
 
+            if (this.data.isReadOnly()) {
+                this.data = this.data.slice();
+            }
+
             this.data.setUint8(TM_DATA_PREFIX_LENGTH + (col | 0) + (row | 0) * this.width, tile);
         }
 
@@ -483,9 +487,7 @@ namespace tiles {
     }
 
     export function createTilemap(data: Buffer, layer: Image, tiles: Image[], scale: TileScale): TileMapData {
-        const b = control.createBuffer(data.length);
-        b.write(0, data);
-        return new TileMapData(b, layer, tiles, scale)
+        return new TileMapData(data, layer, tiles, scale)
     }
 
     //% blockId=tilemap_editor block="set tilemap to $tilemap"

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -483,7 +483,9 @@ namespace tiles {
     }
 
     export function createTilemap(data: Buffer, layer: Image, tiles: Image[], scale: TileScale): TileMapData {
-        return new TileMapData(data, layer, tiles, scale)
+        const b = control.createBuffer(data.length);
+        b.write(0, data);
+        return new TileMapData(b, layer, tiles, scale)
     }
 
     //% blockId=tilemap_editor block="set tilemap to $tilemap"


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1625

Obviously this has memory tradeoffs. I was hoping to only make it writable if the user calls the set tile API, but I can't see a way to check it in the TS. @mmoskal is this okay do you think? Tilemaps are one byte per pixel.