### PR TITLE
Set sprite kind in Create ref page

### DIFF
--- a/libs/game/docs/reference/sprites/create.md
+++ b/libs/game/docs/reference/sprites/create.md
@@ -11,7 +11,7 @@ Sprites provide all the operations to move and animate images. Your sprites can 
 ## Parameters
 
 * **img**: an [image](/types/image) to create a sprite for.
-* **kind**: the type of sprite to create.There are default sprite kinds already defined like - ``Player``, ``Enemy``, ``Food``, etc. You can add your own kind to the `SpriteKind` group (namespace) also.
+* **kind**: the type of sprite to create. There are default sprite kinds already defined like ``Player``, ``Enemy``, ``Food``, etc. You can add your own kind to the currently defined `SpriteKind` (namespace) types also.
 
 ## Returns
 

--- a/libs/game/docs/reference/sprites/create.md
+++ b/libs/game/docs/reference/sprites/create.md
@@ -5,12 +5,13 @@ Create a new sprite with a pixel image.
 ```sig
 sprites.create(null)
 ```
-Sprites provide all the operations to move and animate images. Your sprites can detect collisions and overlaps with other objects. Initially, sprites have a position in the middle of screen and have no motion. You set the location and movement of a sprite in your code.
+
+Sprites provide all the operations to move and animate images. Your sprites can detect collisions and overlaps with other objects. Initially, sprites have a position in the middle of screen and have no motion. You set the location and movement of a sprite in your code. Sprites are associated with a **kind** so that they can be identifed as part of group or type, such as ``Player`` and ``Enemy``.
 
 ## Parameters
 
 * **img**: an [image](/types/image) to create a sprite for.
-* **kind**: an optional type for the sprite to create - ``Player``, ``Enemy``, etc.
+* **kind**: the type of sprite to create.There are default sprite kinds already defined like - ``Player``, ``Enemy``, ``Food``, etc. You can add your own kind to the `SpriteKind` group (namespace) also.
 
 ## Returns
 
@@ -42,7 +43,7 @@ smiley = sprites.create(img`
 . . 1 e e e e e e e e e e 1 . . 
 . . . 1 1 e e e e e e e 1 . . . 
 . . . . . 1 1 1 1 1 1 1 . . . . 
-`)
+`, SpriteKind.Player)
 ```
 
 ### Drive the car #ex2
@@ -66,7 +67,7 @@ theCar = sprites.create(img`
 . . . . f f f f f . . . . . . . . . . . . f f f f f . . . . . . 
 . . . . . f f f . . . . . . . . . . . . . . f f f . . . . . . . 
 
-`)
+`, SpriteKind.Player)
 theCar.vx = 20
 game.onUpdate(function () {
     if (theCar.x > scene.screenWidth() + 16) {


### PR DESCRIPTION
Sprite kind was null in Sprites.create() reference page. Added a default kind to snippets and noted use of **kind**.

Fixes https://github.com/microsoft/pxt-arcade/issues/2372