### PR TITLE
snap to target location when on top of sprite in follow

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -926,6 +926,10 @@ class Sprite extends sprites.BaseSprite {
 
                     // already right on top of target; stop moving
                     if (Math.abs(dx) < 2 && Math.abs(dy) < 2) {
+                        // snap to target location so it sits 'right on top' of sprite.
+                        self.x = target.x;
+                        self.y = target.y;
+
                         self.vx = 0;
                         self.vy = 0;
                         return;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/2448

When we get to the point that we say we're 'close enough' and stop moving in a follow, snap to target location so the positions match exactly.

cc: @cosmoscowboy