### PR TITLE
serial enum fix

### DIFF
--- a/libs/serial/enums.d.ts
+++ b/libs/serial/enums.d.ts
@@ -1,7 +1,7 @@
 // Auto-generated. Do not edit.
 
 
-    declare const enum BaudRate {
+declare const enum BaudRate {
     //% block=115200
     BaudRate115200 = 115200,
     //% block=57600
@@ -26,14 +26,40 @@
     BaudRate1200 = 1200,
     //% block=300
     BaudRate300 = 300,
-    }
+}
 
 
-    declare const enum SerialEvent {
+declare const enum SerialEvent {
     //% block="data received"
     DataReceived = 4,  // CODAL_SERIAL_EVT_DATA_RECEIVED
     //% block="rx buffer full"
     RxBufferFull = 3,  // CODAL_SERIAL_EVT_RX_FULL
-    }
+}
+
+
+declare const enum Delimiters {
+    //% block="new line (\n)"
+    NewLine = 10,
+    //% block=","
+    Comma = 44,
+    //% block="$"
+    Dollar = 36,
+    //% block=":"
+    Colon = 58,
+    //% block="."
+    Fullstop = 46,
+    //% block="#"
+    Hash = 35,
+    //% block="carriage return (\r)"
+    CarriageReturn = 13,
+    //% block="space"
+    Space = 32,
+    //% block="tab (\t)"
+    Tab = 9,
+    //% block="|"
+    Pipe = 124,
+    //% block=";"
+    SemiColon = 59,
+}
 
 // Auto-generated. Do not edit. Really.

--- a/libs/serial/serial-common.h
+++ b/libs/serial/serial-common.h
@@ -36,7 +36,7 @@ enum class SerialEvent {
     RxBufferFull = CODAL_SERIAL_EVT_RX_FULL
 };
 
-enum Delimiters {
+enum class Delimiters {
     //% block="new line (\n)"
     NewLine = 10,
     //% block=","

--- a/libs/serial/serial-common.h
+++ b/libs/serial/serial-common.h
@@ -36,26 +36,28 @@ enum class SerialEvent {
     RxBufferFull = CODAL_SERIAL_EVT_RX_FULL
 };
 
-enum class Delimiters {
-    //% block="new line"
-    NewLine = 10, //'\n',
+enum Delimiters {
+    //% block="new line (\n)"
+    NewLine = 10,
     //% block=","
-    Comma = 44, //',',
+    Comma = 44,
     //% block="$"
-    Dollar = 36, // '$',
+    Dollar = 36,
     //% block=":"
-    Colon = 58, // ':',
+    Colon = 58,
     //% block="."
-    Fullstop = 46, //'.',
+    Fullstop = 46,
     //% block="#"
-    Hash = 35, //'#',
-    //% block=";"
-    SemiColumn = 59,
-    //% block="space",
+    Hash = 35,
+    //% block="carriage return (\r)"
+    CarriageReturn = 13,
+    //% block="space"
     Space = 32,
-    //% block="tab"
-    Tab = 9, //'\t'
-    //% block="pipe"
-    Pipe = 124 // `|`,
+    //% block="tab (\t)"
+    Tab = 9,
+    //% block="|"
+    Pipe = 124,
+    //% block=";"
+    SemiColon = 59,
 };
 

--- a/libs/serial/serial.ts
+++ b/libs/serial/serial.ts
@@ -1,28 +1,3 @@
-const enum Delimiters {
-    //% block="new line (\n)"
-    NewLine = 10,
-    //% block=","
-    Comma = 44,
-    //% block="$"
-    Dollar = 36,
-    //% block=":"
-    Colon = 58,
-    //% block="."
-    Fullstop = 46,
-    //% block="#"
-    Hash = 35,
-    //% block="carriage return (\r)"
-    CarriageReturn = 13,
-    //% block="space"
-    Space = 32,
-    //% block="tab (\t)"
-    Tab = 9,
-    //% block="|"
-    Pipe = 124,
-    //% block=";"
-    SemiColon = 59,
-}
-
 /**
  * Reading and writing data over a serial connection.
  */


### PR DESCRIPTION
The previous fix did take into account that a Delimiters enum was already in C++.