### PR TITLE
apply first frame of animation immediately

### DIFF
--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -425,7 +425,7 @@ namespace animation {
                 game.eventContext().registerFrameHandler(scene.ANIMATION_UPDATE_PRIORITY, () => {
                     state.animations = state.animations.filter((anim: SpriteAnimation) => {
                         if (this.sprite.flags & sprites.Flag.Destroyed)
-                            return true;
+                            return false;
                         return !anim.update(); // If update returns true, the animation is done and will be removed
                     });
                 });


### PR DESCRIPTION
fix issue we ran into on stream today; the animation does not apply until the first interval has passed, so it's always delayed when using with walking animations / etc. This makes it so the leading is frame is shown immediately

e.g. fixes https://makecode.com/_6aPCLTH8DJCz so that the pink circle immediately shows up when you press A, rather than after 500ms
