### PR TITLE
Move Arcade button handling from buttons to game---hw

### DIFF
--- a/libs/buttons/buttons.cpp
+++ b/libs/buttons/buttons.cpp
@@ -27,190 +27,17 @@ enum class ButtonEvent {
 };
 
 namespace pxt {
-
-class PressureButton : public codal::Button {
-  public:
-    PressureButton(Pin &pin, uint16_t id,
-                   ButtonEventConfiguration eventConfiguration = DEVICE_BUTTON_ALL_EVENTS,
-                   ButtonPolarity polarity = ACTIVE_LOW, PullMode mode = PullMode::None)
-        : Button(pin, id, eventConfiguration, polarity, mode) {}
-
-    virtual int pressureLevel() { return isPressed() ? 512 : 0; }
-};
-
-#ifdef PXT_74HC165
-static void waitABit() {
-    for (int i = 0; i < 10; ++i)
-        asm volatile("nop");
-}
-class MultiplexedButton;
-class ButtonMultiplexer : public CodalComponent {
-  public:
-    Pin &latch;
-    Pin &clock;
-    Pin &data;
-    uint32_t state;
-    MultiplexedButton *createButton(uint16_t id, uint8_t shift);
-    ButtonMultiplexer(uint16_t id)
-        : latch(*LOOKUP_PIN(BTNMX_LATCH)), clock(*LOOKUP_PIN(BTNMX_CLOCK)),
-          data(*LOOKUP_PIN(BTNMX_DATA)) {
-        this->state = 0;
-        this->id = id;
-        this->status |= DEVICE_COMPONENT_STATUS_SYSTEM_TICK;
-    }
-
-    virtual void periodicCallback() override {
-        latch.setDigitalValue(0);
-        waitABit();
-        latch.setDigitalValue(1);
-        waitABit();
-
-        state = 0;
-
-        for (int i = 0; i < 8; i++) {
-            state <<= 1;
-            if (data.getDigitalValue())
-                state |= 1;
-            clock.setDigitalValue(1);
-            waitABit();
-            clock.setDigitalValue(0);
-            waitABit();
-        }
-    }
-};
-class MultiplexedButton : public PressureButton {
-  public:
-    ButtonMultiplexer *parent;
-    uint8_t shift;
-    MultiplexedButton(uint16_t id, uint8_t shift, ButtonMultiplexer *parent)
-        : PressureButton(parent->data, id), parent(parent), shift(shift) {}
-
-  protected:
-    virtual int buttonActive() { return (parent->state & (1 << shift)) != 0; }
-};
-
-MultiplexedButton *ButtonMultiplexer::createButton(uint16_t id, uint8_t shift) {
-    return new MultiplexedButton(id, shift, this);
-}
-
-static ButtonMultiplexer *buttonMultiplexer;
-#endif
-
-struct AnalogCache {
-    AnalogCache *next;
-    Pin *pin;
-    uint32_t lastMeasureMS;
-    uint16_t lastMeasure;
-    AnalogCache(Pin *pin) : pin(pin) {
-        next = NULL;
-        lastMeasureMS = 0;
-        lastMeasure = pin->getAnalogValue();
-    }
-    uint16_t read();
-};
-
-uint16_t AnalogCache::read() {
-    uint32_t now = current_time_ms();
-    if (now - lastMeasureMS < 50)
-        return lastMeasure;
-    lastMeasureMS = now;
-    lastMeasure = pin->getAnalogValue();
-    return lastMeasure;
-}
-
-static AnalogCache *analogCache;
-
-class AnalogButton : public PressureButton {
-  public:
-    AnalogCache *cache;
-    int16_t threshold;
-    bool state;
-
-    AnalogButton(AnalogCache *cache, uint16_t id, int threshold)
-        : PressureButton(*cache->pin, id), cache(cache), threshold(threshold), state(false) {}
-
-  protected:
-    virtual int pressureLevel() override {
-        int v = cache->read() - 512;
-        if (threshold < 0)
-            v = -v;
-        int vmin = getConfig(CFG_ANALOG_JOYSTICK_MIN, 50);
-        int vmax = getConfig(CFG_ANALOG_JOYSTICK_MAX, 500);
-        v = (v - vmin) * 512 / (vmax - vmin);
-        if (v < 0)
-            v = 0;
-        if (v > 512)
-            v = 512;
-        return v;
-    }
-
-    virtual int buttonActive() override {
-        int v = cache->read() - 512;
-        int thr = threshold;
-
-        if (thr < 0) {
-            v = -v;
-            thr = -thr;
-        }
-
-        if (v > thr)
-            state = true;
-        else if (state && v > thr * 3 / 4)
-            state = true;
-        else
-            state = false;
-
-        return state;
-    }
-};
-
-AnalogCache *lookupAnalogCache(Pin *pin) {
-    for (auto c = analogCache; c; c = c->next)
-        if (c->pin == pin)
-            return c;
-    auto c = new AnalogCache(pin);
-    c->next = analogCache;
-    analogCache = c;
-    return c;
-}
-
-//% expose
-int pressureLevelByButtonId(int btnId, int codalId) {
-    (void)btnId;
-    auto btn = (PressureButton *)lookupComponent(codalId);
-    if (!btn)
-        return 0;
-    return btn->pressureLevel();
-}
-
 //%
-PressureButton *getButtonByPin(int pin, int flags) {
-    pin &= 0xffff;
-
+Button *getButtonByPin(int pin, int flags) {
     unsigned highflags = (unsigned)pin >> 16;
     if (highflags & 0xff)
         flags = highflags & 0xff;
 
-    auto cpid = DEVICE_ID_FIRST_BUTTON + pin;
-    auto btn = (PressureButton *)lookupComponent(cpid);
-    if (btn == NULL) {
-#ifdef PXT_74HC165
-        if (1000 <= pin && pin < 1100) {
-            if (!buttonMultiplexer)
-                buttonMultiplexer = new ButtonMultiplexer(DEVICE_ID_FIRST_BUTTON);
-            return buttonMultiplexer->createButton(cpid, pin - 1000);
-        }
-#endif
-        if (1100 <= pin && pin < 1300) {
-            pin -= 1100;
-            int thr = getConfig(CFG_ANALOG_BUTTON_THRESHOLD, 300);
-            if (pin >= 100) {
-                thr = -thr;
-                pin -= 100;
-            }
-            return new AnalogButton(lookupAnalogCache(lookupPin(pin)), cpid, thr);
-        }
+    pin &= 0xffff;
 
+    auto cpid = DEVICE_ID_FIRST_BUTTON + pin;
+    auto btn = (Button *)lookupComponent(cpid);
+    if (btn == NULL) {
         auto pull = PullMode::None;
         if ((flags & 0xf0) == 0x10)
             pull = PullMode::Down;
@@ -221,14 +48,14 @@ PressureButton *getButtonByPin(int pin, int flags) {
         else
             oops(3);
         // GCTODO
-        btn = new PressureButton(*lookupPin(pin), cpid, DEVICE_BUTTON_ALL_EVENTS,
+        btn = new Button(*lookupPin(pin), cpid, DEVICE_BUTTON_ALL_EVENTS,
                                  (ButtonPolarity)(flags & 0xf), pull);
     }
     return btn;
 }
 
 //%
-PressureButton *getButtonByPinCfg(int key, int flags) {
+Button *getButtonByPinCfg(int key, int flags) {
     int pin = getConfig(key);
     if (pin == -1)
         target_panic(PANIC_NO_SUCH_CONFIG);
@@ -241,7 +68,7 @@ MultiButton *getMultiButton(int id, int pinA, int pinB, int flags) {
         auto bA = getButtonByPin(pinA, flags);
         auto bB = getButtonByPin(pinB, flags);
         // GCTODO
-        btn = new codal::MultiButton(bA->id, bB->id, id);
+        btn = new MultiButton(bA->id, bB->id, id);
 
         // A user has registered to receive events from the buttonAB multibutton.
         // Disable click events from being generated by ButtonA and ButtonB, and defer the
@@ -349,14 +176,6 @@ bool wasPressed(Button_ button) {
 //%
 int id(Button_ button) {
     return button->id;
-}
-
-/**
- * Gets the pressure level on the button 0 to 512.
- */
-//%
-int pressureLevel(Button_ button) {
-    return ((PressureButton *)button)->pressureLevel();
 }
 
 } // namespace ButtonMethods

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -90,6 +90,7 @@ CODAL_SPI* getSPI(DigitalInOutPin mosi, DigitalInOutPin miso, DigitalInOutPin sc
 LowLevelTimer* getJACDACTimer();
 #endif
 class PressureButton;
+uint32_t readButtonMultiplexer(int bits);
 }
 
 namespace serial {

--- a/libs/game---hw/controllerbuttons.cpp
+++ b/libs/game---hw/controllerbuttons.cpp
@@ -1,0 +1,265 @@
+#include "pxt.h"
+
+namespace pxt {
+
+class PressureButton : public codal::Button {
+  public:
+    PressureButton(Pin &pin, uint16_t id,
+                   ButtonEventConfiguration eventConfiguration = DEVICE_BUTTON_ALL_EVENTS,
+                   ButtonPolarity polarity = ACTIVE_LOW, PullMode mode = PullMode::None)
+        : Button(pin, id, eventConfiguration, polarity, mode) {}
+
+    virtual int pressureLevel() { return isPressed() ? 512 : 0; }
+};
+
+static const int INTERNAL_KEY_UP = 2050;
+static const int INTERNAL_KEY_DOWN = 2051;
+
+static void waitABit() {
+    //for (int i = 0; i < 10; ++i)
+    //    asm volatile("nop");
+}
+
+class ButtonMultiplexer : public CodalComponent {
+  public:
+    Pin &latch;
+    Pin &clock;
+    Pin &data;
+    uint32_t state;
+    uint32_t invMask;
+    uint16_t buttonIdPerBit[8];
+
+    ButtonMultiplexer(uint16_t id)
+        : latch(*LOOKUP_PIN(BTNMX_LATCH)), clock(*LOOKUP_PIN(BTNMX_CLOCK)),
+          data(*LOOKUP_PIN(BTNMX_DATA)) {
+        this->id = id;
+        this->status |= DEVICE_COMPONENT_STATUS_SYSTEM_TICK;
+
+        state = 0;
+        invMask = 0;
+
+        memset(buttonIdPerBit, 0, sizeof(buttonIdPerBit));
+
+        data.getDigitalValue(PullMode::Down);
+        latch.setDigitalValue(1);
+        clock.setDigitalValue(1);
+    }
+
+    bool isButtonPressed(int id) {
+        for (int i = 0; i < 8; ++i) {
+            if (buttonIdPerBit[i] == id)
+                return (state & (1 << i)) != 0;
+        }
+        return false;
+    }
+
+    uint32_t readBits(int bits) {
+        latch.setDigitalValue(0);
+        waitABit();
+        latch.setDigitalValue(1);
+        waitABit();
+
+        uint32_t state = 0;
+        for (int i = 0; i < bits; i++) {
+            state <<= 1;
+            if (data.getDigitalValue(PullMode::Down))
+                state |= 1;
+
+            clock.setDigitalValue(0);
+            waitABit();
+            clock.setDigitalValue(1);
+            waitABit();
+        }
+
+        return state;
+    }
+
+    virtual void periodicCallback() override {
+        uint32_t newState = readBits(8);
+        newState ^= invMask;
+        if (newState == state)
+            return;
+
+        for (int i = 0; i < 8; ++i) {
+            uint32_t mask = 1 << i;
+            if (!buttonIdPerBit[i])
+                continue;
+            int ev = 0;
+            if (!(state & mask) && (newState & mask))
+                ev = INTERNAL_KEY_DOWN;
+            else if ((state & mask) && !(newState & mask))
+                ev = INTERNAL_KEY_UP;
+            if (ev) {
+                Event(ev, buttonIdPerBit[i]);
+                Event(ev, 0); // any key
+            }
+        }
+
+        state = newState;
+    }
+};
+
+static ButtonMultiplexer *btnMultiplexer;
+ButtonMultiplexer *getMultiplexer() {
+    if (!btnMultiplexer)
+        btnMultiplexer = new ButtonMultiplexer(DEVICE_ID_FIRST_BUTTON);
+    return btnMultiplexer;
+}
+
+struct AnalogCache {
+    AnalogCache *next;
+    Pin *pin;
+    uint32_t lastMeasureMS;
+    uint16_t lastMeasure;
+    AnalogCache(Pin *pin) : pin(pin) {
+        next = NULL;
+        lastMeasureMS = 0;
+        lastMeasure = pin->getAnalogValue();
+    }
+    uint16_t read();
+};
+
+uint16_t AnalogCache::read() {
+    uint32_t now = current_time_ms();
+    if (now - lastMeasureMS < 50)
+        return lastMeasure;
+    lastMeasureMS = now;
+    lastMeasure = pin->getAnalogValue();
+    return lastMeasure;
+}
+
+static AnalogCache *analogCache;
+
+class AnalogButton : public PressureButton {
+  public:
+    AnalogCache *cache;
+    int16_t threshold;
+    bool state;
+
+    AnalogButton(AnalogCache *cache, uint16_t id, int threshold)
+        : PressureButton(*cache->pin, id), cache(cache), threshold(threshold), state(false) {}
+
+  protected:
+    virtual int pressureLevel() override {
+        int v = cache->read() - 512;
+        if (threshold < 0)
+            v = -v;
+        int vmin = getConfig(CFG_ANALOG_JOYSTICK_MIN, 50);
+        int vmax = getConfig(CFG_ANALOG_JOYSTICK_MAX, 500);
+        v = (v - vmin) * 512 / (vmax - vmin);
+        if (v < 0)
+            v = 0;
+        if (v > 512)
+            v = 512;
+        return v;
+    }
+
+    virtual int buttonActive() override {
+        int v = cache->read() - 512;
+        int thr = threshold;
+
+        if (thr < 0) {
+            v = -v;
+            thr = -thr;
+        }
+
+        if (v > thr)
+            state = true;
+        else if (state && v > thr * 3 / 4)
+            state = true;
+        else
+            state = false;
+
+        return state;
+    }
+};
+
+AnalogCache *lookupAnalogCache(Pin *pin) {
+    for (auto c = analogCache; c; c = c->next)
+        if (c->pin == pin)
+            return c;
+    auto c = new AnalogCache(pin);
+    c->next = analogCache;
+    analogCache = c;
+    return c;
+}
+
+//% expose
+int pressureLevelByButtonId(int btnId, int codalId) {
+    if (codalId <= 0)
+        codalId = DEVICE_ID_FIRST_BUTTON + btnId;
+    auto btn = (PressureButton *)lookupComponent(codalId);
+    if (!btn) {
+        if (btnMultiplexer)
+            return btnMultiplexer->isButtonPressed(btnId) ? 512 : 0;
+        return 0;
+    }
+    return btn->pressureLevel();
+}
+
+static void sendBtnDown(Event ev) {
+    Event(INTERNAL_KEY_DOWN, ev.source - DEVICE_ID_FIRST_BUTTON);
+}
+
+static void sendBtnUp(Event ev) {
+    Event(INTERNAL_KEY_UP, ev.source - DEVICE_ID_FIRST_BUTTON);
+}
+
+//% expose
+void setupButton(int buttonId, int key) {
+    int pin = getConfig(key);
+    if (pin == -1)
+        target_panic(PANIC_NO_SUCH_CONFIG);
+
+    unsigned highflags = (unsigned)pin >> 16;
+    int flags = BUTTON_ACTIVE_LOW_PULL_UP;
+    if (highflags & 0xff)
+        flags = highflags & 0xff;
+
+    pin &= 0xffff;
+
+    auto cpid = DEVICE_ID_FIRST_BUTTON + buttonId;
+    auto btn = (PressureButton *)lookupComponent(cpid);
+    if (btn == NULL) {
+        if (1050 <= pin && pin < 1058) {
+            pin -= 50;
+            getMultiplexer()->invMask |= 1 << (pin - 1000);
+        }
+        if (1000 <= pin && pin < 1008) {
+            getMultiplexer()->buttonIdPerBit[pin - 1000] = buttonId;
+            return;
+        }
+
+        if (1100 <= pin && pin < 1300) {
+            pin -= 1100;
+            int thr = getConfig(CFG_ANALOG_BUTTON_THRESHOLD, 300);
+            if (pin >= 100) {
+                thr = -thr;
+                pin -= 100;
+            }
+            btn = new AnalogButton(lookupAnalogCache(lookupPin(pin)), cpid, thr);
+        } else {
+            auto pull = PullMode::None;
+            if ((flags & 0xf0) == 0x10)
+                pull = PullMode::Down;
+            else if ((flags & 0xf0) == 0x20)
+                pull = PullMode::Up;
+            else if ((flags & 0xf0) == 0x30)
+                pull = PullMode::None;
+            else
+                oops(3);
+            btn = new PressureButton(*lookupPin(pin), cpid, DEVICE_BUTTON_ALL_EVENTS,
+                                     (ButtonPolarity)(flags & 0xf), pull);
+        }
+        EventModel::defaultEventBus->listen(btn->id, DEVICE_BUTTON_EVT_DOWN, sendBtnDown);
+        EventModel::defaultEventBus->listen(btn->id, DEVICE_BUTTON_EVT_UP, sendBtnUp);
+    }
+}
+
+//% expose
+uint32_t readButtonMultiplexer(int bits) {
+    if (!LOOKUP_PIN(BTNMX_CLOCK))
+        return 0;
+    return getMultiplexer()->readBits(bits);
+}
+} // namespace pxt

--- a/libs/game---hw/pxt.json
+++ b/libs/game---hw/pxt.json
@@ -1,0 +1,10 @@
+{
+    "name": "game",
+    "additionalFilePath": "../game",
+    "partial": true,
+    "dependencies": {
+        "settings": "file:../settings",
+        "screen---st7735": "file:../screen---st7735",
+        "power": "file:../power"
+    }
+}

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -44,6 +44,11 @@ namespace controller {
     //% shim=pxt::pressureLevelByButtonId
     declare function pressureLevelByButtonId(btnId: number, codalId: number): number;
 
+    //% shim=pxt::setupButton
+    function setupButton(buttonId: number, key: number) {
+        return // missing in sim
+     }
+
     //% fixedInstances
     export class Button {
         _owner: Controller;
@@ -55,15 +60,13 @@ namespace controller {
         private _pressed: boolean;
         private _pressedElasped: number;
         private _repeatCount: number;
-        private _buttonId: number;
 
         toString(): string {
-            return `btn ${this.id} ${this._buttonId} ${this._pressed ? "down" : "up"}`;
+            return `btn ${this.id} ${this._pressed ? "down" : "up"}`;
         }
 
-        constructor(id: number, buttonId: number) {
+        constructor(id: number, configKey: number) {
             this.id = id;
-            this._buttonId = buttonId;
             this._pressed = false;
             this.repeatDelay = undefined;
             this.repeatInterval = undefined;
@@ -74,11 +77,9 @@ namespace controller {
                 // this button can't actually be pressed, we don't want it to propagate events
                 control.internalOnEvent(INTERNAL_KEY_UP, this.id, () => this.setPressed(false), 16)
                 control.internalOnEvent(INTERNAL_KEY_DOWN, this.id, () => this.setPressed(true), 16)
-            }
-            if (buttonId > -1) {
-                // only add these events when running on real hardware
-                control.internalOnEvent(buttonId, DAL.DEVICE_BUTTON_EVT_UP, () => control.raiseEvent(INTERNAL_KEY_UP, this.id), 16)
-                control.internalOnEvent(buttonId, DAL.DEVICE_BUTTON_EVT_DOWN, () => control.raiseEvent(INTERNAL_KEY_DOWN, this.id), 16)
+
+                if (configKey > 0)
+                    setupButton(id, configKey)
             }
         }
 
@@ -141,7 +142,7 @@ namespace controller {
                 return this.isPressed() ? 512 : 0
                 // once implemented in sim, this could be similar to the one below
             } else {
-                return pressureLevelByButtonId(this.id, this._buttonId);
+                return pressureLevelByButtonId(this.id, -1);
             }
         }
 

--- a/libs/game/controllerbuttons.cpp
+++ b/libs/game/controllerbuttons.cpp
@@ -1,0 +1,1 @@
+// Overriden in target

--- a/libs/game/controlleroverrides.ts
+++ b/libs/game/controlleroverrides.ts
@@ -1,18 +1,18 @@
 namespace controller {
     //% fixedInstance whenUsed block="{id:controller}A"
-    export const A = new Button(ControllerButton.A, -1);
+    export const A = new Button(ControllerButton.A, DAL.CFG_PIN_BTN_A);
     //% fixedInstance whenUsed block="{id:controller}B"
-    export const B = new Button(ControllerButton.B, -1);
+    export const B = new Button(ControllerButton.B, DAL.CFG_PIN_BTN_B);
     //% fixedInstance whenUsed block="left"
-    export const left = new Button(ControllerButton.Left, -1);
+    export const left = new Button(ControllerButton.Left, DAL.CFG_PIN_BTN_LEFT);
     //% fixedInstance whenUsed block="up"
-    export const up = new Button(ControllerButton.Up, -1);
+    export const up = new Button(ControllerButton.Up, DAL.CFG_PIN_BTN_UP);
     //% fixedInstance whenUsed block="right"
-    export const right = new Button(ControllerButton.Right, -1);
+    export const right = new Button(ControllerButton.Right, DAL.CFG_PIN_BTN_RIGHT);
     //% fixedInstance whenUsed block="down"
-    export const down = new Button(ControllerButton.Down, -1);
+    export const down = new Button(ControllerButton.Down, DAL.CFG_PIN_BTN_DOWN);
     //% fixedInstance whenUsed block="menu"
-    export const menu = new Button(7, -1);
+    export const menu = new Button(7, DAL.CFG_PIN_BTN_MENU);
 
     //% fixedInstance whenUsed block="player 2"
     export const player2 = new Controller(2, undefined);

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -32,6 +32,7 @@
         "ask.ts",
         "targetoverrides.cpp",
         "targetoverrides.ts",
+        "controllerbuttons.cpp",
         "mathUtil.ts",
         "systemmenu.ts",
         "systemmenuicons.ts",


### PR DESCRIPTION
This cuts a level of indirection from our button handling - they are now directly in game---hw - this unifies handling of buttons between simulator, RPi and Cortex targets (ie `input.left` etc are no longer available in Cortex, as they were not available in RPi/sim).