### PR TITLE
cleanup keyboard implementation

### DIFF
--- a/libs/keyboard/keyboard.cpp
+++ b/libs/keyboard/keyboard.cpp
@@ -13,6 +13,11 @@ enum class KeyboardKeyEvent {
 };
 
 namespace keyboard {
+    //%
+    void __flush() {
+        pxt::keyboard.flush();
+    }
+
     //% 
     void __type(String text) {
         if (NULL != text)

--- a/libs/keyboard/shims.d.ts
+++ b/libs/keyboard/shims.d.ts
@@ -1,5 +1,7 @@
 // Auto-generated. Do not edit.
 declare namespace keyboard {
+    //% shim=keyboard::__flush hidden=1
+    function __flush(): void;
 
     //% shim=keyboard::__type hidden=1
     function __type(text: string): void;

--- a/libs/keyboard/sim/keyboard.ts
+++ b/libs/keyboard/sim/keyboard.ts
@@ -4,6 +4,11 @@ namespace pxsim.keyboard {
         "up",
         "down"
     ]
+
+    export function __flush() {
+        console.log(`kb: flush`)
+    }
+
     export function __type(s: string) {
         console.log(`kb: type ${s}`);
     }

--- a/libs/microphone/test.ts
+++ b/libs/microphone/test.ts
@@ -1,7 +1,1 @@
-forever(() => {
-    let level = input.soundLevel()
-    console.logValue("sound", level)
-})
-input.onLoudSound(() => {
-    console.log("loud")
-})
+// tests


### PR DESCRIPTION
- [x] Don't track keys in ts, it is done in C++.
- [x] call C++ flush to clear all keys

This also requires a fix in codal https://github.com/lancaster-university/codal-core/commit/281838f68737771482638a480f02a8b11dc5167f