### PR TITLE
Adjust sprite say bubble position after update

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -533,6 +533,10 @@ class Sprite extends sprites.BaseSprite {
         }
         this.sayBubbleSprite.data[SAYKEY] = key;
         this.updateSay = (dt, camera) => {
+            // The minus 2 is how much transparent padding there is under the sayBubbleSprite
+            this.sayBubbleSprite.y = this.top + bubbleOffset - ((font.charHeight + bubblePadding) >> 1) - 2;
+            this.sayBubbleSprite.x = this.x;
+
             // Update box stuff as long as timeOnScreen doesn't exist or it can still be on the screen
             if (!timeOnScreen || timeOnScreen > currentScene.millis()) {
                 // move bubble
@@ -573,10 +577,6 @@ class Sprite extends sprites.BaseSprite {
                         holdTextSeconds = maxTextWidth / speed;
                     }
                 }
-
-                // The minus 2 is how much transparent padding there is under the sayBubbleSprite
-                this.sayBubbleSprite.y = this.top + bubbleOffset - ((font.charHeight + bubblePadding) >> 1) - 2;
-                this.sayBubbleSprite.x = this.x;
 
                 if (needsRedraw) {
                     needsRedraw = false;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/1714

![854e50d6-f0fd-439c-9aaa-6e7980008e8e](https://user-images.githubusercontent.com/18712271/86189156-9c48ec00-baf5-11ea-9849-a840fabee130.gif)


Update the x and y first, and correct the position afterwards