### PR TITLE
check that sprite can collide before running async on overlap handler

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -335,10 +335,12 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         .forEach(h => {
                             higher._overlappers.push(lower.id);
                             control.runInParallel(() => {
-                                h.handler(
-                                    thisKind === h.kind ? sprite : overlapper,
-                                    thisKind === h.kind ? overlapper : sprite
-                                );
+                                if (!((sprite.flags | overlapper.flags) & SPRITE_CANNOT_COLLIDE)) {
+                                    h.handler(
+                                        thisKind === h.kind ? sprite : overlapper,
+                                        thisKind === h.kind ? overlapper : sprite
+                                    );
+                                }
                                 higher._overlappers.removeElement(lower.id);
                             });
                         });


### PR DESCRIPTION
re: https://forum.makecode.com/t/ghost-flag-not-sync-between-multiple-simultaneous-overlap-event-fire/2459

In the game https://makecode.com/_6Yd0KYLcoRJV , if you press `a` twice to spawn two enemies and then press `b` to place the sprite on top of them you can see the issue; the overlap event sets the sprite to be a ghost, so that you get some invincibility frames, but it doesn't work here because the overlap events are spawned synchronously but they run asynchronously, and the two sprites both overlap within the same frame.

This makes it bail out before the handler if a previous event has changed the state of one of the sprites such that the overlap is now invalid (i.e. sprite is now destroyed or a ghost).