### PR TITLE
make sprite.say take any

### DIFF
--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -26,7 +26,8 @@ namespace console {
         function (priority: ConsolePriority, text: string) { control.__log(priority, text); }
     ];
 
-    export function add(priority: ConsolePriority, text: string) {
+    export function add(priority: ConsolePriority, message: any) {
+        let text = inspect(message);
         if (priority < minPriority) return;
         // add new line
         text += "\n";
@@ -35,15 +36,15 @@ namespace console {
             listeners[i](priority, text);
     }
 
-    export function debug(text: string) {
+    export function debug(text: any) {
         add(ConsolePriority.Debug, text);
     }
 
-    export function warn(text: string) {
+    export function warn(text: any) {
         add(ConsolePriority.Warning, text);
     }
 
-    export function error(text: string) {
+    export function error(text: any) {
         add(ConsolePriority.Error, text);
     }
 
@@ -56,7 +57,7 @@ namespace console {
     //% blockId=console_log block="console log $value"
     //% value.shadow=text
     export function log(value: any): void {
-        add(ConsolePriority.Log, inspect(value));
+        add(ConsolePriority.Log, value);
     }
 
     /**
@@ -67,8 +68,9 @@ namespace console {
     //% weight=88 blockGap=8
     //% help=console/log-value
     //% blockId=console_log_value block="console|log value %name|= %value"
-    export function logValue(name: string, value: number): void {
-        log(name ? `${name}: ${value}` : `${value}`)
+    //% name.shadow=text
+    export function logValue(name: any, value: number): void {
+        log(name ? `${inspect(name)}: ${value}` : `${value}`)
     }
 
     /**
@@ -123,7 +125,7 @@ namespace console {
 
     /**
      * Removes a listener
-     * @param listener 
+     * @param listener
      */
     //%
     export function removeListener(listener: (priority: ConsolePriority, text: string) => void) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -429,9 +429,10 @@ class Sprite extends sprites.BaseSprite {
     //% weight=60
     //% blockId=spritesay block="%sprite(mySprite) say %text||for %millis ms"
     //% millis.shadow=timePicker
+    //% text.shadow=text
     //% inlineInputMode=inline
     //% help=sprites/sprite/say
-    say(text: string, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
+    say(text: any, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
         // clear say
         if (!text) {
             this.updateSay = undefined;
@@ -441,6 +442,8 @@ class Sprite extends sprites.BaseSprite {
             }
             return;
         }
+
+        text = console.inspect(text);
 
         // same text, color, time, etc...
         const SAYKEY = "__saykey";
@@ -463,6 +466,9 @@ class Sprite extends sprites.BaseSprite {
         let font = image.getFontForText(text);
         let startX = 2;
         let startY = 2;
+        console.log(`${text} --- ${typeof text}`);
+        // fails here; text === "abc" but text.length throws `backend.js:6 Cannot read property 'iface' of undefined`
+        console.log("" + text.length);
         let bubbleWidth = text.length * font.charWidth + bubblePadding;
         let maxOffset = text.length * font.charWidth - maxTextWidth;
         let bubbleOffset: number = Fx.toInt(this._hitbox.oy);

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -442,13 +442,12 @@ class Sprite extends sprites.BaseSprite {
             }
             return;
         }
-
-        text = console.inspect(text);
+        const textToDisplay = console.inspect(text);
 
         // same text, color, time, etc...
         const SAYKEY = "__saykey";
         const key = JSON.stringify({
-            text: text,
+            text: textToDisplay,
             textColor: textColor,
             textBoxColor: textBoxColor
         })
@@ -463,14 +462,11 @@ class Sprite extends sprites.BaseSprite {
         let holdTextSeconds = 1.5;
         let bubblePadding = 4;
         let maxTextWidth = 100;
-        let font = image.getFontForText(text);
+        let font = image.getFontForText(textToDisplay);
         let startX = 2;
         let startY = 2;
-        console.log(`${text} --- ${typeof text}`);
-        // fails here; text === "abc" but text.length throws `backend.js:6 Cannot read property 'iface' of undefined`
-        console.log("" + text.length);
-        let bubbleWidth = text.length * font.charWidth + bubblePadding;
-        let maxOffset = text.length * font.charWidth - maxTextWidth;
+        let bubbleWidth = textToDisplay.length * font.charWidth + bubblePadding;
+        let maxOffset = textToDisplay.length * font.charWidth - maxTextWidth;
         let bubbleOffset: number = Fx.toInt(this._hitbox.oy);
         let needsRedraw = true;
 
@@ -562,10 +558,10 @@ class Sprite extends sprites.BaseSprite {
                     this.sayBubbleSprite.image.fill(textBoxColor);
                     // If maxOffset is negative it won't scroll
                     if (maxOffset < 0) {
-                        this.sayBubbleSprite.image.print(text, startX, startY, textColor, font);
+                        this.sayBubbleSprite.image.print(textToDisplay, startX, startY, textColor, font);
 
                     } else {
-                        this.sayBubbleSprite.image.print(text, startX - pixelsOffset, startY, textColor, font);
+                        this.sayBubbleSprite.image.print(textToDisplay, startX - pixelsOffset, startY, textColor, font);
                     }
 
                     // Left side padding

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -442,7 +442,7 @@ class Sprite extends sprites.BaseSprite {
             }
             return;
         }
-        const textToDisplay = console.inspect(text);
+        const textToDisplay = console.inspect(text).split("\n").join(" ");
 
         // same text, color, time, etc...
         const SAYKEY = "__saykey";


### PR DESCRIPTION
make sprite say take `any`. `sprite.say` doesn't play too nicely with `\n`'s at the moment; I just worked around it for now by replacing them with spaces, but I think supporting multi line `say`s  nicely would be a nice feature? Can see how much effort that would be if we want, but I'm not sure how that would end  up looking -- conflicts with the basic scrolling.

Noticed that we probably should add string.replace and string.replaceAll (non regex versions of course) to the string 'prototype' in pxtlib

(Also, took an extra few minutes to debug what was wrong with the first commit; pretty subtle error that feels very hard to catch)