### PR TITLE
tile overlaps should handle overlaps not in the direction of movement

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -372,6 +372,8 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             s._lastY
         );
 
+        const overlappedTiles: tiles.Location[] = [];
+
         if (xDiff !== Fx.zeroFx8) {
             const right = xDiff > Fx.zeroFx8;
             const x0 = Fx.toIntShifted(
@@ -385,7 +387,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 tileScale
             );
             const collidedTiles: sprites.StaticObstacle[] = [];
-            const overlappedTiles: tiles.Location[] = [];
 
             // check collisions with tiles sprite is moving towards horizontally
             for (
@@ -454,8 +455,6 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     // but still facing same direction; prevent further movement this update.
                     movingSprite.dx = Fx.zeroFx8;
                 }
-            } else if (overlappedTiles.length) {
-                this.tilemapOverlaps(s, overlappedTiles);
             }
         }
 
@@ -538,9 +537,50 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     // but still facing same direction; prevent further movement this update.
                     movingSprite.dy = Fx.zeroFx8;
                 }
-            } else if (overlappedTiles.length) {
-                this.tilemapOverlaps(s, overlappedTiles);
             }
+        }
+
+        // Now that we've moved, check all of the tiles underneath the current position
+        // for overlaps
+        for (
+            let x = hbox.left;
+            x < Fx.iadd(tileSize, hbox.right);
+            x = Fx.iadd(tileSize, x)
+        ) {
+            const x0 = Fx.toIntShifted(
+                Fx.add(
+                    Fx.min(
+                        x,
+                        hbox.right
+                    ),
+                    Fx.oneHalfFx8
+                ),
+                tileScale
+            );
+            for (
+                let y = hbox.top;
+                y < Fx.iadd(tileSize, hbox.bottom);
+                y = Fx.iadd(tileSize, y)
+            ) {
+                const y0 = Fx.toIntShifted(
+                    Fx.add(
+                        Fx.min(
+                            y,
+                            hbox.bottom
+                        ),
+                        Fx.oneHalfFx8
+                    ),
+                    tileScale
+                );
+
+                if (!tm.isObstacle(x0, y0)) {
+                    overlappedTiles.push(tm.getTile(x0, y0));
+                }
+            }
+        }
+
+        if (overlappedTiles.length) {
+            this.tilemapOverlaps(s, overlappedTiles);
         }
     }
 
@@ -551,7 +591,14 @@ class ArcadePhysicsEngine extends PhysicsEngine {
      * @param overlappedTiles the list of tiles the sprite is overlapping
      */
     private tilemapOverlaps(sprite: Sprite, overlappedTiles: tiles.Location[]) {
+        const alreadyHandled: tiles.Location[] = [];
+
         for (const tile of overlappedTiles) {
+            if (alreadyHandled.some(l => l.col === tile.col && l.row === tile.row)) {
+                continue;
+            }
+            alreadyHandled.push(tile);
+
             const tileOverlapHandlers = game.currentScene().tileOverlapHandlers;
             if (tileOverlapHandlers) {
                 tileOverlapHandlers

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -17,6 +17,14 @@ namespace tiles {
         protected _col: number;
         protected tileMap: TileMap;
 
+        get col() {
+            return this._col;
+        }
+
+        get row() {
+            return this._row;
+        }
+
         constructor(col: number, row: number, map: TileMap) {
             this._col = col;
             this._row = row;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1772

Here is a test program that demonstrates the bug:

https://makecode.com/_D497oY0yViu2

The fish should hit the red orb, teleport to the green orb, and then instantly teleport to the top-right corner. I'll check this program into arcade once this is merged and bumped.
