### PR TITLE
support for continuous servo in sim

### DIFF
--- a/libs/buttons/shims.d.ts
+++ b/libs/buttons/shims.d.ts
@@ -60,7 +60,7 @@ declare interface Button {
     wasPressed(): boolean;
 
     /**
-     * Gets the component identifier for the buton
+     * Gets the component identifier for the button
      */
     //% shim=ButtonMethods::id
     id(): int32;

--- a/libs/core---samd/shims.d.ts
+++ b/libs/core---samd/shims.d.ts
@@ -1,4 +1,16 @@
 // Auto-generated. Do not edit.
+declare namespace light {
+
+    /**
+     * Send a programmable light buffer to the specified digital pin
+     * @param data The pin that the lights are connected to
+     * @param clk the clock line if any
+     * @param mode the color encoding mode
+     * @param buf The buffer to send to the pin
+     */
+    //% shim=light::sendBuffer
+    function sendBuffer(data: DigitalInOutPin, clk: DigitalInOutPin, mode: int32, buf: Buffer): void;
+}
 declare namespace control {
 
     /**
@@ -127,7 +139,7 @@ declare interface DigitalInOutPin {
      * @param value the value of the pulse (default high)
      * @param maximum duration in micro-seconds
      */
-    //% blockId="pins_pulse_in" block="pulse in (µs)|pin %name|pulsed %high||timeout %maxDuration (us)"
+    //% blockId="pins_pulse_in" block="pulse in (µs)|pin %name|pulsed %high||timeout %maxDuration (µs)"
     //% weight=18 blockGap=8
     //% help="pins/pulse-in"
     //% blockNamespace=pins
@@ -202,6 +214,12 @@ declare interface PwmOnlyPin {
     //% name.fieldOptions.width=220
     //% name.fieldOptions.columns=4 shim=PwmOnlyPinMethods::servoSetPulse
     servoSetPulse(duration: int32): void;
+
+    /**
+     * Indicates if the servo is running continuously
+     */
+    //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinous
+    servoSetContinous(continuous: boolean): void;
 }
 declare namespace control {
 
@@ -295,18 +313,6 @@ declare interface SPI {
      */
     //% shim=SPIMethods::setMode
     setMode(mode: int32): void;
-}
-declare namespace light {
-
-    /**
-     * Send a programmable light buffer to the specified digital pin
-     * @param data The pin that the light are connected to
-     * @param clk the clock line if any
-     * @param mode the color encoding mode
-     * @param buf The buffer to send to the pin
-     */
-    //% shim=light::sendBuffer
-    function sendBuffer(data: DigitalInOutPin, clk: DigitalInOutPin, mode: int32, buf: Buffer): void;
 }
 declare namespace configStorage {
 

--- a/libs/core---samd/shims.d.ts
+++ b/libs/core---samd/shims.d.ts
@@ -218,8 +218,8 @@ declare interface PwmOnlyPin {
     /**
      * Indicates if the servo is running continuously
      */
-    //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinous
-    servoSetContinous(continuous: boolean): void;
+    //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinuous
+    servoSetContinuous(continuous: boolean): void;
 }
 declare namespace control {
 

--- a/libs/core/pinsPWM.cpp
+++ b/libs/core/pinsPWM.cpp
@@ -59,4 +59,9 @@ void servoSetPulse(PwmOnlyPin name, int duration) {
     PINOP(setServoPulseUs(duration));
 }
 
+//% blockHidden=1
+void servoSetContinous(PwmOnlyPin name, boolean continuous) {
+    // used by simulator
+}
+
 }

--- a/libs/core/pinsPWM.cpp
+++ b/libs/core/pinsPWM.cpp
@@ -59,8 +59,11 @@ void servoSetPulse(PwmOnlyPin name, int duration) {
     PINOP(setServoPulseUs(duration));
 }
 
+/**
+* Indicates if the servo is running continuously
+*/
 //% blockHidden=1
-void servoSetContinous(PwmOnlyPin name, boolean continuous) {
+void servoSetContinous(PwmOnlyPin name, bool continuous) {
     // used by simulator
 }
 

--- a/libs/core/pinsPWM.cpp
+++ b/libs/core/pinsPWM.cpp
@@ -63,7 +63,7 @@ void servoSetPulse(PwmOnlyPin name, int duration) {
 * Indicates if the servo is running continuously
 */
 //% blockHidden=1
-void servoSetContinous(PwmOnlyPin name, bool continuous) {
+void servoSetContinuous(PwmOnlyPin name, bool continuous) {
     // used by simulator
 }
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -1,4 +1,16 @@
 // Auto-generated. Do not edit.
+declare namespace light {
+
+    /**
+     * Send a programmable light buffer to the specified digital pin
+     * @param data The pin that the lights are connected to
+     * @param clk the clock line if any
+     * @param mode the color encoding mode
+     * @param buf The buffer to send to the pin
+     */
+    //% shim=light::sendBuffer
+    function sendBuffer(data: DigitalInOutPin, clk: DigitalInOutPin, mode: int32, buf: Buffer): void;
+}
 declare namespace control {
 
     /**
@@ -127,7 +139,7 @@ declare interface DigitalInOutPin {
      * @param value the value of the pulse (default high)
      * @param maximum duration in micro-seconds
      */
-    //% blockId="pins_pulse_in" block="pulse in (µs)|pin %name|pulsed %high||timeout %maxDuration (us)"
+    //% blockId="pins_pulse_in" block="pulse in (µs)|pin %name|pulsed %high||timeout %maxDuration (µs)"
     //% weight=18 blockGap=8
     //% help="pins/pulse-in"
     //% blockNamespace=pins
@@ -202,6 +214,12 @@ declare interface PwmOnlyPin {
     //% name.fieldOptions.width=220
     //% name.fieldOptions.columns=4 shim=PwmOnlyPinMethods::servoSetPulse
     servoSetPulse(duration: int32): void;
+
+    /**
+     * Indicates if the servo is running continuously
+     */
+    //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinous
+    servoSetContinous(continuous: boolean): void;
 }
 declare namespace control {
 
@@ -295,18 +313,6 @@ declare interface SPI {
      */
     //% shim=SPIMethods::setMode
     setMode(mode: int32): void;
-}
-declare namespace light {
-
-    /**
-     * Send a programmable light buffer to the specified digital pin
-     * @param data The pin that the light are connected to
-     * @param clk the clock line if any
-     * @param mode the color encoding mode
-     * @param buf The buffer to send to the pin
-     */
-    //% shim=light::sendBuffer
-    function sendBuffer(data: DigitalInOutPin, clk: DigitalInOutPin, mode: int32, buf: Buffer): void;
 }
 declare namespace configStorage {
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -219,7 +219,7 @@ declare interface PwmOnlyPin {
      * Indicates if the servo is running continuously
      */
     //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinuous
-    servoSetContinous(continuous: boolean): void;
+    servoSetContinuous(continuous: boolean): void;
 }
 declare namespace control {
 

--- a/libs/core/shims.d.ts
+++ b/libs/core/shims.d.ts
@@ -218,7 +218,7 @@ declare interface PwmOnlyPin {
     /**
      * Indicates if the servo is running continuously
      */
-    //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinous
+    //% blockHidden=1 shim=PwmOnlyPinMethods::servoSetContinuous
     servoSetContinous(continuous: boolean): void;
 }
 declare namespace control {

--- a/libs/core/sim/edgeconnector.ts
+++ b/libs/core/sim/edgeconnector.ts
@@ -19,6 +19,7 @@ namespace pxsim {
         pull = 0; // PullDown
         eventMode = 0;
         used: boolean = false;
+        servoContinuous: boolean;
 
         setValue(value: number) {
             // value set from the simulator
@@ -69,6 +70,10 @@ namespace pxsim {
             this.analogSetPeriod(20000);
             this.servoAngle = Math.max(0, Math.min(180, value));
             runtime.queueDisplayUpdate();
+        }
+
+        servoSetContinuous(continuous: boolean) {
+            this.servoContinuous = continuous;
         }
 
         servoSetPulse(pinId: number, micros: number) {

--- a/libs/core/sim/microservo.ts
+++ b/libs/core/sim/microservo.ts
@@ -63,7 +63,7 @@ namespace pxsim.visuals {
         }
         updateState(): void {
             const p = this.state.getPin(this.pin);
-            const continuous = !p.servoContinuous;
+            const continuous = !!p.servoContinuous;
             const servoAngle = p.servoAngle;
             if (continuous) {
                 // for a continuous servo, the angle is interpreted as a rotation speed

--- a/libs/core/sim/microservo.ts
+++ b/libs/core/sim/microservo.ts
@@ -74,7 +74,8 @@ namespace pxsim.visuals {
             } else {
                 this.targetAngle = 180.0 - servoAngle;
             }
-            if (this.targetAngle != this.currentAngle)
+            if (continuous ||
+                this.targetAngle != this.currentAngle)
                 this.renderAngle();
         }
 

--- a/libs/core/sim/microservo.ts
+++ b/libs/core/sim/microservo.ts
@@ -24,6 +24,7 @@ namespace pxsim.visuals {
         return { el: createMicroServoElement(), x: xy[0], y: xy[1], w: 112.188, h: 299.674 };
     }
 
+    const SPEED = 300; // 0.1s/60 degree
     export class MicroServoView implements IBoardPart<EdgeConnectorState> {
         public style: string = "";
         public overElement: SVGElement = undefined;
@@ -61,21 +62,35 @@ namespace pxsim.visuals {
             translateEl(this.element, [x, y])
         }
         updateState(): void {
-            this.targetAngle = 180.0 - this.state.getPin(this.pin).servoAngle;
-            if (this.targetAngle != this.currentAngle) {
+            const p = this.state.getPin(this.pin);
+            const continuous = !p.servoContinuous;
+            const servoAngle = p.servoAngle;
+            if (continuous) {
+                // for a continuous servo, the angle is interpreted as a rotation speed
+                // 0 -> -100%, 90 - 0%, 180 - 100%
                 const now = U.now();
-                const cx = 56.661;
-                const cy = 899.475;
-                const speed = 300; // 0.1s/60 degree
                 const dt = Math.min(now - this.lastAngleTime, 50) / 1000;
-                const delta = this.targetAngle - this.currentAngle;
-                this.currentAngle += Math.min(Math.abs(delta), speed * dt) * (delta > 0 ? 1 : -1);
-                this.crankEl.setAttribute("transform", this.crankTransform
-                    + ` rotate(${this.currentAngle}, ${cx}, ${cy})`)
-                this.lastAngleTime = now;
-                setTimeout(() => runtime.updateDisplay(), 20);
+                this.targetAngle += ((servoAngle - 90) / 90) * SPEED * dt;
+            } else {
+                this.targetAngle = 180.0 - servoAngle;
             }
+            if (this.targetAngle != this.currentAngle)
+                this.renderAngle();
         }
+
+        private renderAngle() {
+            const now = U.now();
+            const cx = 56.661;
+            const cy = 899.475;
+            const dt = Math.min(now - this.lastAngleTime, 50) / 1000;
+            const delta = this.targetAngle - this.currentAngle;
+            this.currentAngle += Math.min(Math.abs(delta), SPEED * dt) * (delta > 0 ? 1 : -1);
+            this.crankEl.setAttribute("transform", this.crankTransform
+                + ` rotate(${this.currentAngle}, ${cx}, ${cy})`)
+            this.lastAngleTime = now;
+            setTimeout(() => runtime.updateDisplay(), 20);
+        }
+
         updateTheme(): void {
 
         }

--- a/libs/core/sim/microservo.ts
+++ b/libs/core/sim/microservo.ts
@@ -70,12 +70,12 @@ namespace pxsim.visuals {
                 // 0 -> -100%, 90 - 0%, 180 - 100%
                 const now = U.now();
                 const dt = Math.min(now - this.lastAngleTime, 50) / 1000;
+                this.currentAngle = this.targetAngle;
                 this.targetAngle += ((servoAngle - 90) / 90) * SPEED * dt;
             } else {
                 this.targetAngle = 180.0 - servoAngle;
             }
-            if (continuous ||
-                this.targetAngle != this.currentAngle)
+            if (this.targetAngle != this.currentAngle)
                 this.renderAngle();
         }
 

--- a/libs/core/sim/pins.ts
+++ b/libs/core/sim/pins.ts
@@ -119,6 +119,11 @@ namespace pxsim.PwmOnlyPinMethods {
         name.servoWritePin(value);
     }
 
+    export function servoSetContinuous(name: pins.PwmOnlyPin, continuous: boolean): void {
+        pins.markUsed(name);
+        name.servoSetContinuous(continuous);
+    }
+
     export function servoSetPulse(name: pins.PwmOnlyPin, micros: number): void {
         pins.markUsed(name);
         name.servoSetPulse(name.id, micros);

--- a/libs/microphone/shims.d.ts
+++ b/libs/microphone/shims.d.ts
@@ -2,7 +2,7 @@
 declare namespace input {
 
     /**
-     * Registers an event that runs when a lound sound is detected
+     * Registers an event that runs when a loud sound is detected
      */
     //% help=input/on-loud-sound
     //% blockId=input_on_loud_sound block="on loud sound"
@@ -25,7 +25,7 @@ declare namespace input {
     //% help=input/set-loud-sound-threshold
     //% blockId=input_set_loud_sound_threshold block="set loud sound threshold %value"
     //% parts="microphone"
-    //% value.min=1 value.max=100
+    //% value.min=1 value.max=255
     //% group="More" weight=14 blockGap=8 shim=input::setLoudSoundThreshold
     function setLoudSoundThreshold(value: int32): void;
 }

--- a/libs/radio/shims.d.ts
+++ b/libs/radio/shims.d.ts
@@ -28,12 +28,12 @@ declare namespace radio {
     function sendRawPacket(msg: Buffer): void;
 
     /**
-     * Registers code to run when a packet is received over radio.
+     * Used internally by the library.
      */
     //% help=radio/on-data-received
-    //% weight=50
+    //% weight=0
     //% blockId=radio_datagram_received_event block="radio on data received" blockGap=8
-    //% deprecated=true shim=radio::onDataReceived
+    //% deprecated=true blockHidden=1 shim=radio::onDataReceived
     function onDataReceived(body: () => void): void;
 
     /**

--- a/libs/serial/shims.d.ts
+++ b/libs/serial/shims.d.ts
@@ -11,6 +11,14 @@ declare namespace serial {
 
 declare interface SerialDevice {
     /**
+     */
+    //% shim=SerialDeviceMethods::redirect
+    redirect(tx: DigitalInOutPin, rx: DigitalInOutPin, rate: BaudRate): void;
+}
+
+
+declare interface SerialDevice {
+    /**
      * Sets the size of the RX buffer in bytes
      */
     //% shim=SerialDeviceMethods::setRxBufferSize
@@ -45,11 +53,6 @@ declare interface SerialDevice {
      */
     //% shim=SerialDeviceMethods::writeBuffer
     writeBuffer(buffer: Buffer): void;
-
-    /**
-     */
-    //% shim=SerialDeviceMethods::redirect
-    redirect(tx: DigitalInOutPin, rx: DigitalInOutPin, rate: BaudRate): void;
 
     /**
      * Register code when a serial event occurs

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -38,7 +38,8 @@ namespace servos {
         //% group="Positional"
         setAngle(degrees: number) {
             degrees = this.clampDegrees(degrees);
-            this._angle = this.internalSetAngle(degrees, false);
+            this.internalSetContinuous(false);
+            this._angle = this.internalSetAngle(degrees);
         }
 
         get angle() {
@@ -49,7 +50,7 @@ namespace servos {
 
         }
 
-        protected internalSetAngle(angle: number, continuous: boolean): number {
+        protected internalSetAngle(angle: number): number {
             return 0;
         }
 
@@ -68,10 +69,11 @@ namespace servos {
         run(speed: number): void {
             const degrees = this.clampDegrees(Math.map(speed, -100, 100, this._minAngle, this._maxAngle));
             const neutral = (this.maxAngle - this.minAngle) >> 1;
+            this.internalSetContinuous(true);
             if (this._stopOnNeutral && degrees == neutral)
                 this.stop();
             else
-                this._angle = this.internalSetAngle(degrees, true);
+                this._angle = this.internalSetAngle(degrees);
         }
 
         /**

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -45,6 +45,10 @@ namespace servos {
             return this._angle || 90;
         }
 
+        protected internalSetContinuous(continuous: number): void {
+
+        }
+
         protected internalSetAngle(angle: number, continuous: boolean): number {
             return 0;
         }
@@ -174,10 +178,13 @@ namespace servos {
             this._pin = pin;
         }
 
-        protected internalSetAngle(angle: number, continuous: boolean): number {
-            this._pin.servoSetContinuous(continuous);
+        protected internalSetAngle(angle: number): number {
             this._pin.servoWrite(angle);
             return angle;
+        }
+
+        protected internalSetContinuous(continuous: number): void {
+            this._pin.servoSetContinuous(continuous);
         }
 
         protected internalSetPulse(micros: number): void {

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -38,14 +38,14 @@ namespace servos {
         //% group="Positional"
         setAngle(degrees: number) {
             degrees = this.clampDegrees(degrees);
-            this._angle = this.internalSetAngle(degrees);
+            this._angle = this.internalSetAngle(degrees, false);
         }
 
         get angle() {
             return this._angle || 90;
         }
 
-        protected internalSetAngle(angle: number): number {
+        protected internalSetAngle(angle: number, continuous: boolean): number {
             return 0;
         }
 
@@ -67,7 +67,7 @@ namespace servos {
             if (this._stopOnNeutral && degrees == neutral)
                 this.stop();
             else
-                this.setAngle(degrees);
+                this._angle = this.internalSetAngle(degrees, true);
         }
 
         /**
@@ -174,7 +174,8 @@ namespace servos {
             this._pin = pin;
         }
 
-        protected internalSetAngle(angle: number): number {
+        protected internalSetAngle(angle: number, continuous: number): number {
+            this._pin.servoSetContinous(continuous);
             this._pin.servoWrite(angle);
             return angle;
         }

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -45,7 +45,7 @@ namespace servos {
             return this._angle || 90;
         }
 
-        protected internalSetContinuous(continuous: number): void {
+        protected internalSetContinuous(continuous: boolean): void {
 
         }
 
@@ -183,7 +183,7 @@ namespace servos {
             return angle;
         }
 
-        protected internalSetContinuous(continuous: number): void {
+        protected internalSetContinuous(continuous: boolean): void {
             this._pin.servoSetContinuous(continuous);
         }
 

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -174,8 +174,8 @@ namespace servos {
             this._pin = pin;
         }
 
-        protected internalSetAngle(angle: number, continuous: number): number {
-            this._pin.servoSetContinous(continuous);
+        protected internalSetAngle(angle: number, continuous: boolean): number {
+            this._pin.servoSetContinuous(continuous);
             this._pin.servoWrite(angle);
             return angle;
         }


### PR DESCRIPTION
Keeps track if the servo is used as a continuous servor (a motor) and update the simulator rendering accordingly.
+ regen of shims
![2020-02-13 17 07 48](https://user-images.githubusercontent.com/4175913/74492413-a68a8680-4e83-11ea-9229-c87fcc45afc1.gif)
