### PR TITLE
Add info for color number to bkgnd ref pages

### DIFF
--- a/libs/game/docs/reference/images/image/get-pixel.md
+++ b/libs/game/docs/reference/images/image/get-pixel.md
@@ -35,4 +35,5 @@ if (randoColors.getPixel(8, 8) == 14) {
 
 ## See also #seeaslo
 
+[image](/types/image),
 [set pixel](/reference/images/image/set-pixel)

--- a/libs/game/docs/reference/scene/background-color.md
+++ b/libs/game/docs/reference/scene/background-color.md
@@ -19,19 +19,19 @@ default:
 
 * `0`: transparent
 * `1`: white
-* `2`: light blue
-* `3`: medium blue
-* `4`: dark blue
-* `5`: violet
-* `6`: lime
-* `7`: olive
-* `8`: brown
-* `9`: cyan
-* `10`: red
-* `11`: purple
-* `12`: pink
-* `13`: orange
-* `14`: yellow
+* `2`: red
+* `3`: pink
+* `4`: orange
+* `5`: yellow
+* `6`: teal
+* `7`: green
+* `8`: blue
+* `9`: light blue
+* `10`: purple
+* `11`: light purple
+* `12`: dark purple
+* `13`: tan
+* `14`: brown
 * `15`: black
 
 ### ~

--- a/libs/game/docs/reference/scene/background-color.md
+++ b/libs/game/docs/reference/scene/background-color.md
@@ -14,7 +14,7 @@ The background color is the color painted behind other images shown on the scree
 
 There are 16 colors available to choose from. These colors are set in the current color _pallete_.
 The pallete contains a collection of colors, each of which have an index number from `0` to `15`. The index
-is also known as the color number. Unless the pallete is changed the pallete has these colors as the
+is also known as the **color number**. Unless the pallete is changed, the pallete has these colors as the
 default:
 
 * `0`: transparent

--- a/libs/game/docs/reference/scene/background-color.md
+++ b/libs/game/docs/reference/scene/background-color.md
@@ -6,7 +6,35 @@ Get the background color of the screen.
 scene.backgroundColor()
 ```
 
-You can get the background color of the screen anytime. The background color is always behind other images shown on the screen.
+The background color is the color painted behind other images shown on the screen.
+
+### ~ hint
+
+#### Color number
+
+There are 16 colors available to choose from. These colors are set in the current color _pallete_.
+The pallete contains a collection of colors, each of which have an index number from `0` to `15`. The index
+is also known as the color number. Unless the pallete is changed the pallete has these colors as the
+default:
+
+* `0`: transparent
+* `1`: white
+* `2`: light blue
+* `3`: medium blue
+* `4`: dark blue
+* `5`: violet
+* `6`: lime
+* `7`: olive
+* `8`: brown
+* `9`: cyan
+* `10`: red
+* `11`: purple
+* `12`: pink
+* `13`: orange
+* `14`: yellow
+* `15`: black
+
+### ~
 
 ## Returns
 

--- a/libs/game/docs/reference/scene/set-background-color.md
+++ b/libs/game/docs/reference/scene/set-background-color.md
@@ -14,7 +14,7 @@ You can set the background color of the screen at anytime. The background color 
 
 There are 16 colors available to choose from. These colors are set in the current color _pallete_.
 The pallete contains a collection of colors, each of which have an index number from `0` to `15`. The index
-is also known as the color number. Unless the pallete is changed the pallete has these colors as the
+is also known as the **color number**. Unless the pallete is changed, the pallete has these colors as the
 default:
 
 * `0`: transparent

--- a/libs/game/docs/reference/scene/set-background-color.md
+++ b/libs/game/docs/reference/scene/set-background-color.md
@@ -19,19 +19,19 @@ default:
 
 * `0`: transparent
 * `1`: white
-* `2`: light blue
-* `3`: medium blue
-* `4`: dark blue
-* `5`: violet
-* `6`: lime
-* `7`: olive
-* `8`: brown
-* `9`: cyan
-* `10`: red
-* `11`: purple
-* `12`: pink
-* `13`: orange
-* `14`: yellow
+* `2`: red
+* `3`: pink
+* `4`: orange
+* `5`: yellow
+* `6`: teal
+* `7`: green
+* `8`: blue
+* `9`: light blue
+* `10`: purple
+* `11`: light purple
+* `12`: dark purple
+* `13`: tan
+* `14`: brown
 * `15`: black
 
 ### ~

--- a/libs/game/docs/reference/scene/set-background-color.md
+++ b/libs/game/docs/reference/scene/set-background-color.md
@@ -6,7 +6,35 @@ Set the background color of the screen.
 scene.setBackgroundColor(0)
 ```
 
-You can set the background color of the screen anytime. The background color is always behind other images shown on the screen.
+You can set the background color of the screen at anytime. The background color is always behind other images shown on the screen.
+
+### ~ hint
+
+#### Color number
+
+There are 16 colors available to choose from. These colors are set in the current color _pallete_.
+The pallete contains a collection of colors, each of which have an index number from `0` to `15`. The index
+is also known as the color number. Unless the pallete is changed the pallete has these colors as the
+default:
+
+* `0`: transparent
+* `1`: white
+* `2`: light blue
+* `3`: medium blue
+* `4`: dark blue
+* `5`: violet
+* `6`: lime
+* `7`: olive
+* `8`: brown
+* `9`: cyan
+* `10`: red
+* `11`: purple
+* `12`: pink
+* `13`: orange
+* `14`: yellow
+* `15`: black
+
+### ~
 
 ## Parameters
 


### PR DESCRIPTION
Include some hints to help clarify what the color numbers are.

Closes https://github.com/microsoft/pxt-arcade/issues/2135