### PR TITLE
Add dropdown block for camera properties

### DIFF
--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -44,6 +44,12 @@ namespace scene {
             }
         }
 
+        get x() {
+            return this.drawOffsetX + (screen.width >> 1);
+        }
+        get y() {
+            return this.drawOffsetY + (screen.height >> 1);
+        }
         get left() {
             return this.drawOffsetX;
         }

--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -44,6 +44,19 @@ namespace scene {
             }
         }
 
+        get left() {
+            return this.drawOffsetX;
+        }
+        get right() {
+            return this.drawOffsetX + screen.width;
+        }
+        get top() {
+            return this.drawOffsetY;
+        }
+        get bottom() {
+            return this.drawOffsetY + screen.height;
+        }
+
         shake(amplitude: number = 4, duration: number = 1000) {
             if (amplitude <= 0 || duration <= 0) {
                 this.shakeStartTime = undefined;

--- a/libs/game/docs/reference/scene/camera-left.md
+++ b/libs/game/docs/reference/scene/camera-left.md
@@ -10,4 +10,4 @@ scene.cameraLeft()
 
 [camera follow sprite](/reference/scene/camera-follow-sprite)
 [center camera at](/reference/scene/center-camera-at)
-[get camera property](/reference/scene/get-camera-property)
+[camera property](/reference/scene/camera-property)

--- a/libs/game/docs/reference/scene/camera-left.md
+++ b/libs/game/docs/reference/scene/camera-left.md
@@ -1,4 +1,4 @@
-# camera left
+# camera left **deprecated**
 
 Returns the x coordinate of the camera (the left side of the screen).
 
@@ -10,4 +10,4 @@ scene.cameraLeft()
 
 [camera follow sprite](/reference/scene/camera-follow-sprite)
 [center camera at](/reference/scene/center-camera-at)
-[camera left](/reference/scene/camera-left)
+[get camera property](/reference/scene/get-camera-property)

--- a/libs/game/docs/reference/scene/camera-property.md
+++ b/libs/game/docs/reference/scene/camera-property.md
@@ -1,18 +1,26 @@
-# Get Camera Property
+# Camera Property
 
-Returns a property of the camera: `left`, `right`, `top` or `bottom`.
+Returns a property of the camera.
 
 ```sig
-scene.getCameraProperty(CameraProperty.left)
+scene.cameraProperty(CameraProperty.Left)
 ```
 
 ## Example
 
 ```blocks
-let top = scene.getCameraProperty(CameraProperty.top)
+let top = scene.cameraProperty(CameraProperty.Top)
 ```
 
 ## Properties
+
+### x
+
+Returns the x-axis screen coordinate of the camera's center.
+
+### y
+
+Returns the y-axis screen coordinate of the camera's center.
 
 ### left
 

--- a/libs/game/docs/reference/scene/camera-top.md
+++ b/libs/game/docs/reference/scene/camera-top.md
@@ -10,4 +10,4 @@ scene.cameraTop()
 
 [camera follow sprite](/reference/scene/camera-follow-sprite)
 [center camera at](/reference/scene/center-camera-at)
-[get camera property](/reference/scene/get-camera-property)
+[camera property](/reference/scene/camera-property)

--- a/libs/game/docs/reference/scene/camera-top.md
+++ b/libs/game/docs/reference/scene/camera-top.md
@@ -1,4 +1,4 @@
-# camera top
+# camera top **deprecated**
 
 Returns the y coordinate of the camera (the top of the screen).
 
@@ -10,4 +10,4 @@ scene.cameraTop()
 
 [camera follow sprite](/reference/scene/camera-follow-sprite)
 [center camera at](/reference/scene/center-camera-at)
-[camera top](/reference/scene/camera-top)
+[get camera property](/reference/scene/get-camera-property)

--- a/libs/game/docs/reference/scene/get-camera-property.md
+++ b/libs/game/docs/reference/scene/get-camera-property.md
@@ -1,0 +1,36 @@
+# Get Camera Property
+
+Returns a property of the camera: `left`, `right`, `top` or `bottom`.
+
+```sig
+scene.getCameraProperty(CameraProperty.left)
+```
+
+## Example
+
+```blocks
+let top = scene.getCameraProperty(CameraProperty.top)
+```
+
+## Properties
+
+### left
+
+Returns the x-axis screen coordinate of the camera's left edge.
+
+### right
+
+Returns the x-axis screen coordinate of the camera's right edge.
+
+### top
+
+Returns the y-axis screen coordinate of the camera's top edge.
+
+### bottom
+
+Returns the y-axis screen coordinate of the camera's bottom edge.
+
+## See also #seealso
+
+[camera follow sprite](/reference/scene/camera-follow-sprite)
+[center camera at](/reference/scene/center-camera-at)

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -1,6 +1,14 @@
 /**
  * Control the background, tiles and camera
  */
+
+enum CameraProperty {
+    left,
+    right,
+    top,
+    bottom
+}
+
 //% weight=88 color="#4b6584" icon="\uf1bb"
 //% groups='["Screen", "Effects", "Tiles", "Collisions", "Camera"]'
 //% blockGap=8
@@ -149,6 +157,7 @@ namespace scene {
     //% blockId=cameraleft block="camera left"
     //% group="Camera"
     //% help=scene/camera-left
+    //% deprecated=true
     export function cameraLeft() {
         const scene = game.currentScene();
         return scene.camera.drawOffsetX;
@@ -160,8 +169,27 @@ namespace scene {
     //% blockId=cameratop block="camera top"
     //% group="Camera"
     //% help=scene/camera-top
+    //% deprecated=true
     export function cameraTop() {
         const scene = game.currentScene();
         return scene.camera.drawOffsetY;
+    }
+
+    /**
+     * Returns the specified camera property
+     * @param property The property to get
+     */
+    //% blockId=getcameraproperty block="camera %property"
+    //% group="Camera"
+    //% field.defl=0
+    //% help=scene/get-camera-property
+    export function getCameraProperty(property: CameraProperty) {
+        const scene = game.currentScene();
+        switch (property) {
+            case CameraProperty.left: return scene.camera.left
+            case CameraProperty.right: return scene.camera.right;
+            case CameraProperty.top: return scene.camera.top;
+            case CameraProperty.bottom: return scene.camera.bottom;
+        }
     }
 }

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -3,10 +3,18 @@
  */
 
 enum CameraProperty {
-    left,
-    right,
-    top,
-    bottom
+    //% block="x"
+    X,
+    //% block="y"
+    Y,
+    //% block="left"
+    Left,
+    //% block="right"
+    Right,
+    //% block="top"
+    Top,
+    //% block="bottom"
+    Bottom
 }
 
 //% weight=88 color="#4b6584" icon="\uf1bb"
@@ -179,17 +187,18 @@ namespace scene {
      * Returns the specified camera property
      * @param property The property to get
      */
-    //% blockId=getcameraproperty block="camera %property"
+    //% blockId=cameraproperty block="camera $property"
     //% group="Camera"
-    //% field.defl=0
-    //% help=scene/get-camera-property
-    export function getCameraProperty(property: CameraProperty) {
+    //% help=scene/camera-property
+    export function cameraProperty(property: CameraProperty): number {
         const scene = game.currentScene();
         switch (property) {
-            case CameraProperty.left: return scene.camera.left
-            case CameraProperty.right: return scene.camera.right;
-            case CameraProperty.top: return scene.camera.top;
-            case CameraProperty.bottom: return scene.camera.bottom;
+            case CameraProperty.X: return scene.camera.x;
+            case CameraProperty.Y: return scene.camera.y;
+            case CameraProperty.Left: return scene.camera.left;
+            case CameraProperty.Right: return scene.camera.right;
+            case CameraProperty.Top: return scene.camera.top;
+            case CameraProperty.Bottom: return scene.camera.bottom;
         }
     }
 }


### PR DESCRIPTION
Original description:
> camera-right: Returns the x coordinate of the camera's right edge (right edge of the screen).
> camera-bottom: Returns the y coordinate of the camera's bottom edge (bottom edge of the screen).

New description:

Added a new block to get camera properties: `left`, `top`, `right`, `bottom`. Deprecated corresponding `camera-left` and `camera-top` blocks.

Resolves https://github.com/microsoft/pxt-arcade/issues/1836