### PR TITLE
Expose isStatic on RefImages, recalculate sprite hitbox for non-static images

### DIFF
--- a/libs/color-coded-tilemap/tilemap.ts
+++ b/libs/color-coded-tilemap/tilemap.ts
@@ -379,6 +379,7 @@ namespace tiles.legacy {
         }
 
         public isOnWall(s: Sprite) {
+            if (!s.isStatic()) s.setHitbox();
             const hbox = s._hitbox
 
             const left = Fx.toIntShifted(hbox.left, this.scale);

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -360,6 +360,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 s.flags &= ~sprites.Flag.IsClipping;
             }
         }
+        if (!s.isStatic()) s.setHitbox();
         const hbox = s._hitbox;
         const tileScale = tm.scale;
         const tileSize = 1 << tileScale;
@@ -610,6 +611,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
     // Attempt to resolve clipping by moving the sprite slightly up / down / left / right
     protected canResolveClipping(s: Sprite, tm: tiles.TileMap) {
+        if (!s.isStatic()) s.setHitbox();
         const hbox = s._hitbox;
         const sz = 1 << tm.scale;
         const maxMove = this.maxStep;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -293,6 +293,14 @@ class Sprite extends sprites.BaseSprite {
         }
     }
 
+    setHitbox() {
+        this._hitbox = game.calculateHitBox(this);
+    }
+
+    isStatic() {
+        return this._image.isStatic();
+    }
+
     __visible() {
         return !(this.flags & SpriteFlag.Invisible);
     }

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -140,6 +140,11 @@ bool isMono(Image_ img) {
     return img->bpp() == 1;
 }
 
+//% property
+bool isStatic(Image_ img) {
+    return img->buffer->isReadOnly();
+}
+
 /**
  * Sets all pixels in the current image from the other image, which has to be of the same size and
  * bpp.

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -99,6 +99,9 @@ interface Image {
      */
     //% shim=ImageMethods::equals
     equals(other: Image): boolean;
+
+    //% shim=ImageMethods::isStatic
+    isStatic(): boolean;
 }
 
 declare namespace image {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -4,8 +4,7 @@ namespace pxsim {
         _height: number;
         _bpp: number;
         data: Uint8Array;
-        dirty = true
-        isStatic = false
+        isStatic = true;
 
         constructor(w: number, h: number, bpp: number) {
             super();
@@ -49,7 +48,7 @@ namespace pxsim {
         }
 
         makeWritable() {
-            this.dirty = true
+            this.isStatic = false
         }
 
         toDebugString() {
@@ -67,6 +66,8 @@ namespace pxsim.ImageMethods {
     export function height(img: RefImage) { return img._height }
 
     export function isMono(img: RefImage) { return img._bpp == 1 }
+
+    export function isStatic(img: RefImage) { return img.gcIsStatic() }
 
     export function setPixel(img: RefImage, x: number, y: number, c: number) {
         img.makeWritable()

--- a/libs/screen/sim/state.ts
+++ b/libs/screen/sim/state.ts
@@ -92,16 +92,8 @@ namespace pxsim {
             }
 
             this.lastImageFlushTime = Date.now()
-
-            if (img == this.lastImage) {
-                if (!img.dirty)
-                    return
-            } else {
-                this.lastImage = img
-            }
-
+            this.lastImage = img
             this.changed = true
-            img.dirty = false
 
             const src = img.data
             const dst = this.screen


### PR DESCRIPTION
Also removes the "dirty" property and always renders the screen image.

Build: https://arcade.makecode.com/app/7379a2aa01b069ee05aa1e1746df57004002823b-4be123dca1
Test program: https://makecode.com/_UftW2pLMt41k

Fixes https://github.com/microsoft/pxt-arcade/issues/1892