### PR TITLE
align c++ parsefloat with js

### DIFF
--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -561,7 +561,7 @@ int length(String s) {
 }
 
 #define isspace(c) ((c) == ' ')
-#define iswhitespace(c) ((c) == 0x0009 || (c) == 0x000B || (c) == 0x000C || (c) == 0x0020 || (c) == 0x00A0 || (c) == 0xFEFF || (c) == 0x000A || (c) == 0x000D || (c) == 0x2028 || (c) == 0x2029)
+#define iswhitespace(c) ((c) == 0x09 || (c) == 0x0B || (c) == 0x0C || (c) == 0x20 || (c) == 0xA0 || (c) == 0x0A || (c) == 0x0D)
 
 NUMBER mystrtod(const char *p, char **endp) {
     while (iswhitespace(*p))
@@ -600,11 +600,7 @@ NUMBER mystrtod(const char *p, char **endp) {
     if (*p == 'e' || *p == 'E') {
         p++;
         int pw = (int)strtol(p, endp, 10);
-        if (!isnan(pw)) {
-            v *= p10(pw);
-        } else {
-            *endp = (char *)p;
-        }
+        v *= p10(pw);
     } else {
         *endp = (char *)p;
     }

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -569,6 +569,7 @@ NUMBER mystrtod(const char *p, char **endp) {
     NUMBER m = 1;
     NUMBER v = 0;
     int dot = 0;
+    int hasDigit = 0;
     if (*p == '+')
         p++;
     if (*p == '-') {
@@ -585,8 +586,11 @@ NUMBER mystrtod(const char *p, char **endp) {
             v += c;
             if (dot)
                 m /= 10;
+            hasDigit = 1;
         } else if (!dot && *p == '.') {
             dot = 1;
+        } else if (!hasDigit) {
+            return NAN;
         } else {
             break;
         }

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -576,9 +576,7 @@ NUMBER mystrtod(const char *p, char **endp) {
         m = -1;
         p++;
     }
-    if (*p == '0' && (p[1] | 0x20) == 'x') {
-        return m * strtol(p, endp, 16);
-    }
+
     while (*p) {
         int c = *p - '0';
         if (0 <= c && c <= 9) {


### PR DESCRIPTION
along with https://github.com/microsoft/pxt/pull/6825 fix https://github.com/microsoft/pxt-microbit/issues/2664

fix some parsefloat mismatches with js; allow any whitespace chars (not just spaces), return value up to given point if values after first digit are non-numeric (`1f` => 1, `f1` => NaN), handle trailing e that is not followed by a number (`1ef` => 1), don't ignore spaces after first digit (`123 456` => 123). Also drop auto conversion to hex for parsefloat (js doesn't) (this makes the change require https://github.com/microsoft/pxt/pull/6825 or equivalent to keep hex parsing in parseInt)

isspace was used in a decent number of other places so I left it as is and added one to check if character is whitespace; can check if the other places should actually be checking for any whitespace