### PR TITLE
pxsim.image.toBuffer match pxsim.image.ofBuffer

### DIFF
--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -766,7 +766,7 @@ namespace pxsim.image {
             if (img._bpp == 4) {
                 let p = i
                 for (let j = 0; j < h; j += 2) {
-                    r[dstP++] = ((data[p + 1] & 0xf) << 4) | ((data[p] || 0) & 0xf)
+                    r[dstP++] = ((data[p + w] & 0xf) << 4) | ((data[p] || 0) & 0xf)
                     p += 2 * w
                 }
                 dstP = (dstP + 3) & ~3


### PR DESCRIPTION
I was using this during our hackathon project to half image size when sending messages, and the screen was messed up on the other end - when unpacking it is placing them offset by [w](https://github.com/microsoft/pxt-common-packages/blob/f5c1827799d13688b95f78f7cfc948cbc88b6c09/libs/screen/sim/image.ts#L738) instead of 1