### PR TITLE
constrain speed changes applied outside physics calc

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -235,7 +235,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         }
 
         if (sprite._ay) {
-            sprite._vy =Fx.add(
+            sprite._vy = Fx.add(
                 sprite._vy,
                 Fx.mul(
                     sprite._ay,

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -216,13 +216,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         sprite._lastY = sprite._y;
 
         if (sprite._ax) {
-            sprite._vx = this.constrain(
-                Fx.add(
-                    sprite._vx,
-                    Fx.mul(
-                        sprite._ax,
-                        dtSec
-                    )
+            sprite._vx = Fx.add(
+                sprite._vx,
+                Fx.mul(
+                    sprite._ax,
+                    dtSec
                 )
             );
         } else if (sprite._fx) {
@@ -237,13 +235,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         }
 
         if (sprite._ay) {
-            sprite._vy = this.constrain(
-                Fx.add(
-                    sprite._vy,
-                    Fx.mul(
-                        sprite._ay,
-                        dtSec
-                    )
+            sprite._vy =Fx.add(
+                sprite._vy,
+                Fx.mul(
+                    sprite._ay,
+                    dtSec
                 )
             );
         } else if( sprite._fy) {
@@ -256,6 +252,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
             else
                 sprite._vy = Fx.zeroFx8
         }
+
+        sprite._vx = this.constrain(sprite._vx);
+        sprite._vy = this.constrain(sprite._vy);
 
         const dx = Fx.idiv(
             Fx.mul(


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2153

When friction was added the acceleration was moved into an if, but the constrain always needs to occur. This was allowing unbounded speed when the speed change is applied outside physics (in this case, the repeat was adding 30vy every frame, and since the physics engine thought the max was 500 it didn't handle it well when speeds got to around a few thousand)

As a side note, I'm pretty happy I got to make a branch named 'fixSpaceMan' and have it be an accurate name