### PR TITLE
Add block to get tile from screen coords

### DIFF
--- a/libs/game/docs/reference/tiles/get-tile-location-from-screen.md
+++ b/libs/game/docs/reference/tiles/get-tile-location-from-screen.md
@@ -1,0 +1,96 @@
+# get Tile Location From Screen
+
+Get a tile location from a pair of screen coordinates.
+
+```sig
+tiles.getTileLocationFromScreen(0, 0)
+```
+
+## Parameters
+
+* **x**: the x coordinate in screen coordinates.
+* **y**: the y coordinate in screen coordinates.
+
+## Returns
+
+* a [tile](/types/tile) from the mapped location in the tilemap.
+
+## Example #example
+
+Modify the tilemap. Replace the tile underneath the player's sprite.
+
+```blocks
+namespace myTiles {
+    //% blockIdentity=images._tile
+    export const tile0 = img`
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+`
+}
+tiles.setTilemap(tiles.createTilemap(
+            hex`1000100003030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303`,
+            img`
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+. . . . . . . . . . . . . . . . 
+`,
+            [myTiles.tile0,sprites.castle.tileGrass2,sprites.castle.tileGrass1,sprites.castle.tilePath5],
+            TileScale.Sixteen
+        ))
+let mySprite = sprites.create(img`
+. . . . . . f f f f . . . . . . 
+. . . . f f f 2 2 f f f . . . . 
+. . . f f f 2 2 2 2 f f f . . . 
+. . f f f e e e e e e f f f . . 
+. . f f e 2 2 2 2 2 2 e e f . . 
+. . f e 2 f f f f f f 2 e f . . 
+. . f f f f e e e e f f f f . . 
+. f f e f b f 4 4 f b f e f f . 
+. f e e 4 1 f d d f 1 4 e e f . 
+. . f e e d d d d d d e e f . . 
+. . . f e e 4 4 4 4 e e f . . . 
+. . e 4 f 2 2 2 2 2 2 f 4 e . . 
+. . 4 d f 2 2 2 2 2 2 f d 4 . . 
+. . 4 4 f 4 4 5 5 4 4 f 4 4 . . 
+. . . . . f f f f f f . . . . . 
+. . . . . f f . . f f . . . . . 
+`, SpriteKind.Player)
+controller.moveSprite(mySprite)
+scene.cameraFollowSprite(mySprite)
+game.onUpdate(function () {
+    tiles.setTileAt(tiles.getTileLocationFromScreen(mySprite.x, mySprite.y), sprites.food.smallBurger)
+})
+```
+
+## See also #seealso
+
+[get tiles by type](/reference/tiles/get-tiles-by-type),
+[set tile at](/reference/tiles/set-tile-at),
+[get tile location](/reference/get-tile-location)

--- a/libs/game/docs/reference/tiles/get-tile-location.md
+++ b/libs/game/docs/reference/tiles/get-tile-location.md
@@ -48,4 +48,5 @@ tiles.setTileAt(tiles.getTileLocation(5, 3), image)
 ## See also #seealso
 
 [get tiles by type](/reference/tiles/get-tiles-by-type),
-[set tile at](/reference/tiles/set-tile-at)
+[set tile at](/reference/tiles/set-tile-at),
+[get tile location from screen](/reference/get-tile-location-from-screen)

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -482,6 +482,23 @@ namespace tiles {
     }
 
     /**
+     * Get the tile position given a pair of screen coordinates
+     * @param x
+     * @param y
+     */
+    //% blockId=mapgettilefromscreen block="tilemap x $x y $y"
+    //% blockNamespace="scene" group="Tiles"
+    //% weight=25 blockGap=8
+    //% help=tiles/get-tile-location-from-screen
+    export function getTileLocationFromScreen(x: number, y: number): Location {
+        const scene = game.currentScene();
+        if (!scene.tileMap) return null;
+        const col = x >> scene.tileMap.scale;
+        const row = y >> scene.tileMap.scale;
+        return scene.tileMap.getTile(col, row);
+    }
+
+    /**
      * Get the image of a tile, given a location in the tilemap
      * @param loc
      */


### PR DESCRIPTION
Resolves https://github.com/microsoft/pxt-arcade/issues/1983 (if consensus is this is a good solution).

Adds a block to get a tile from screen coords:

![image](https://user-images.githubusercontent.com/12176807/85100047-f1126b80-b1b3-11ea-8128-52851133b285.png)

Erring on the side of too many reviewers to get feedback on whether a new block is the best solution here.