### PR TITLE
Text must be string in sprite.say

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -465,7 +465,7 @@ class Sprite extends sprites.BaseSprite {
     //% text.shadow=text
     //% inlineInputMode=inline
     //% help=sprites/sprite/say
-    say(text: any, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
+    say(text: string, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
         // clear say
         if (!text) {
             this.updateSay = undefined;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/2078

Is there a reason this was any before? I'm worried about breaking things -.-