### PR TITLE
allow resetting countdown in 'on countdown end'

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -134,11 +134,10 @@ namespace info {
                         t = 0;
                         if (!infoState.countdownExpired) {
                             infoState.countdownExpired = true;
+                            infoState.gameEnd = undefined;
                             if (infoState.countdownEndHandler) {
                                 infoState.countdownEndHandler();
-                                infoState.gameEnd = undefined;
-                            }
-                            else {
+                            } else {
                                 game.over();
                             }
                         }
@@ -605,7 +604,7 @@ namespace info {
 
         /**
          * Change the score of a player
-         * @param value 
+         * @param value
          */
         //% group="Multiplayer"
         //% blockId=pichangescore block="change %player score by %value"
@@ -654,7 +653,7 @@ namespace info {
 
         /**
          * Change the life of a player
-         * @param value 
+         * @param value
          */
         //% group="Multiplayer"
         //% blockId=pichangelife block="change %player life by %value"
@@ -679,7 +678,7 @@ namespace info {
 
         /**
          * Runs code when life reaches zero
-         * @param handler 
+         * @param handler
          */
         //% group="Multiplayer"
         //% blockId=playerinfoonlifezero block="on %player life zero"


### PR DESCRIPTION
reset the gameEnd / timer for countdown before invoking the game over / countdown end handler, so that user can choose to reset timer in their handlers (e.g. a 'need more time' screen that pops back up with a few more ms)