### PR TITLE
Remove pixel functions from base examples

### DIFF
--- a/libs/base/docs/reference/control/on-event.md
+++ b/libs/base/docs/reference/control/on-event.md
@@ -66,26 +66,25 @@ to your board. You could make it known to your program that any event that comes
 
 ## Example #example
 
-Register two events coming from source `22`. Make pixels light up on the pixel strip when
+Register two events coming from source `22`. Write to the console when
 the events of `0` and `1` are _raised_.
 
 ```blocks
-const pixelLighter = 22
-let pixels = light.createStrip()
+const myNotify = 22
 
-control.runInParallel(() => {
+control.runInParallel(function() {
     for (let i = 0; i < 2; i++) {
         pause(1000)
-    control.raiseEvent(pixelLighter, i)
+    control.raiseEvent(myNotify, i)
     }
 })
 
-control.onEvent(pixelLighter, 0, () => {
-    pixels.setPixelColor(0, 0xff0000)
+control.onEvent(myNotify, 0, () => {
+    console.logValue("myNotify", 0)
 })
 
-control.onEvent(pixelLighter, 1, () => {
-    pixels.setPixelColor(1, 0x0000ff)
+control.onEvent(myNotify, 1, () => {
+    console.logValue("myNotify", 1)
 })
 ```
 

--- a/libs/base/docs/reference/control/raise-event.md
+++ b/libs/base/docs/reference/control/raise-event.md
@@ -34,26 +34,25 @@ control.raiseEvent(51, 1)
 
 ## Example #example
 
-Register two events coming from source `22`. Make pixels light up on the pixel strip when
+Register two events coming from source `22`. Write to the console when
 the events of `0` and `1` are _raised_.
 
 ```blocks
-const pixelLighter = 22;
-let pixels = light.createStrip();
+const myNotify = 22;
 
-control.runInParallel(() => {
+control.runInParallel(function() {
     for (let i = 0; i < 2; i++) {
         pause(1000);
-        control.raiseEvent(pixelLighter, i);
+        control.raiseEvent(myNotify, i);
     }
 })
 
-control.onEvent(pixelLighter, 0, () => {
-    pixels.setPixelColor(0, 0xff0000);
+control.onEvent(myNotify, 0, () => {
+    console.logValue("myNotify", 0)
 })
 
-control.onEvent(pixelLighter, 1, () => {
-    pixels.setPixelColor(1, 0x0000ff);
+control.onEvent(myNotify, 1, () => {
+    console.logValue("myNotify", 1)
 })
 ```
 

--- a/libs/base/docs/reference/control/run-in-parallel.md
+++ b/libs/base/docs/reference/control/run-in-parallel.md
@@ -13,35 +13,42 @@ and you don't want to wait for some other actions to happen first.
 
 ## Separate tasks #tasks
 
-As an example, you could have a small task to rotate the pixel lights the pixel strip. This is
-placed inside a ``||control:run in parallel||`` block:
+As an example, you could have a small task to rotate a bit in a 16 character
+string of zeros. This is placed inside a ``||control:run in parallel||`` block:
 
 ```blocks
-let spinit = true;
-let pixels = light.createStrip();
+let bitPos = 0
+let rorit = true
+let zeros = ""
 
-control.runInParallel(() => {
-    while (spinit) {
-        pixels.move(LightMove.Rotate, 1);
-        pause(200);
+control.runInParallel(function() {
+    while (rorit) {
+        if (bitPos > 15) {
+            bitPos = 0
+        }
+        zeros = ""
+        for (let i = 0; i < 16; i++) {
+            if (bitPos == i) {
+                zeros = zeros + "1"
+            } else {
+                zeros = zeros + "0"
+            }
+        }
+        console.log(zeros)
+        pause(200)
     }
 })
 ```
 
-Code is added to the main part of the program to turn the pixels on. It turns on one pixel, waits
-for `5` seconds and turns on another pixel. Then, it waits for `5` more seconds and stops the rotate
-loop in the background task.
+Code is added to the main part of the program to turn the bit rotation on, pause for `5` seconds and then turn it off. It pauses for another `5` seconds and then trys to turn the bit rotation back on. However, the parallel task has finished and
+the bit rotation won't start again.
 
 ```blocks
-let spinit = true;
-let pixels = light.createStrip();
-
-pixels.setPixelColor(0, 0x0000ff);
-pause(5000);
-pixels.setPixelColor(0, 0x0000ff);
-pause(5000);
-spinit = false;
-pixels.clear();
+let rorit = true
+pause(5000)
+rorit = false
+pause(5000)
+rorit = true
 ```
 
 ## Parameters
