### PR TITLE
Convert to floats for sprite properties

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -69,7 +69,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x" callInDebugger
     get x(): number {
-        return Fx.toInt(this._x) + (this._image.width >> 1)
+        return Fx.toFloat(this._x) + (this._image.width >> 1)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x"
@@ -80,7 +80,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y" callInDebugger
     get y(): number {
-        return Fx.toInt(this._y) + (this._image.height >> 1)
+        return Fx.toFloat(this._y) + (this._image.height >> 1)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y"
@@ -311,7 +311,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="left"
     get left() {
-        return Fx.toInt(this._x)
+        return Fx.toFloat(this._x)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="left"
@@ -341,7 +341,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="top"
     get top() {
-        return Fx.toInt(this._y);
+        return Fx.toFloat(this._y);
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="top"

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -69,7 +69,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x" callInDebugger
     get x(): number {
-        return Fx.toFloat(this._x) + (this._image.width >> 1)
+        return Fx.toFloat(this._x) + (this._image.width / 2)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x"
@@ -80,7 +80,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y" callInDebugger
     get y(): number {
-        return Fx.toFloat(this._y) + (this._image.height >> 1)
+        return Fx.toFloat(this._y) + (this._image.height / 2)
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y"


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/1702

Return floats, not ints!