### PR TITLE
fix sprite.say(0)

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -467,7 +467,7 @@ class Sprite extends sprites.BaseSprite {
     //% help=sprites/sprite/say
     say(text: any, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
         // clear say
-        if (text == null || text === "") {
+        if (text === null || text === undefined || text === "") {
             this.updateSay = undefined;
             if (this.sayBubbleSprite) {
                 this.sayBubbleSprite.destroy();

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -466,7 +466,7 @@ class Sprite extends sprites.BaseSprite {
     //% inlineInputMode=inline
     //% help=sprites/sprite/say
     say(text: any, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
-        // clear say
+        // clear say if nullish or empty string (not on e.g. 0)
         if (text === null || text === undefined || text === "") {
             this.updateSay = undefined;
             if (this.sayBubbleSprite) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -467,7 +467,7 @@ class Sprite extends sprites.BaseSprite {
     //% help=sprites/sprite/say
     say(text: any, timeOnScreen?: number, textColor = 15, textBoxColor = 1) {
         // clear say
-        if (!text) {
+        if (text == null || text === "") {
             this.updateSay = undefined;
             if (this.sayBubbleSprite) {
                 this.sayBubbleSprite.destroy();


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2331; we still want it to bail out on null, undefined, and "" (as that's commonly used as 'clear say' in games)