### PR TITLE
add separate options for no collisions / overlaps

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -24,7 +24,8 @@ class PhysicsEngine {
 }
 
 const MAX_TIME_STEP = Fx8(100); // milliseconds
-const SPRITE_CANNOT_COLLIDE = sprites.Flag.Ghost | sprites.Flag.Destroyed | sprites.Flag.RelativeToCamera;
+const SPRITE_CANNOT_COLLIDE = SpriteFlag.NoTileCollisions | sprites.Flag.Destroyed | SpriteFlag.RelativeToCamera;
+const SPRITE_CANNOT_OVERLAP = SpriteFlag.NoSpriteOverlaps | sprites.Flag.Destroyed | SpriteFlag.RelativeToCamera;
 const MIN_MOVE_GAP = Fx8(0.1);
 
 class MovingSprite {
@@ -329,11 +330,11 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         // sprites that have moved this step
         for (const ms of movedSprites) {
             const sprite = ms.sprite;
-            if (sprite.flags & SPRITE_CANNOT_COLLIDE) continue;
+            if (sprite.flags & SPRITE_CANNOT_OVERLAP) continue;
             const overSprites = this.map.overlaps(ms.sprite);
 
             for (const overlapper of overSprites) {
-                if (overlapper.flags & SPRITE_CANNOT_COLLIDE) continue;
+                if (overlapper.flags & SPRITE_CANNOT_OVERLAP) continue;
                 const thisKind = sprite.kind();
                 const otherKind = overlapper.kind();
 
@@ -354,7 +355,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         .forEach(h => {
                             higher._overlappers.push(lower.id);
                             control.runInParallel(() => {
-                                if (!((sprite.flags | overlapper.flags) & SPRITE_CANNOT_COLLIDE)) {
+                                if (!((sprite.flags | overlapper.flags) & SPRITE_CANNOT_OVERLAP)) {
                                     h.handler(
                                         thisKind === h.kind ? sprite : overlapper,
                                         thisKind === h.kind ? overlapper : sprite

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -14,7 +14,11 @@ enum SpriteFlag {
     //% block="invisible"
     Invisible = sprites.Flag.Invisible,
     //% block="relative to camera"
-    RelativeToCamera = sprites.Flag.RelativeToCamera
+    RelativeToCamera = sprites.Flag.RelativeToCamera,
+    //% block="no tile collisions"
+    NoTileCollisions = sprites.Flag.NoTileCollisions,
+    //% block="no sprite overlaps"
+    NoSpriteOverlaps = sprites.Flag.NoSpriteOverlaps,
 }
 
 enum TileDirection {
@@ -749,9 +753,9 @@ class Sprite extends sprites.BaseSprite {
     overlapsWith(other: Sprite) {
         control.enablePerfCounter("overlapsCPP")
         if (other == this) return false;
-        if (this.flags & (sprites.Flag.Ghost | sprites.Flag.RelativeToCamera))
+        if (this.flags & (SpriteFlag.NoSpriteOverlaps | SpriteFlag.RelativeToCamera))
             return false
-        if (other.flags & (sprites.Flag.Ghost | sprites.Flag.RelativeToCamera))
+        if (other.flags & (SpriteFlag.NoSpriteOverlaps | SpriteFlag.RelativeToCamera))
             return false
         return other._image.overlapsWith(this._image, this.left - other.left, this.top - other.top)
     }

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -142,7 +142,7 @@ namespace sprites {
 
     export enum Flag {
         None = 0, // no flags are set
-        Ghost = 1 << 0, // doesn't collide with other sprites
+        // 1 << 0 was previously used for Ghost / is now available.
         Destroyed = 1 << 1, // whether the sprite has been destroyed or not
         AutoDestroy = 1 << 2, // remove the sprite when no longer visible
         StayInScreen = 1 << 3, // sprite cannot move outside the camera region
@@ -151,6 +151,9 @@ namespace sprites {
         ShowPhysics = 1 << 6, // display position, velocity, acc
         Invisible = 1 << 7, // makes the sprite invisible, so it does not show up on the screen
         IsClipping = 1 << 8, // whether the sprite is currently clipping into a wall. This can happen when a sprite is created or moved explicitly.
-        RelativeToCamera = 1 << 9 // draw relative to the camera, not the world (e.g. HUD elements)
+        RelativeToCamera = 1 << 9, // draw relative to the camera, not the world (e.g. HUD elements)
+        NoTileCollisions = 1 << 10, // No collisions or overlaps with tiles
+        NoSpriteOverlaps = 1 << 11, // No overlaps with other sprites
+        Ghost = sprites.Flag.NoSpriteOverlaps | sprites.Flag.NoTileCollisions, // doesn't collide with other sprites or walls
     }
 }


### PR DESCRIPTION
for https://forum.makecode.com/t/sprite-move-through-tile-map-walls/3985/13

example: jumpy platformer where the bats can move through walls and you get a cheat mode where you don't touch sprites if you hit 'b' https://arcade.makecode.com/app/09cfd1c8063b0d69ce25e7703281edb2efb1b0dc-b3db6078b4#pub:_ftk7vCXPUFWF