### PR TITLE
Particle effects and say sprites should respect relativeToCamera

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -22,11 +22,12 @@ namespace effects {
          * Attaches a new particle animation to the sprite or anchor for a short period of time
          * @param anchor
          * @param duration
-         * @param particlesPerSecond 
+         * @param particlesPerSecond
          */
-        start(anchor: particles.ParticleAnchor, duration?: number, particlesPerSecond?: number): void {
+        start(anchor: particles.ParticleAnchor, duration?: number, particlesPerSecond?: number, relativeToCamera?: boolean): void {
             if (!this.sourceFactory) return;
             const src = this.sourceFactory(anchor, particlesPerSecond ? particlesPerSecond : this.defaultRate);
+            src.setRelativeToCamera(!!relativeToCamera);
             if (duration)
                 src.lifespan = duration > 0 ? duration : this.defaultLifespan;
         }
@@ -40,7 +41,7 @@ namespace effects {
          */
         destroy(anchor: Sprite, duration?: number, particlesPerSecond?: number) {
             anchor.setFlag(SpriteFlag.Ghost, true);
-            this.start(anchor, particlesPerSecond);
+            this.start(anchor, particlesPerSecond, null, !!(anchor.flags & sprites.Flag.RelativeToCamera));
             anchor.lifespan = duration ? duration : this.defaultLifespan >> 2;
             effects.dissolve.applyTo(anchor);
         }
@@ -86,7 +87,7 @@ namespace effects {
 
         /**
          * Creates a new effect that occurs over the entire screen
-         * @param particlesPerSecond 
+         * @param particlesPerSecond
          * @param duration
          */
         //% blockId=particlesStartScreenAnimation block="start screen %effect effect || for %duration ms"
@@ -113,7 +114,7 @@ namespace effects {
 
         /**
          * If this effect is currently occurring as a full screen effect, stop producing particles and end the effect
-         * @param particlesPerSecond 
+         * @param particlesPerSecond
          */
         //% blockId=particlesEndScreenAnimation block="end screen %effect effect"
         //% blockNamespace=scene
@@ -163,19 +164,19 @@ namespace effects {
     export const fountain = new ParticleEffect(20, 3000, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
         class FountainFactory extends particles.SprayFactory {
             galois: Math.FastRandom;
-    
+
             constructor() {
                 super(40, 180, 90);
                 this.galois = new Math.FastRandom(1234);
             }
-    
+
             createParticle(anchor: particles.ParticleAnchor) {
                 const p = super.createParticle(anchor);
                 p.color = this.galois.randomBool() ? 8 : 9;
                 p.lifespan = 1500;
                 return p;
             }
-    
+
             drawParticle(p: particles.Particle, x: Fx8, y: Fx8) {
                 screen.setPixel(Fx.toInt(x), Fx.toInt(y), p.color);
             }
@@ -217,11 +218,11 @@ namespace effects {
     //% fixedInstance whenUsed block="smiles"
     export const smiles = new ScreenEffect(5, 25, 1500, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
         const factory = new particles.ShapeFactory(anchor.width ? anchor.width : 16, 16, img`
-            . f . f . 
-            . f . f . 
-            . . . . . 
-            f . . . f 
-            . f f f . 
+            . f . f .
+            . f . f .
+            . . . . .
+            f . . . f
+            . f f f .
         `);
         // if large anchor, increase lifespan
         if (factory.xRange > 50) {
@@ -236,11 +237,11 @@ namespace effects {
     //% fixedInstance whenUsed block="rings"
     export const rings = createEffect(5, 1000, function () {
         return new particles.ShapeFactory(16, 16, img`
-            . F F F . 
-            F . . . F 
-            F . . . F 
-            f . . . f 
-            . f f f . 
+            . F F F .
+            F . . . F
+            F . . . F
+            f . . . f
+            . f f f .
         `);
     });
 

--- a/libs/game/particles.ts
+++ b/libs/game/particles.ts
@@ -2,6 +2,7 @@ namespace particles {
     enum Flag {
         enabled = 1 << 0,
         destroyed = 1 << 1,
+        relativeToCamera = 1 << 2
     }
 
     // maximum count of sources before removing previous sources
@@ -81,7 +82,7 @@ namespace particles {
         /**
          * @param anchor to emit particles from
          * @param particlesPerSecond rate at which particles are emitted
-         * @param factory [optional] factory to generate particles with; otherwise, 
+         * @param factory [optional] factory to generate particles with; otherwise,
          */
         constructor(anchor: ParticleAnchor, particlesPerSecond: number, factory?: ParticleFactory) {
             super(scene.SPRITE_Z)
@@ -110,8 +111,8 @@ namespace particles {
 
         __draw(camera: scene.Camera) {
             let current = this.head;
-            const left = Fx8(camera.drawOffsetX);
-            const top = Fx8(camera.drawOffsetY);
+            const left = (this.pFlags & Flag.relativeToCamera) ? Fx.zeroFx8 : Fx8(camera.drawOffsetX);
+            const top = (this.pFlags & Flag.relativeToCamera) ? Fx.zeroFx8 : Fx8(camera.drawOffsetY);
 
             while (current) {
                 if (current.lifespan > 0)
@@ -197,10 +198,19 @@ namespace particles {
 
         /**
          * Enables or disables particles
-         * @param on 
+         * @param on
          */
         setEnabled(on: boolean) {
             this.enabled = on;
+        }
+
+        /**
+         * Sets whether the particle source is drawn relative to the camera or not
+         * @param on
+         */
+        setRelativeToCamera(on: boolean) {
+            if (on) this.pFlags |= Flag.relativeToCamera
+            else this.pFlags = ~(~this.pFlags | Flag.relativeToCamera);
         }
 
         get enabled() {
@@ -244,7 +254,7 @@ namespace particles {
 
         /**
          * Sets the number of particle created per second
-         * @param particlesPerSecond 
+         * @param particlesPerSecond
          */
         setRate(particlesPerSecond: number) {
             this.period = Math.ceil(1000 / particlesPerSecond);
@@ -257,7 +267,7 @@ namespace particles {
 
         /**
          * Sets the particle factor
-         * @param factory 
+         * @param factory
          */
         setFactory(factory: ParticleFactory) {
             if (factory)
@@ -284,7 +294,7 @@ namespace particles {
 
     /**
      * Creates a new source of particles attached to a sprite
-     * @param sprite 
+     * @param sprite
      * @param particlesPerSecond number of particles created per second
      */
     export function createParticleSource(sprite: Sprite, particlesPerSecond: number): ParticleSource {
@@ -318,7 +328,7 @@ namespace particles {
         const sources = particleSources();
         if (sources) sources.slice(0, sources.length).forEach(s => s._prune());
     }
-    
+
     function sortSources(sources: ParticleSource[]) {
         sources.sort((a, b) => (a.priority - b.priority || a.id - b.id));
     }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -501,6 +501,7 @@ class Sprite extends sprites.BaseSprite {
             else { // needs a new sprite
                 this.sayBubbleSprite = sprites.create(sayImg, -1);
                 this.sayBubbleSprite.setFlag(SpriteFlag.Ghost, true);
+                this.sayBubbleSprite.setFlag(SpriteFlag.RelativeToCamera, !!(this.flags & sprites.Flag.RelativeToCamera))
             }
         }
         this.sayBubbleSprite.data[SAYKEY] = key;
@@ -590,7 +591,7 @@ class Sprite extends sprites.BaseSprite {
     //% blockId=startEffectOnSprite block="%sprite(mySprite) start %effect effect || for %duration=timePicker|ms"
     //% help=sprites/sprite/start-effect
     startEffect(effect: effects.ParticleEffect, duration?: number) {
-        effect.start(this, duration);
+        effect.start(this, duration, null, !!(this.flags & sprites.Flag.RelativeToCamera));
     }
 
     /**
@@ -695,6 +696,10 @@ class Sprite extends sprites.BaseSprite {
     setFlag(flag: SpriteFlag, on: boolean) {
         if (on) this.flags |= flag
         else this.flags = ~(~this.flags | flag);
+
+        if (flag === SpriteFlag.RelativeToCamera && this.sayBubbleSprite) {
+            this.sayBubbleSprite.setFlag(SpriteFlag.RelativeToCamera, on);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1700

This does not update particle effects after they are created because they don't keep a reference to sprites and it would have been too big a refactor. I think it's a pretty niche scenario anyways.

![2020-01-13 17 54 25](https://user-images.githubusercontent.com/13754588/72307086-047e4100-362e-11ea-819b-e41069689964.gif)
