### PR TITLE
[stable6.17] don't crash on .fromBuffer(hex, ...)

### DIFF
--- a/libs/color/colorbuffer.ts
+++ b/libs/color/colorbuffer.ts
@@ -24,7 +24,7 @@ namespace color {
 
         static fromBuffer(buffer: Buffer, layout: ColorBufferLayout) {
             const b = new ColorBuffer(0, layout);
-            b.buf = buffer;
+            b.buf = buffer.slice();
             return b;
         }
 
@@ -81,8 +81,8 @@ namespace color {
 
         /**
          * Writes the content of the src color buffer starting at the start dstOffset in the current buffer
-         * @param dstOffset 
-         * @param src 
+         * @param dstOffset
+         * @param src
          */
         write(dstOffset: number, src: ColorBuffer): void {
             if (this.layout == src.layout) {


### PR DESCRIPTION
for nfl game, integrating #1054 