@@ -50,34 +57,19 @@ pixels.clear();
 
 ## Example #example
 
-Automatically rotate lighted pixels as they are added to the pixel strip.
-
-**First**: As a background task, rotate the lighted pixels on the pixel strip.
-
-**Next**: In the main part of the program, slowly add a few more lights to the strip.
-
-**Finally**: When the `A` button is pressed, stop the rotate task and turn off all the all the pixels.
+Use a parallel task to generate a magic number. In the main program check the value of the magic number twice. The first time check the value right away. The
+second time, check `2` seconds later after the parallel task has time to run.
 
 ```blocks
-let spinit = false;
-let pixels = light.createStrip();
+let magic = 0
 
-input.buttonA.onEvent(ButtonEvent.Click, () => {
-    spinit = false;
-    pixels.clear();
-    control.runInParallel(() => {
-        pixels.setPixelColor(0, 0x0000ff);
-        while (spinit) {
-            pixels.move(LightMove.Rotate, 1);
-            pause(250);
-        }
-    })
+control.runInParallel(function() {
+    magic = Math.randomRange(1000, 5000) 
 })
-spinit = true;
-for (let i = 0; i < 5; i++) {
-    pause(1000);
-    pixels.setPixelColor(0, 0x0000ff);
-}
+
+console.logValue("magic", magic)
+pause(2000)
+console.logValue("magic", magic)
 ```
 
 ## #seealso

--- a/libs/base/docs/reference/control/wait-for-event.md
+++ b/libs/base/docs/reference/control/wait-for-event.md
@@ -21,7 +21,7 @@ events like this:
 const myTimer = 6;
 const timerTimeout = 1;
 
-control.runInParallel(() => {
+control.runInParallel(function() {
     while (true) {
         control.waitMicros(100000)
         control.raiseEvent(myTimer, timerTimeout)
@@ -38,24 +38,24 @@ control.waitForEvent(myTimer, timerTimeout)
 
 ## Example #example
 
-Make a timeout timer to signal every 2 seconds. Wait two times and light a pixel each time.
+Make a timeout timer to signal every 2 seconds. Wait two times and write to the
+console each time.
 
 ```blocks
 const myTimer = 6;
 const timerTimeout = 1;
-let pixels = light.createStrip();
 
-control.runInParallel(() => {
+control.runInParallel(function() {
     while (true) {
-        pause(2000);
-        control.raiseEvent(myTimer, timerTimeout);
+        pause(2000)
+        control.raiseEvent(myTimer, timerTimeout)
     }
 })
 
-control.waitForEvent(myTimer, timerTimeout);
-pixels.setPixelColor(0, 0xff0000);
-control.waitForEvent(myTimer, timerTimeout);
-pixels.setPixelColor(0, 0xffff00);
+control.waitForEvent(myTimer, timerTimeout)
+console.log("Timer timeout")
+control.waitForEvent(myTimer, timerTimeout)
+console.log("Timer timeout")
 ```
 
 ## See also #seealso

--- a/libs/base/docs/reference/loops/forever.md
+++ b/libs/base/docs/reference/loops/forever.md
@@ -17,19 +17,13 @@ loop is running. This includes other ``||loops:forever||`` loops and the [``||co
 
 ## Example #example
 
-Rotate a blue pixel along the pixel strip (one pixel at a time) and keep it rotating.
+Create an mood generator that writes a current mood to the console every `5` seconds.
 
 ```blocks
-let lightSpot = 0;
-let pixels = light.createStrip();
-forever(() => {
-    if (lightSpot == light.pixels.length()) {
-        lightSpot = 0;
-    }
-    pixels.setPixelColor(lightSpot, 0x0000ff);
-    pause(500);
-    pixels.setPixelColor(lightSpot, 0x000000);
-    lightSpot++;
+let mood = ["happy", "sad", "joyful", "angry"]
+forever(function () {
+    console.log("mood = " + mood[Math.randomRange(0, 3)])
+    pause(5000)
 })
 ```
 

--- a/libs/base/docs/reference/loops/pause.md
+++ b/libs/base/docs/reference/loops/pause.md
@@ -16,12 +16,11 @@ block is waiting at a ``||control:pause||``.
 
 ## Example #example
 
-Light up to `5` pixels but wait one-half second before lighting each pixel.
+Write the first five natural numbers to the console but wait one-half second between each write.
 
 ```blocks
-let pixels = light.createStrip();
 for (let i = 0; i < 5; i++) {
-    pixels.setPixelColor(i, 0x00ff00)
+    console.logValue("naturals", i + 1)
     pause(500)
 }
 ```


### PR DESCRIPTION
Not all targets include "light" pixel support. Make the examples in the base reference more generic.