### PR TITLE
allow console logValue to take any for value param

### DIFF
--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -63,7 +63,7 @@ namespace console {
     /**
      * Write a name:value pair as a line of text to the console output.
      * @param name name of the value stream, eg: "x"
-     * @param value to write, eg: 0
+     * @param value to write
      */
     //% weight=88 blockGap=8
     //% help=console/log-value

--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -63,14 +63,15 @@ namespace console {
     /**
      * Write a name:value pair as a line of text to the console output.
      * @param name name of the value stream, eg: "x"
-     * @param value to write
+     * @param value to write, eg: 0
      */
     //% weight=88 blockGap=8
     //% help=console/log-value
     //% blockId=console_log_value block="console|log value %name|= %value"
     //% name.shadow=text
-    export function logValue(name: any, value: number): void {
-        log(name ? `${inspect(name)}: ${value}` : `${value}`)
+    //% value.shadow=math_number
+    export function logValue(name: any, value: any): void {
+        log(name ? `${inspect(name)}: ${inspect(value)}` : `${inspect(value)}`)
     }
 
     /**


### PR DESCRIPTION
re: https://forum.makecode.com/t/debug-function-in-arcade-game/2750/3?u=jwunderl, it's confusing that `console.log` takes any but `console.logValue` only takes numbers for the `value` field. Block still looks the same, but now you can drop whatever you want in each slot:

![image](https://user-images.githubusercontent.com/5615930/87255246-db543700-c43d-11ea-86eb-cd3d2fd84d6c.png)

![image](https://user-images.githubusercontent.com/5615930/87255255-f32bbb00-c43d-11ea-8129-5ef159396f72.png)

![image](https://user-images.githubusercontent.com/5615930/87255260-faeb5f80-c43d-11ea-934d-64cd4f7ae433.png)
