### PR TITLE
Animation missing help

### DIFF
--- a/libs/animation/legacy.ts
+++ b/libs/animation/legacy.ts
@@ -108,7 +108,7 @@ namespace animation {
         //% block="add frame $frame=screen_image_picker to $this=variables_get(anim)"
         //% group="Legacy"
         //% weight=40
-        //% help=animation/add-animation
+        //% help=animation/add-animation-frame
         addAnimationFrame(frame: Image) {
             this.frames[++this.index] = frame;
         }


### PR DESCRIPTION
AddAnimationFrame had a bad help path.

Also, https://github.com/microsoft/pxt-arcade/issues/2040 mentions missing help for the enum args. This is the case across all game/animation api's. Will the enum shims link the help path when clicked in the Toolbox? If so, I could add pages for those.

Fixes https://github.com/microsoft/pxt-arcade/issues/2040