### PR TITLE
stop sprite when sprite following is invalidated

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -901,6 +901,8 @@ class Sprite extends sprites.BaseSprite {
                     // one of the involved sprites has been destroyed,
                     // so exit and remove that in the cleanup step
                     if ((self.flags | target.flags) & sprites.Flag.Destroyed) {
+                        self.vx = 0;
+                        self.vy = 0;
                         destroyedSprites = true;
                         return;
                     }
@@ -945,6 +947,8 @@ class Sprite extends sprites.BaseSprite {
         if (!target || !speed) {
             if (fs) {
                 sc.followingSprites.removeElement(fs);
+                this.vx = 0;
+                this.vy = 0;
             }
         } else if (!fs) {
             sc.followingSprites.push(new sprites.FollowingSprite(


### PR DESCRIPTION
fix issue where you end a follow and the sprite keeps moving with it's last 'momentum'; e.g. https://makecode.com/_7fvLjU4hD7ri