### PR TITLE
createTilemap: Default scale to TileScale.Sixteen

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -427,7 +427,7 @@ namespace tiles {
         return i;
     }
 
-    export function createTilemap(data: Buffer, layer: Image, tiles: Image[], scale: TileScale): TileMapData {
+    export function createTilemap(data: Buffer, layer: Image, tiles: Image[], scale = TileScale.Sixteen): TileMapData {
         return new TileMapData(data, layer, tiles, scale)
     }
 


### PR DESCRIPTION
**The problem**
In the JS editor, typing `tiles.createTilemap(` and tab to autocomplete fills in a scale of `TileScale.Eight`, but it should be `TileScale.Sixteen`.

**My solution**
I wasn't able to find a way to have it explicitly become `TileScale.Sixteen`, but making it the default value is an improvement, I think. Curious what others think, and if there's a better solution.

Fixes https://github.com/microsoft/pxt-arcade/issues/2112
