### PR TITLE
Adding literals for different tile widths

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -463,6 +463,7 @@ namespace tiles {
     //% tilemap.fieldEditor="tilemap"
     //% tilemap.fieldOptions.decompileArgumentAsString="true"
     //% tilemap.fieldOptions.filter="tile"
+    //% tilemap.fieldOptions.taggedTemplate="tilemap"
     //% blockNamespace="scene" group="Tiles" duplicateShadowOnDrag
     //% help=tiles/set-tile-map
     export function setTilemap(tilemap: TileMapData) {
@@ -618,6 +619,18 @@ namespace tiles {
 //% helper=getTilemapByName
 //% pyConvertToTaggedTemplate
 function tilemap(lits: any, ...args: any[]): tiles.TileMapData { return null }
+
+//% helper=getTilemapByName
+//% pyConvertToTaggedTemplate
+function tilemap8(lits: any, ...args: any[]): tiles.TileMapData { return null }
+
+//% helper=getTilemapByName
+//% pyConvertToTaggedTemplate
+function tilemap16(lits: any, ...args: any[]): tiles.TileMapData { return null }
+
+//% helper=getTilemapByName
+//% pyConvertToTaggedTemplate
+function tilemap32(lits: any, ...args: any[]): tiles.TileMapData { return null }
 
 namespace helpers {
     export type TilemapFactory = (name: string) => tiles.TileMapData;


### PR DESCRIPTION
And fixing an annotation that I accidentally left out of https://github.com/microsoft/pxt/pull/7360

These literals are all exactly the same as `tilemap` at runtime, but they will make it so that the tilewidth is correct when you create a new tilemap from monaco. Eventually we can deprecate once we have an asset editor.