### PR TITLE
Fix handling of assembly .comm directives

### DIFF
--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -995,6 +995,7 @@ void *gcAllocate(int numbytes);
 void *gcAllocateArray(int numbytes);
 extern "C" void *app_alloc(int numbytes);
 extern "C" void *app_free(void *ptr);
+extern "C" void *app_alloc_at(void *at, int numbytes);
 void gcPreAllocateBlock(uint32_t sz);
 
 #ifdef PXT64

--- a/libs/core/codal.cpp
+++ b/libs/core/codal.cpp
@@ -11,8 +11,6 @@ PXT_ABI(__aeabi_dsub)
 PXT_ABI(__aeabi_ddiv)
 PXT_ABI(__aeabi_dmul)
 
-#define PXT_COMM_BASE 0x20001000 // 4k in
-
 #ifdef DEVICE_GET_FIBER_LIST_AVAILABLE
 // newer codal-core has get_fiber_list() but not list_fibers()
 namespace codal {
@@ -62,37 +60,10 @@ static void commInit() {
     if (!commSize)
         return;
 
-    FreeList *head = NULL;
-    void *commBase = (void *)PXT_COMM_BASE;
-    for (;;) {
-        void *p = xmalloc(4);
-        // assume 4 byte alloc header; if we're not hitting 8 byte alignment, try allocating 8
-        // bytes, not 4 without the volatile, gcc assumes 8 byte alignment on malloc()
-        volatile uintptr_t hp = (uintptr_t)p;
-        if (hp & 4) {
-            xfree(p);
-            p = xmalloc(8);
-        }
-        if (p == commBase) {
-            xfree(p);
-            // allocate the comm section; this is never freed
-            p = xmalloc(commSize);
-            if (p != commBase)
-                oops(10);
-            break;
-        }
-        if (p > commBase)
-            oops(11);
-        auto f = (FreeList *)p;
-        f->next = head;
-        head = f;
-    }
-    // free all the filler stuff
-    while (head) {
-        auto p = head;
-        head = head->next;
-        xfree(p);
-    }
+    void *r = app_alloc_at((void *)PXT_COMM_BASE, commSize);
+    DMESG("comm %d -> %p", commSize, r);
+    if (!r)
+        target_panic(20);
 }
 
 static void initCodal() {
@@ -190,7 +161,7 @@ void runForever(Action a) {
 void runInParallel(Action a) {
     if (a != 0) {
         registerGCPtr(a);
-        create_fiber((void (*)(void *))runAction0, (void *)a, fiberDone);
+        create_fiber((void (*)(void *))(void*)runAction0, (void *)a, fiberDone);
     }
 }
 
@@ -289,4 +260,3 @@ void initSystemTimer() {
 }
 
 } // namespace pxt
-

--- a/libs/core/pxt.h
+++ b/libs/core/pxt.h
@@ -41,6 +41,8 @@ using namespace codal;
 #endif
 #endif
 
+#define PXT_COMM_BASE 0x20002000 // 8k in
+
 namespace pxt {
 
 #if CONFIG_ENABLED(DEVICE_USB)


### PR DESCRIPTION
This was for ELL compiled models; it was broken.

(I now use it for EdgeImpulse models)