### PR TITLE
Ref page for sprite 'set-velocity'

### DIFF
--- a/libs/game/docs/reference/sprites/sprite/set-velocity.md
+++ b/libs/game/docs/reference/sprites/sprite/set-velocity.md
@@ -1,0 +1,52 @@
+# set Velocity
+
+Set the horizontal and vertical velocities of a sprite.
+
+```sig
+sprites.create(null).setVelocity(0, 0)
+```
+
+Sprites that aren't projectiles are created without any motion. Every sprite has `vx` and `vy` properties which are its horizontal and vertical speeds.
+You can set both of the speeds at once to make a sprite move in any direction.
+
+### Parameters
+
+* **vx**: the new horizontal velocity (speed) for the sprite.
+* **vy**: the new vertical velocity (speed) for the sprite.
+
+## Example #example
+
+Create a sprite to bounce off the sides of the screen. Set the **vx** and ***vy**
+velocities to `50`.
+
+```blocks
+enum SpriteKind {
+    Example
+}
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
+7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
+7 5 5 7 2 2 2 2 2 2 2 2 7 4 4 7 
+7 5 5 5 7 2 2 2 2 2 2 7 4 4 4 7 
+7 5 5 5 5 7 2 2 2 2 7 4 4 4 4 7 
+7 5 5 5 5 5 7 2 2 7 4 4 4 4 4 7 
+7 5 5 5 5 5 5 7 7 4 4 4 4 4 4 7 
+7 5 5 5 5 5 5 7 7 4 4 4 4 4 4 7 
+7 5 5 5 5 5 7 8 8 7 4 4 4 4 4 7 
+7 5 5 5 5 7 8 8 8 8 7 4 4 4 4 7 
+7 5 5 5 7 8 8 8 8 8 8 7 4 4 4 7 
+7 5 5 7 8 8 8 8 8 8 8 8 7 4 4 7 
+7 5 7 8 8 8 8 8 8 8 8 8 8 7 4 7 
+7 7 8 8 8 8 8 8 8 8 8 8 8 8 7 7 
+7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+`, SpriteKind.Example)
+mySprite.setFlag(SpriteFlag.BounceOnWall, true)
+mySprite.setVelocity(50, 50)
+```
+
+## See also #seealso
+
+[vx](/reference/sprites/sprite/vx),
+[vy](/reference/sprites/sprite/vy)

--- a/libs/game/docs/reference/sprites/sprite/set-velocity.md
+++ b/libs/game/docs/reference/sprites/sprite/set-velocity.md
@@ -9,7 +9,7 @@ sprites.create(null).setVelocity(0, 0)
 Sprites that aren't projectiles are created without any motion. Every sprite has `vx` and `vy` properties which are its horizontal and vertical speeds.
 You can set both of the speeds at once to make a sprite move in any direction.
 
-### Parameters
+## Parameters
 
 * **vx**: the new horizontal velocity (speed) for the sprite.
 * **vy**: the new vertical velocity (speed) for the sprite.

--- a/libs/game/docs/reference/sprites/sprite/set-velocity.md
+++ b/libs/game/docs/reference/sprites/sprite/set-velocity.md
@@ -20,9 +20,6 @@ Create a sprite to bounce off the sides of the screen. Set the **vx** and ***vy*
 velocities to `50`.
 
 ```blocks
-enum SpriteKind {
-    Example
-}
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
@@ -41,7 +38,7 @@ mySprite = sprites.create(img`
 7 5 7 8 8 8 8 8 8 8 8 8 8 7 4 7 
 7 7 8 8 8 8 8 8 8 8 8 8 8 8 7 7 
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
-`, SpriteKind.Example)
+`, SpriteKind.Player)
 mySprite.setFlag(SpriteFlag.BounceOnWall, true)
 mySprite.setVelocity(50, 50)
 ```

--- a/libs/game/docs/reference/sprites/sprite/set-velocity.md
+++ b/libs/game/docs/reference/sprites/sprite/set-velocity.md
@@ -16,7 +16,7 @@ You can set both of the speeds at once to make a sprite move in any direction.
 
 ## Example #example
 
-Create a sprite to bounce off the sides of the screen. Set the **vx** and ***vy**
+Create a sprite to bounce off the sides of the screen. Set the **vx** and **vy**
 velocities to `50`.
 
 ```blocks

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -445,7 +445,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics"
     //% weight=100
     //% blockId=spritesetvel block="set %sprite(mySprite) velocity to vx %vx vy %vy"
-    //% help=sprites/sprite/set-velociy
+    //% help=sprites/sprite/set-velocity
     //% vx.shadow=spriteSpeedPicker
     //% vy.shadow=spriteSpeedPicker
     setVelocity(vx: number, vy: number): void {


### PR DESCRIPTION
Add the missing reference page for `sprite.setVelocity()`.

Closes https://github.com/microsoft/pxt-arcade/issues/2252