### PR TITLE
reattach stats so users can see in sim too

### DIFF
--- a/libs/base/eventcontext.ts
+++ b/libs/base/eventcontext.ts
@@ -63,6 +63,9 @@ namespace control {
             this.deltaTimeMillis = 0;
             this.frameWorker = 0;
             this.idleCallbacks = undefined;
+            if (!EventContext.lastStats) {
+                EventContext.lastStats = "";
+            }
         }
 
         get deltaTime() {

--- a/libs/game/systemmenu.ts
+++ b/libs/game/systemmenu.ts
@@ -300,6 +300,9 @@ namespace scene.systemMenu {
 
     function toggleStats() {
         game.stats = !game.stats;
+        if (!game.stats && control.EventContext.onStats) {
+            control.EventContext.onStats("");
+        }
     }
 
     function toggleConsole() {

--- a/libs/screen/sim/state.ts
+++ b/libs/screen/sim/state.ts
@@ -111,6 +111,10 @@ namespace pxsim {
 
         updateStats(stats: string) {
             this.stats = stats;
+            const b = (board() as any);
+            if (b && b.updateStats) {
+                b.updateStats();
+            }
         }
 
         bindToSvgImage(lcd: SVGImageElement) {


### PR DESCRIPTION
re: https://github.com/microsoft/pxt-arcade/issues/2323, I remembered this got dropped at some point and stopped working in the sim (probably when it got set so it was drawn at the bottom of the screen on hardware?). These are the stats that are set when `game.stats == true` / you turn on the setting in the menu. https://makecode.com/_LfW3FAWALKHt

fixes https://github.com/microsoft/pxt-arcade/issues/1645 and fixes https://github.com/microsoft/pxt-arcade/issues/1306

the portion in EventContext is to stop it from always starting off with a big "undefined" until the first fps is identified.

images below are with a few styling changes in a separate sim pr to make it fit in with the sim again

![image](https://user-images.githubusercontent.com/5615930/90088325-86713e00-dcd3-11ea-9983-32956b01552e.png)

![image](https://user-images.githubusercontent.com/5615930/90088471-e10a9a00-dcd3-11ea-8730-00ad0ec2bcdd.png)

![image](https://user-images.githubusercontent.com/5615930/90097967-073c3400-dcec-11ea-93c8-13cb78036a67.png)
