### PR TITLE
set font before chunking texts

### DIFF
--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -226,9 +226,9 @@ namespace game {
         }
 
         setText(rawString: string) {
+            this.setFont(image.getFontForText(rawString));
             this.chunks = this.chunkText(rawString);
             this.chunkIndex = 0;
-            this.setFont(image.getFontForText(rawString));
         }
 
         drawTextCore() {


### PR DESCRIPTION
Font height / width is used in chunking text, setting it before chunking allows dealing with non-latin characters.

https://github.com/microsoft/pxt-arcade/issues/2270