### PR TITLE
fix bug to support LCD using ILI9341(320x240)

### DIFF
--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -95,10 +95,12 @@ class WDisplay {
         lcd->configure(madctl, frmctr1);
         width = getConfig(CFG_DISPLAY_WIDTH, 160);
         height = getConfig(CFG_DISPLAY_HEIGHT, 128);
+        DMESG("screen: %d x %d, off=%d,%d", width, height, offX, offY);
+        int sz = width * height;
+        width = doubleSize ? (width << 1) : width;
+        height = doubleSize ? (height << 1) : height;
         displayHeight = height;
         setAddrMain();
-        DMESG("screen: %d x %d, off=%d,%d", width, height, offX, offY);
-        int sz = doubleSize ? (width >> 1) * (height >> 1) : width * height;
         screenBuf = (uint8_t *)app_alloc(sz / 2 + 20);
 
         lastStatus = NULL;


### PR DESCRIPTION
I tried to follow the guide in following link to add a LCD using ILI9341(320x240).
https://arcade.makecode.com/hardware/adding

Specifically this:
```
DISPLAY_TYPE = 9341
DISPLAY_WIDTH = 320
DISPLAY_HEIGHT = 240
DISPLAY_CFG0 = 0x08
DISPLAY_CFG1 = 0x0010ff
DISPLAY_CFG2 = 50
```

But at first a `PANIC_GC_TOO_BIG_ALLOCATION` happened because the program entered following part:
https://github.com/microsoft/pxt-common-packages/blob/master/libs/base/gc.cpp#L719

This is because the image size is 320x240 and `numbytes` exceeds `GC_MAX_ALLOC_SIZE`, which is defined as 16k.
So I temporarily changed `GC_MAX_ALLOC_SIZE` to 64k and this panic didn't happen.

However, after that, `PANIC_SCREEN_ERROR` happens because the program entered following part:

https://github.com/microsoft/pxt-common-packages/blob/master/libs/screen---st7735/screen.cpp#L204

This is because both `img->width()` and `display->width` are 320, but `mult` is 2. The same situation for `img->height()` and `display->displayHeight`, both are 240.

Even if I skip this panic, the image buffer is the data for 320x240 resolution, so it is difficult to directly be used to `display->lcd->sendIndexedImage()`. Please refer this PR: https://github.com/lancaster-university/codal-core/pull/118

In order to solve this problem, I think one solution is doing two things:
1. The user set resolution to 160 and 120 rather than 320 and 240 in his/her pxt-target.
```
    const DISPLAY_TYPE = 9341
    const DISPLAY_WIDTH = 160
    const DISPLAY_HEIGHT = 120
```
2. Do modifications in this PR.
This commit is for doubling display's width and height if LCD type is ILI9341.

By doing this, we can keep `GC_MAX_ALLOC_SIZE` as 16k, the original value.

I have tested with both ILI9341 and ST7735 and are all working fine. I used "Set background image to" block.

