### PR TITLE
ColorBuffer slice fix, palette.getCurrentColors

### DIFF
--- a/libs/color/colorbuffer.ts
+++ b/libs/color/colorbuffer.ts
@@ -68,8 +68,7 @@ namespace color {
 
             if (length == undefined)
                 length = this.length;
-            else
-                length = Math.min(length, this.length - start);
+            length = Math.min(length, this.length - start);
 
             const output = new ColorBuffer(length, this.layout);
             for (let i = 0; i < length; ++i) {

--- a/libs/color/colorbuffer.ts
+++ b/libs/color/colorbuffer.ts
@@ -38,7 +38,8 @@ namespace color {
 
         color(index: number): number {
             index = index | 0;
-            if (index < 0 || index >= this.length) return -1;
+            if (index < 0 || index >= this.length)
+                return -1;
 
             const s = this.stride;
             const start = index * s;
@@ -61,22 +62,21 @@ namespace color {
         }
 
         slice(start?: number, length?: number): ColorBuffer {
-            const s = this.stride;
-            if (start === undefined)
-                start = 0;
             start = start | 0;
             if (start < 0)
                 start = this.length - start;
-            if (length === undefined)
+
+            if (length == undefined)
                 length = this.length;
-            else if (length < 0)
-                length = this.length - length;
-            length = Math.min(length | 0, this.length - length - start);
-            const b = new ColorBuffer(length, this.layout);
+            else
+                length = Math.min(length, this.length - start);
+
+            const output = new ColorBuffer(length, this.layout);
             for (let i = 0; i < length; ++i) {
-                b.setColor(i, this.color(start + i));
+                output.setColor(i, this.color(start + i));
             }
-            return b;
+
+            return output;
         }
 
         /**

--- a/libs/color/colors.ts
+++ b/libs/color/colors.ts
@@ -105,20 +105,20 @@ namespace color {
         h = (h * 192 / 255) >> 0;
 
         //reference: based on FastLED's hsv2rgb rainbow algorithm [https://github.com/FastLED/FastLED](MIT)
-        let invsat = 255 - sat;
-        let brightness_floor = ((val * invsat) / 255) >> 0;
-        let color_amplitude = val - brightness_floor;
-        let section = (h / 0x40) >> 0; // [0..2]
-        let offset = (h % 0x40) >> 0; // [0..63]
+        const invsat = 255 - sat;
+        const brightness_floor = ((val * invsat) / 255) >> 0;
+        const color_amplitude = val - brightness_floor;
+        const section = (h / 0x40) >> 0; // [0..2]
+        const offset = (h % 0x40) >> 0; // [0..63]
 
-        let rampup = offset;
-        let rampdown = (0x40 - 1) - offset;
+        const rampup = offset;
+        const rampdown = (0x40 - 1) - offset;
 
-        let rampup_amp_adj = ((rampup * color_amplitude) / (255 / 4)) >> 0;
-        let rampdown_amp_adj = ((rampdown * color_amplitude) / (255 / 4)) >> 0;
+        const rampup_amp_adj = ((rampup * color_amplitude) / (255 / 4)) >> 0;
+        const rampdown_amp_adj = ((rampdown * color_amplitude) / (255 / 4)) >> 0;
 
-        let rampup_adj_with_floor = (rampup_amp_adj + brightness_floor);
-        let rampdown_adj_with_floor = (rampdown_amp_adj + brightness_floor);
+        const rampup_adj_with_floor = (rampup_amp_adj + brightness_floor);
+        const rampdown_adj_with_floor = (rampdown_amp_adj + brightness_floor);
 
         let r: number;
         let g: number;

--- a/libs/color/colors.ts
+++ b/libs/color/colors.ts
@@ -56,11 +56,11 @@ const enum ColorHues {
 //% advanced=1
 namespace color {
     /**
- * Converts red, green, blue channels into a RGB color
- * @param red value of the red channel between 0 and 255. eg: 255
- * @param green value of the green channel between 0 and 255. eg: 255
- * @param blue value of the blue channel between 0 and 255. eg: 255
- */
+     * Converts red, green, blue channels into a RGB color
+     * @param red value of the red channel between 0 and 255. eg: 255
+     * @param green value of the green channel between 0 and 255. eg: 255
+     * @param blue value of the blue channel between 0 and 255. eg: 255
+     */
     //% blockId="colorsrgb" block="red %red|green %green|blue %blue"
     //% red.min=0 red.max=255 green.min=0 green.max=255 blue.min=0 blue.max=255
     //% help="colors/rgb"

--- a/libs/palette/palette.ts
+++ b/libs/palette/palette.ts
@@ -33,7 +33,7 @@ namespace palette {
     }
 
     /**
-     * Get the current palette used for the games colors
+     * Get the palette that is currently being used
      */
     export function getCurrentColors() {
         const scene = game.currentScene();

--- a/libs/palette/palette.ts
+++ b/libs/palette/palette.ts
@@ -23,16 +23,24 @@ namespace palette {
      * @param pOffset The offset to start copying from the palette
      */
     export function setColors(palette: color.ColorBuffer, pOffset = 0) {
-        const scene = game.currentScene();
-        let userPalette = scene.data[FIELD] as color.ColorBuffer;
-        if (!userPalette)
-            userPalette = scene.data[FIELD] = defaultPalette();
+        const userPalette = getCurrentColors();
         userPalette.write(pOffset, palette);
         image.setPalette(userPalette.buf);
 
         // make sure to clean up
         game.addScenePushHandler(scenePush);
         game.addScenePopHandler(scenePop);
+    }
+
+    /**
+     * Get the current palette used for the games colors
+     */
+    export function getCurrentColors() {
+        const scene = game.currentScene();
+        let userPalette = scene.data[FIELD] as color.ColorBuffer;
+        if (!userPalette)
+            userPalette = scene.data[FIELD] = defaultPalette();
+        return userPalette;
     }
 
     function scenePush(scene: scene.Scene) {


### PR DESCRIPTION
currently slice is returning a  0 length ColorBuffer when you try to copy one due to `length = Math.min(length | 0 /**  16 **/, this.length - length - start /** 16 - 16 - 0 **/);`

Also add a way to get the current color palette