### PR TITLE
Replace sineTone lookup table with approximation

### DIFF
--- a/libs/mixer/melody.h
+++ b/libs/mixer/melody.h
@@ -6,7 +6,7 @@
 
 #define SW_TRIANGLE 1
 #define SW_SAWTOOTH 2
-#define SW_SINE 3 // TODO remove it? it takes space
+#define SW_SINE 3
 #define SW_NOISE 5
 #define SW_SQUARE_10 11
 #define SW_SQUARE_50 15


### PR DESCRIPTION
Instead of a 512-byte lookup table, use Bhaskara's approximation
formula, with some rescaling to match the input and output ranges.

The maximum error is 54/32767 = 0.00165 which should be good enough
for sound generation purposes, especially on target devices with
small non-HiFi speakers.