### PR TITLE
fix animations 'sprite destroyed' check

### DIFF
--- a/libs/animation/animation.ts
+++ b/libs/animation/animation.ts
@@ -424,7 +424,7 @@ namespace animation {
 
                 game.eventContext().registerFrameHandler(scene.ANIMATION_UPDATE_PRIORITY, () => {
                     state.animations = state.animations.filter((anim: SpriteAnimation) => {
-                        if (this.sprite.flags & sprites.Flag.Destroyed)
+                        if (anim.sprite.flags & sprites.Flag.Destroyed)
                             return false;
                         return !anim.update(); // If update returns true, the animation is done and will be removed
                     });


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2033
fix https://github.com/microsoft/pxt-arcade/issues/2052

I didn't look for the pr, but if I remember right I broke this a while ago while fixing another bug, oops :(

(issue is that the ev handler was checking destroyed state based off the sprite the first animation was init'd with, not the sprite attached to the animation)