### PR TITLE
add image equals block

### DIFF
--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -98,6 +98,10 @@ interface Image {
      * otherwise returns false.
      */
     //% shim=ImageMethods::equals
+    //% blockNamespace="images"
+    //% block="$this is equal to image $other"
+    //% this.shadow=variables_get
+    //% this.defl="picture"
     equals(other: Image): boolean;
 
     //% shim=ImageMethods::isStatic

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -98,7 +98,7 @@ interface Image {
      * otherwise returns false.
      */
     //% shim=ImageMethods::equals
-    //% blockNamespace="images"
+    //% blockNamespace="images" group="Compare"
     //% block="$this is equal to image $other"
     //% this.shadow=variables_get
     //% this.defl="picture"

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -102,6 +102,7 @@ interface Image {
     //% block="$this is equal to image $other"
     //% this.shadow=variables_get
     //% this.defl="picture"
+    //% other.shadow=screen_image_picker
     equals(other: Image): boolean;
 
     //% shim=ImageMethods::isStatic


### PR DESCRIPTION
Not fully certain best wording, but to start:

![image](https://user-images.githubusercontent.com/5615930/87353749-42432000-c512-11ea-8a2b-3b39d54a0c0a.png)


Maybe can drop 'image' from the text, but could see someone being confused if they variables in and things 'randomly' break with an equals block.

Doesn't really fit in Drawing / Create / Transformations so I put it in it's own "Compare" group