### PR TITLE
Match loudness range for sound threshold

### DIFF
--- a/libs/microphone/docs/reference/input/on-loud-sound.md
+++ b/libs/microphone/docs/reference/input/on-loud-sound.md
@@ -3,7 +3,7 @@
 Run some code when the microphone hears a loud sound.
 
 ```sig
-input.onLoudSound(() => {});
+input.onLoudSound(function(){});
 ```
 
 ## Parameters
@@ -17,11 +17,11 @@ Flash the pixels when a loud sound is detected.
 ```blocks
 let pixels = light.createStrip()
 
-input.onLoudSound(() => {
-	pixels.setAll(0xff0000);
-	pause(100);
-	pixels.setAll(0x000000);
-});
+input.onLoudSound(function() {
+	pixels.setAll(0xff0000)
+	pause(100)
+	pixels.setAll(0x000000)
+})
 ```
 
 # See also #seealso

--- a/libs/microphone/docs/reference/input/set-loud-sound-threshold.md
+++ b/libs/microphone/docs/reference/input/set-loud-sound-threshold.md
@@ -5,10 +5,11 @@ Tell how loud it should be for your board to detect a loud sound.
 ```sig
 input.setLoudSoundThreshold(0)
 ```
+
 When the microphone hears a sound, it gives you a number for how loud the sound was at that moment.
-This number is the sound level and has a value from `0` (no sound) to `1023` (very loud). You can use
+This number is the sound level and has a value from `0` (no sound) to `255` (very loud). You can use
 a sound level number as a _threshold_ (just the right amount of sound) to make the
-[``||on loud sound||``](/reference/input/on-loud-sound) event happen.
+[on loud sound](/reference/input/on-loud-sound) event happen.
 
 ## Parameters
 
@@ -19,14 +20,14 @@ a sound level number as a _threshold_ (just the right amount of sound) to make t
 Flash the pixels to `pink` on the pixel strip when you clap or make another loud sound nearby.
 
 ```blocks
-let pixels = light.createStrip();
-input.setLoudSoundThreshold(768);
+let pixels = light.createStrip()
+input.setLoudSoundThreshold(768)
 
-input.onLoudSound(() => {
-	pixels.setAll(0xff007f);
-    pause(200);
-    pixels.clear();
-});
+input.onLoudSound(function() {
+	pixels.setAll(0xff007f)
+    pause(200)
+    pixels.clear()
+})
 ```
 
 ## See also #seealso

--- a/libs/microphone/docs/reference/input/sound-level.md
+++ b/libs/microphone/docs/reference/input/sound-level.md
@@ -1,13 +1,14 @@
 # sound Level
 
-Find out what the the level of sounds are.
+Find out what the the level of sound heard by microphone is.
 
 ```sig
 input.soundLevel()
 ```
+
 ## Returns
 
-* a ``number`` between `0` (quiet) and `255` (loud) which tells how loud the sounds are that the microphone hears
+* a ``number`` between `0` (quiet) and `255` (loud) which tells how loud the sounds are that the microphone hears.
 
 ## Example #example
 
@@ -15,18 +16,18 @@ Use the pixels to make a sound meter. If loud sounds are detected, more pixels l
 
 ```blocks
 let lastLevel = 0;
-let pixels = light.createStrip();
+let pixels = light.createStrip()
 
-forever(() => {
-    let level = input.soundLevel();
+forever(function () {
+    let level = input.soundLevel()
     if (lastLevel != level) {
-        pixels.clear();
+        pixels.clear()
         for (let i = 0; i < pixels.length() / 255 * level; i++) {
-            pixels.setPixelColor(i, 0x00ff00);
+            pixels.setPixelColor(i, 0x00ff00)
         }
-        lastLevel = level;
+        lastLevel = level
     }
-});
+})
 ```
 ## See also #seealso
 

--- a/libs/microphone/microphone.cpp
+++ b/libs/microphone/microphone.cpp
@@ -56,7 +56,7 @@ int soundLevel() {
 //% help=input/set-loud-sound-threshold
 //% blockId=input_set_loud_sound_threshold block="set loud sound threshold %value"
 //% parts="microphone"
-//% value.min=1 value.max=100
+//% value.min=1 value.max=255
 //% group="More" weight=14 blockGap=8
 void setLoudSoundThreshold(int value) {
     value = max(0, min(0xff, value));


### PR DESCRIPTION
Looks like loud threshold max should be `255` instead of `100`. Otherwise, maybe use another scale factor to make a range of `0` - `100`.

Closes https://github.com/microsoft/pxt-adafruit/issues/1149