### PR TITLE
Update 'Game' ref snippets kinds

### DIFF
--- a/libs/game/docs/reference/controller/move-sprite.md
+++ b/libs/game/docs/reference/controller/move-sprite.md
@@ -21,10 +21,6 @@ Create a sprite with a circular image. Move the sprite around the screen with th
 ### Single player
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 
@@ -50,10 +46,6 @@ controller.moveSprite(mySprite, 100, 100)
 ### Multiplayer
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . . . . . . . . . . . . 

--- a/libs/game/docs/reference/controller/set-repeat-default.md
+++ b/libs/game/docs/reference/controller/set-repeat-default.md
@@ -18,10 +18,6 @@ When your using a repeated controller button event, you may want to decide when 
 Create a sprite with a circular image.  Set the button event repeat time to `200` milliseconds when a controller button is held down. Move the sprite down and to the right when button **A** is pressed. When button **B** is pressed, send the sprite in the other direction but faster.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 controller.A.onEvent(ControllerButtonEvent.Repeated, function () {
     mySprite.top += 1
     mySprite.left += 1

--- a/libs/game/docs/reference/game/on-update.md
+++ b/libs/game/docs/reference/game/on-update.md
@@ -35,10 +35,6 @@ As part of **gameUpdate**, the code inside your **onUpdate** is run to handle th
 Create a sprite and start it moving. In the **onUpdate** function, check if the sprite reaches the edge of the screen. If it does, send it in the opposite direction.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 mySprite = sprites.create(img`
 . . . . . 5 5 5 5 5 5 . . . . . 

--- a/libs/game/docs/reference/images/screen-image.md
+++ b/libs/game/docs/reference/images/screen-image.md
@@ -15,12 +15,6 @@ image.screenImage()
 Place a cake sprite on the screen with a background color. When the **A** button is pressed, get the screen image and then destroy the cake sprite. Flip the image upside down and set it to the background.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Projectile,
-    Food,
-    Enemy
-}
 let mySprite: Sprite = null
 let screenCap: Image = null
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {

--- a/libs/game/docs/reference/sprites/create-projectile.md
+++ b/libs/game/docs/reference/sprites/create-projectile.md
@@ -31,10 +31,6 @@ Projectiles are destroyed when they move off of the screen.
 Send a smiley sprite from one corner of the screen to the other.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let smiley: Sprite = null
 let xSpeed = 50
 let ySpeed = xSpeed * scene.screenHeight() / scene.screenWidth()
@@ -63,10 +59,8 @@ f e e e e e f f f f f e e e e f
 Send photons out of a spaceship when the ``B`` button is pressed.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy,
-    Photon
+namespace SpriteKind {
+    export const Photon = SpriteKind.create()
 }
 let photon: Sprite = null
 

--- a/libs/game/docs/reference/sprites/on-destroyed.md
+++ b/libs/game/docs/reference/sprites/on-destroyed.md
@@ -18,10 +18,8 @@ sprites.onDestroyed(0, function (sprite) {
 Create a ``Ghost`` sprite and set it's ``lifespan`` to `1500`. You win the game when the ghost is destroyed.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy,
-    Ghost
+namespace SpriteKind {
+    export const Ghost = SpriteKind.create()
 }
 let ghost: Sprite = null
 ghost = sprites.create(img`

--- a/libs/game/docs/reference/sprites/on-overlap.md
+++ b/libs/game/docs/reference/sprites/on-overlap.md
@@ -29,14 +29,13 @@ An overlap of two sprites is dectected when the first non-transparent pixel in t
 Create a ``Ghost`` sprite that is blasted by green balls. Let the balls go through the sprite until it's ``kind`` is changed to ``Mortal`` by pressing the **A** button. When the ``Ghost`` sprite is changed to ``Mortal``, any contact with the balls is detected in ``||sprites:on overlaps||``. Make the balls push the ``Mortal`` sprite off the screen.
 
 ```blocks
-enum SpriteKind {
-    Mortal,
-    Ghost,
-    Ball
+namespace SpriteKind {
+    export const Mortal = SpriteKind.create()
+    export const Ghost = SpriteKind.create()
+    export const Ball = SpriteKind.create()
 }
 let ghost: Sprite = null
 let projectile: Sprite = null
-let sprite: Sprite = null
 ghost = sprites.create(img`
 . . . . . . d d d d d . . . . . 
 . . . d d d d 1 1 1 d d d . . . 
@@ -89,54 +88,75 @@ sprites.onDestroyed(SpriteKind.Mortal, function (sprite) {
 Use the **A** to blast a green ball at a ``Ghost`` sprite. Set the flag for the sprite to ``Ghost``. In the ``||sprites:on overlaps||`` block, try to detect the contact of the ball with the ghost. When button **B** is pressed, switch the value of the ``ghost`` flag and see if the ball hits the ghost sprite.
 
 ```blocks
-enum SpriteKind {
-    Ghost,
-    Ball
+namespace SpriteKind {
+    export const Mortal = SpriteKind.create()
+    export const Ghost = SpriteKind.create()
+    export const Ball = SpriteKind.create()
 }
-let ghosting = true
-let ghost: Sprite = null
 let projectile: Sprite = null
+let ghost: Sprite = null
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Ball)
 ghost = sprites.create(img`
-. . . . . . d d d d d . . . . . 
-. . . d d d d 1 1 1 d d d . . . 
-. . d d 1 1 1 1 1 1 1 1 d d . . 
-. . d 1 1 1 1 1 1 1 1 1 1 d . . 
-. . d 1 1 1 1 1 1 1 1 1 1 d d . 
-. d d 1 1 1 f 1 1 1 f 1 1 1 d . 
-. d 1 1 1 1 1 1 1 1 1 1 1 1 d d 
-. d 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
-. d 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
-d d 1 1 1 1 1 1 f f 1 1 1 1 1 d 
-d 1 1 1 1 1 1 1 f f 1 1 1 1 1 d 
-d 1 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
-d 1 1 1 1 1 1 1 d 1 1 1 1 1 1 d 
-d 1 d d d 1 1 d d d d 1 d 1 1 d 
-d d d . d d d d . . d d d d d d 
-d d . . . d d . . . . d . . d d 
-`, SpriteKind.Ghost)
+    . . . . . . d d d d d . . . . . 
+    . . . d d d d 1 1 1 d d d . . . 
+    . . d d 1 1 1 1 1 1 1 1 d d . . 
+    . . d 1 1 1 1 1 1 1 1 1 1 d . . 
+    . . d 1 1 1 1 1 1 1 1 1 1 d d . 
+    . d d 1 1 1 f 1 1 1 f 1 1 1 d . 
+    . d 1 1 1 1 1 1 1 1 1 1 1 1 d d 
+    . d 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
+    . d 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
+    d d 1 1 1 1 1 1 f f 1 1 1 1 1 d 
+    d 1 1 1 1 1 1 1 f f 1 1 1 1 1 d 
+    d 1 1 1 1 1 1 1 1 1 1 1 1 1 1 d 
+    d 1 1 1 1 1 1 1 d 1 1 1 1 1 1 d 
+    d 1 d d d 1 1 d d d d 1 d 1 1 d 
+    d d d . d d d d . . d d d d d d 
+    d d . . . d d . . . . d . . d d 
+    `, SpriteKind.Ghost)
 ghost.x = 40
-ghost.setFlag(SpriteFlag.Ghost, true)
-sprites.onOverlap(SpriteKind.Ghost, SpriteKind.Ball, function (sprite, otherSprite) {
+ghost.setFlag(SpriteFlag.AutoDestroy, true)
+game.onUpdateInterval(400, function () {
+    projectile = sprites.createProjectile(img`
+        . . 7 7 7 7 . . 
+        . 7 7 7 7 7 7 . 
+        7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 
+        . 7 7 7 7 7 7 . 
+        . . 7 7 7 7 . . 
+        `, -400, 0, SpriteKind.Ball)
+    projectile.z = -1
+})
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    ghost.setKind(SpriteKind.Mortal)
+})
+sprites.onDestroyed(SpriteKind.Mortal, function (sprite) {
+    game.over(false)
+})
+sprites.onOverlap(SpriteKind.Mortal, SpriteKind.Ball, function (sprite, otherSprite) {
     sprite.say("Ouch!", 200)
     otherSprite.vx = otherSprite.vx * -1
     otherSprite.vy = Math.randomRange(-100, 100)
-})
-controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
-    projectile = sprites.createProjectile(img`
-. . 7 7 7 7 . . 
-. 7 7 7 7 7 7 . 
-7 7 7 7 7 7 7 7 
-7 7 7 7 7 7 7 7 
-7 7 7 7 7 7 7 7 
-7 7 7 7 7 7 7 7 
-. 7 7 7 7 7 7 . 
-. . 7 7 7 7 . . 
-`, -400, 0, SpriteKind.Ball)
-    projectile.z = -1
-})
-controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
-    ghosting = !(ghosting)
-    ghost.setFlag(SpriteFlag.Ghost, ghosting)
+    sprite.x += -1
 })
 ```
 

--- a/libs/game/docs/reference/sprites/sprite/ax.md
+++ b/libs/game/docs/reference/sprites/sprite/ax.md
@@ -57,13 +57,10 @@ If the speed of a sprite is currently at `0` and it's acceleration is set to `2`
 Accelerate a a sprite as it moves from the left side of the screen to the right side and back.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -99,14 +96,11 @@ game.onUpdateInterval(500, function () {
 Accelerate a sprite at `100` starting with a speed of `0`. Check after about `1` second and see how fast the sprite was travelling.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let interval = 0
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/ay.md
+++ b/libs/game/docs/reference/sprites/sprite/ay.md
@@ -57,13 +57,10 @@ If the speed of a sprite is currently at `0` and it's acceleration is set to `2`
 Accelerate a a sprite as it moves from the top side of the screen to the bottom side and back.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -91,7 +88,6 @@ game.onUpdateInterval(500, function () {
 
     }
 })
-
 ```
 
 ### How fast was it? #ex2
