### PR TITLE
dont crash when using place on random tile when tile count >>> big number

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -602,8 +602,8 @@ namespace tiles {
     }
 
     /**
-     *
-     * @param tile a random tile of the get
+     * Get a random tile of the given type
+     * @param tile the type of tile to get a random selection of
      */
     export function getRandomTileByType(tile: Image): Location {
         const scene = game.currentScene();

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -315,6 +315,32 @@ namespace tiles {
             return output;
         }
 
+        public sampleTilesByType(index: number, maxCount: number): Location[] {
+            if (this.isInvalidIndex(index) || !this.enabled || maxCount <= 0) return [];
+
+            let count = 0;
+            const reservoir: Location[] = [];
+            for (let col = 0; col < this._map.width; ++col) {
+                for (let row = 0; row < this._map.height; ++row) {
+                    let currTile = this._map.getTile(col, row);
+                    if (currTile === index) {
+                        // first **maxCount** elements just enqueue
+                        if (count < maxCount) {
+                            reservoir.push(new Location(col, row, this));
+                        } else {
+                            const potentialIndex = randint(0, count);
+                            if (potentialIndex < maxCount) {
+                                reservoir[potentialIndex] = new Location(col, row, this);
+                            }
+                        }
+                        ++count;
+                    }
+                }
+            }
+
+            return reservoir;
+        }
+
         protected isInvalidIndex(index: number): boolean {
             return index < 0 || index > 0xff;
         }
@@ -554,9 +580,9 @@ namespace tiles {
     //% help=tiles/place-on-random-tile
     export function placeOnRandomTile(sprite: Sprite, tile: Image): void {
         if (!sprite || !game.currentScene().tileMap) return;
-        const tiles = getTilesByType(tile);
-        if (tiles.length > 0)
-            Math.pickRandom(tiles).place(sprite);
+        const loc = getRandomTileByType(tile);
+        if (loc)
+            loc.place(sprite);
     }
 
     /**
@@ -573,6 +599,19 @@ namespace tiles {
         if (!tile || !scene.tileMap) return [];
         const index = scene.tileMap.getImageType(tile);
         return scene.tileMap.getTilesByType(index);
+    }
+
+    /**
+     *
+     * @param tile a random tile of the get
+     */
+    export function getRandomTileByType(tile: Image): Location {
+        const scene = game.currentScene();
+        if (!tile || !scene.tileMap)
+            return undefined;
+        const index = scene.tileMap.getImageType(tile);
+        const sample = scene.tileMap.sampleTilesByType(index, 1);
+        return sample[0];
     }
 }
 


### PR DESCRIPTION
When we do place on random tile, it creates an array of all of the tiles of that type; that's fine a lot of the time, but VERY BAD when that tile is the base of a big level (e.g. the standard floor in a ~80x80 tilemap)

This adds a helper to get an n-length random sample from the tiles of the given type w/ a [reservoir sample](https://en.wikipedia.org/wiki/Reservoir_sampling) (Yay for all the times I had to help students with interview questions prep!).

test that it's actually random (I tried a handful of different lengths / tile arrangements, just need to draw on tilemap): https://makecode.com/_5tx7bz2ua59o

w/ two quick runs:

![image](https://user-images.githubusercontent.com/5615930/87817886-973aab00-c81e-11ea-9051-d2dbb31e80c7.png)


fixes issue with Sonia's game (see teams)