### PR TITLE
Convert sprite x/y setters to floats

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -74,7 +74,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x"
     set x(v: number) {
-        this.left = v - (this._image.width >> 1)
+        this.left = v - (this._image.width / 2)
     }
 
     //% group="Physics" blockSetVariable="mySprite"
@@ -85,7 +85,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y"
     set y(v: number) {
-        this.top = v - (this._image.height >> 1)
+        this.top = v - (this._image.height / 2)
     }
 
     //% group="Physics" blockSetVariable="mySprite"


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2115

Minimal repro (image with odd-numbered dimension): https://makecode.com/_gCA8PWYaoFR1