@@ -99,14 +95,11 @@ game.onUpdateInterval(500, function () {
 Accelerate a sprite at `100` starting with a speed of `0`. Check after about `1` second and see how fast the sprite was travelling.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let interval = 0
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/bottom.md
+++ b/libs/game/docs/reference/sprites/sprite/bottom.md
@@ -47,11 +47,10 @@ The sprite image forms a rectangle with some number of pixel rows. The **bottom*
 Move a sprite to the top side of the screen. Wait 2 seconds and then move it to the bottom side.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -82,13 +81,10 @@ forever(function () {
 Send a sprite moving from the bottom side of the screen to the top. In an ``||game:on game update||`` loop, check to see if the the sprite touched the top side of the screen. If so, reset the sprite back to the bottom side of the screen.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/destroy.md
+++ b/libs/game/docs/reference/sprites/sprite/destroy.md
@@ -24,10 +24,6 @@ You can also select an optional particle effect to display at the sprite when it
 Make a ``Player`` and an ``Enemy`` sprite. The player moves into the open area of the enemy sprite. When an overlap of the two is detected, destroy the ``Player``.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let enemy: Sprite = null
 let catchBox: Image = null
 let player: Sprite = null

--- a/libs/game/docs/reference/sprites/sprite/height.md
+++ b/libs/game/docs/reference/sprites/sprite/height.md
@@ -35,8 +35,8 @@ let height = mySprite.bottom - mySprite.top
 Create an image that is `16` pixels wide. Make a sprite that has this image. Let the sprite say how wide it is.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let blockImage = image.create(16, 16)
 blockImage.fill(4)

--- a/libs/game/docs/reference/sprites/sprite/image.md
+++ b/libs/game/docs/reference/sprites/sprite/image.md
@@ -23,8 +23,8 @@ A sprite's image is set when the sprite is created or a different image is set u
 Create a sprite with a checkbox that has a green border. Copy the checkbox image and change the border to a different color. Show a new sprite with the checkbox copy.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let sprite1 = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 

--- a/libs/game/docs/reference/sprites/sprite/is-hitting-tile.md
+++ b/libs/game/docs/reference/sprites/sprite/is-hitting-tile.md
@@ -23,10 +23,6 @@ The sprite must be in motion (a velocity of ``vx`` or ``vy`` that isn't `0`) bef
 Build a brick wall of tiles in the scene. Send a arrow sprite towards the wall. If the sprite hits the wall, send it back in the oppsite direction.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let flipImage: Image = null
 let mySprite: Sprite = null
 scene.setTile(2, img`

--- a/libs/game/docs/reference/sprites/sprite/kind.md
+++ b/libs/game/docs/reference/sprites/sprite/kind.md
@@ -8,10 +8,10 @@ sprites.create(null).kind()
 
 To keep track of different types of sprites, you can assign a _kind_ to them. This is a value that will help identify them and decide what actions to take when events happen in the game. There are no particular rules or names for how you decide on what the kinds should be. The sprite kinds in your game might be defined like this:
 
-```typescript
-enum SpriteKind {
-    Player,
-    Enemy
+```typescript-ignore
+namespace SpriteKind {
+    export const Player = SpriteKind.create()
+    export const Enemy = SpriteKind.create()
 }
 ```
 
@@ -24,10 +24,8 @@ enum SpriteKind {
 Make a ``Player`` sprite and two ``Friend`` sprites. Every 2 seconds, turn one of the friend sprites into an ``Enemy``. Every 10 seconds have the enemy sprites become friends again.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Friend,
-    Enemy
+namespace SpriteKind {
+    export const Friend = SpriteKind.create()
 }
 let player: Sprite = null
 let friend2: Sprite = null

--- a/libs/game/docs/reference/sprites/sprite/left.md
+++ b/libs/game/docs/reference/sprites/sprite/left.md
@@ -49,11 +49,10 @@ The sprite image forms a rectangle with some number of pixel columns. The **left
 Move a sprite to the right side of the screen. Wait 2 seconds and then move it to the left side.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -84,13 +83,10 @@ forever(function () {
 Send a sprite moving from the right side of the screen to the left. In an ``||game:on game update||`` loop, check to see if the the sprite touched the left side of the screen. If so, reset the sprite back to the right side of the screen.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/lifespan.md
+++ b/libs/game/docs/reference/sprites/sprite/lifespan.md
@@ -47,10 +47,6 @@ The lifespan of a sprite is infinite when it's created and stays that way until 
 Make a ``Player`` sprite and set its ``lifespan`` to `1000` milliseconds (or `1` second).
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let orangeBlock = image.create(16, 16)
 orangeBlock.fill(4)
 orangeBlock.drawRect(0, 0, 16, 16, 1)

--- a/libs/game/docs/reference/sprites/sprite/right.md
+++ b/libs/game/docs/reference/sprites/sprite/right.md
@@ -47,11 +47,10 @@ The sprite image forms a rectangle with some number of pixel columns. The **righ
 Move a sprite to the left side of the screen. Wait 2 seconds and then move it to the right side.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -82,13 +81,10 @@ forever(function () {
 Send a sprite moving from the left side of the screen to the right. In an ``||game:on game update||`` loop, check to see if the the sprite touched the right side of the screen. If so, reset the sprite back to the left side of the screen.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/set-flag.md
+++ b/libs/game/docs/reference/sprites/sprite/set-flag.md
@@ -33,13 +33,10 @@ A sprite will always stay inside the limits of your scene if your game has a til
 Create a scene with orange wall tiles. Make the scene be slightly wider than the screen. Move a sprite from the left side of the screen toward the right side. Set the sprite to be a ``ghost`` so it passes through the wall and make it ``auto destroy`` when it moves past the screen.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let ghost: Sprite = null
-ghost = sprites.create(img`
+let ghost = sprites.create(img`
 . . . . . . d d d d d . . . . .
 . . . d d d d 1 1 1 d d d . . .
 . . d d 1 1 1 1 1 1 1 1 d d . .

--- a/libs/game/docs/reference/sprites/sprite/set-kind.md
+++ b/libs/game/docs/reference/sprites/sprite/set-kind.md
@@ -12,22 +12,25 @@ sprites.create(null).setKind(0)
 
 ### Sprite kinds
 
-To keep track of different types of sprites, you can assign a _kind_ to them. This is a value that will help identify them and decide what actions to take when events happen in the game. There are no particular rules or names for how you decide on what the kinds should be. A good way to do it though is to make an enumerated list of kinds like this:
+To keep track of different types of sprites, you can assign a _kind_ to them. This is a value that will help identify them and decide what actions to take when events happen in the game. There are no particular rules or names for how you decide on what the kinds should be. The way to do it though is to assign a kind in the **SpriteKind** namespace.
 
 ```typescript
-enum SpriteKind {
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Star = SpriteKind.create()
+    export const Comet = SpriteKind.create()
 }
 ```
 
-Then, when you create a sprite, you can optionally assign it a kind:
+There are some default kinds that are already part of **SpriteKind**. These are:
+
+* SpriteKind.Player
+* SpriteKind.Enemy
+* SpriteKind.Food
+* SpriteKind.Projectile
+
+When you create a sprite, you can optionally assign it a kind:
 
 ```block
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite = sprites.create(img`
 2 4
 4 2
@@ -44,11 +47,11 @@ let mySprite = sprites.create(img`
 If you were making a space game, you might have kinds like this:
 
 ```typescript
-enum SpriteKind {
-    Ship,
-    Planet,
-    Asteroid,
-    Moon
+namespace SpriteKind {
+    export const Ship = SpriteKind.create()
+    export const Planet = SpriteKind.create()
+    export const Asteroid = SpriteKind.create()
+    export const moon = SpriteKind.create()
 }
 ```
 
@@ -59,10 +62,8 @@ During the game, if you need a sprite to change to a different kind, say a ``Pla
 Make a ``Player`` sprite and two ``Friend`` sprites. Every 2 seconds, turn one of the friend sprites into an ``Enemy``. Every 10 seconds have the enemy sprites become friends again.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Friend,
-    Enemy
+namespace SpriteKind {
+    export const Friend = SpriteKind.create()
 }
 let player: Sprite = null
 let friend2: Sprite = null

--- a/libs/game/docs/reference/sprites/sprite/set-position.md
+++ b/libs/game/docs/reference/sprites/sprite/set-position.md
@@ -24,11 +24,10 @@ Similarly, the **y** position of the sprite can have a value that is greater tha
 Set the sprite **x** and **y** locations to `64`. Have the sprite say what it's **x** and **y** values are.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/set-velocity.md
+++ b/libs/game/docs/reference/sprites/sprite/set-velocity.md
@@ -20,8 +20,7 @@ Create a sprite to bounce off the sides of the screen. Set the **vx** and **vy**
 velocities to `50`.
 
 ```blocks
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/tile-hit-from.md
+++ b/libs/game/docs/reference/sprites/sprite/tile-hit-from.md
@@ -21,10 +21,6 @@ If your sprite is contacting a wall tile, you can find out what kind of tile it 
 Build a brick wall of tiles in the scene. Send a arrow sprite towards the wall. When the sprite hits the wall, say what type of tile it contacted.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 let flipImage: Image = null
 scene.onHitTile(SpriteKind.Player, 2, function (sprite) {

--- a/libs/game/docs/reference/sprites/sprite/tile-kind-at.md
+++ b/libs/game/docs/reference/sprites/sprite/tile-kind-at.md
@@ -22,10 +22,6 @@ You can check to see if the tiles next to or under your sprite have a specific t
 Build a brick wall of tiles in the scene. Send a arrow sprite towards the wall. When the sprite hits the wall, say what type of tile it contacted.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 let flipImage: Image = null
 scene.onHitTile(SpriteKind.Player, 2, function (sprite) {

--- a/libs/game/docs/reference/sprites/sprite/top.md
+++ b/libs/game/docs/reference/sprites/sprite/top.md
@@ -47,11 +47,10 @@ The sprite image forms a rectangle with some number of pixel rows. The **top** o
 Move a sprite to the bottom side of the screen. Wait 2 seconds and then move it to the top side.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -82,13 +81,10 @@ forever(function () {
 Send a sprite moving from the left side of the screen to the top. In an ``||game:on game update||`` loop, check to see if the the sprite touched the top side of the screen. If so, reset the sprite back to the left side of the screen.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/vx.md
+++ b/libs/game/docs/reference/sprites/sprite/vx.md
@@ -60,13 +60,10 @@ Distance in your game is measured in pixels so the speed of a sprite is in _pixe
 Send a sprite moving to the right at `40` pixels per second. When it reaches the right side of the screen, send it back to the left side.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -98,14 +95,11 @@ game.onUpdateInterval(500, function () {
 Set a sprite in motion. Check after about `1` second and see how far the sprite has travelled.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let interval = 0
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/vy.md
+++ b/libs/game/docs/reference/sprites/sprite/vy.md
@@ -58,13 +58,10 @@ Distance in your game is measured in pixels so the speed of a sprite is in _pixe
 Send a sprite moving to the bottom at `40` pixels per second. When it reaches the bottom side of the screen, send it back to the top side.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 
@@ -96,14 +93,11 @@ game.onUpdateInterval(500, function () {
 Set a sprite in motion. Check after about `1` second and see how far the sprite has travelled.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let interval = 0
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/width.md
+++ b/libs/game/docs/reference/sprites/sprite/width.md
@@ -35,8 +35,8 @@ let width = mySprite.right - mySprite.left
 Create an image that is `16` pixels wide. Make a sprite that has this image. Let the sprite say how wide it is.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let blockImage = image.create(16, 16)
 blockImage.fill(4)

--- a/libs/game/docs/reference/sprites/sprite/x.md
+++ b/libs/game/docs/reference/sprites/sprite/x.md
@@ -37,13 +37,10 @@ The sprite image forms a rectangle with some number of pixel columns. The **x** 
 Set the sprite **x** and **y** locations to `64`. Have the sprite say what it's **x** value is.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/y.md
+++ b/libs/game/docs/reference/sprites/sprite/y.md
@@ -45,13 +45,10 @@ The sprite image forms a rectangle with some number of pixel rows. The **y** pos
 Set the sprite **x** and **y** locations to `64`. Have the sprite say what it's **y** value is.
 
 ```blocks
-enum SpriteKind {
-    Example,
-    Player,
-    Enemy
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
-let mySprite: Sprite = null
-mySprite = sprites.create(img`
+let mySprite = sprites.create(img`
 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
 7 7 2 2 2 2 2 2 2 2 2 2 2 2 7 7 
 7 5 7 2 2 2 2 2 2 2 2 2 2 7 4 7 

--- a/libs/game/docs/reference/sprites/sprite/z.md
+++ b/libs/game/docs/reference/sprites/sprite/z.md
@@ -41,8 +41,8 @@ Sprites have a depth of `0` when they are created. Sprites at the same depth lev
 Make two block sprites of green and orange. Have the orange sprite move across the green one. Each time the orange sprite passes by the green one, have it change its Z-order so it will go either under or over.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let greenBlock = image.create(32, 48)
 greenBlock.fill(7)
@@ -74,8 +74,8 @@ game.onUpdateInterval(500, function () {
 Use an array to hold a set of overlapping block sprites with different colors. Set a **Z** value for each sprite that is one greater then the previous sprite. When any button is clicked, reverse the Z-order for the set of sprites so that they overlap in the opposite direction.
 
 ```blocks
-enum SpriteKind {
-    Example
+namespace SpriteKind {
+    export const Example = SpriteKind.create()
 }
 let colorBlocks: Sprite[] = []
 let blockImg: Image = null

--- a/libs/game/docs/reference/tiles/place-on-random-tile.md
+++ b/libs/game/docs/reference/tiles/place-on-random-tile.md
@@ -19,10 +19,6 @@ You a can place a sprite on top of a random tile in the tile map. Use the tile i
 Make a tilemap with several different tiles. Create a circle sprite. Randomly place the sprite on a tile with color number `8`.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 // TODO tiles.setTilemap(tiles.createTilemap(null, 0, 8 ** 8, 9)); 
 mySprite = sprites.create(img`

--- a/libs/game/docs/reference/tiles/place.md
+++ b/libs/game/docs/reference/tiles/place.md
@@ -17,10 +17,6 @@ You a can place a sprite directly on a tile. If you have a [tile](/types/tile) l
 Make a tilemap with several different tiles. Create a circle sprite. Choose the tile at position (1, 1) in the tilemap and place the sprite over it.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
 let mySprite: Sprite = null
 // TODO tiles.setTilemap(tiles.createTilemap(null, 0, 8 ** 8, 9)); 
 mySprite = sprites.create(img`


### PR DESCRIPTION
Snippets in Game reference pages had the old `SpriteKind` enums. Enums removed and namespace constants added where necessary.

Fixes https://github.com/microsoft/pxt-arcade/issues/2150