### PR TITLE
add flag to disable msg broadcast in simmessages

### DIFF
--- a/libs/base/controlmessage.ts
+++ b/libs/base/controlmessage.ts
@@ -4,7 +4,7 @@ namespace control.simmessages {
     export const CONTROL_MESSAGE_RECEIVED = 1;
 
     //% shim=pxt::sendMessage
-    export declare function send(channel: string, message: Buffer, noBroadcast?: boolean) : void;
+    export declare function send(channel: string, message: Buffer, parentOnly?: boolean) : void;
 
     //% shim=pxt::peekMessageChannel
     declare function peekMessageChannel(): string;

--- a/libs/base/controlmessage.ts
+++ b/libs/base/controlmessage.ts
@@ -4,11 +4,11 @@ namespace control.simmessages {
     export const CONTROL_MESSAGE_RECEIVED = 1;
 
     //% shim=pxt::sendMessage
-    export declare function send(channel: string, message: Buffer) : void;
+    export declare function send(channel: string, message: Buffer, noBroadcast?: boolean) : void;
 
     //% shim=pxt::peekMessageChannel
     declare function peekMessageChannel(): string;
-    
+
     //% shim=pxt::readMessageData
     declare function readMessageData(): Buffer;
 
@@ -27,8 +27,8 @@ namespace control.simmessages {
         }
     }
 
-    /** 
-     * Registers the handler for a message on a given channel 
+    /**
+     * Registers the handler for a message on a given channel
      **/
     export function onReceived(channel: string, handler: (msg: Buffer) => void) {
         if (!channel) return;

--- a/libs/base/sim/controlmessage.ts
+++ b/libs/base/sim/controlmessage.ts
@@ -1,12 +1,12 @@
 
 namespace pxsim.pxtcore {
     // general purpose message sending mechanism
-    export function sendMessage(channel: string, message: RefBuffer, noBroadcast?: boolean) {
+    export function sendMessage(channel: string, message: RefBuffer, parentOnly?: boolean) {
         if (!channel) return;
 
         Runtime.postMessage({
             type: "messagepacket",
-            broadcast: !noBroadcast,
+            broadcast: !parentOnly,
             channel: channel,
             data: message && message.data
         } as SimulatorControlMessage)

--- a/libs/base/sim/controlmessage.ts
+++ b/libs/base/sim/controlmessage.ts
@@ -1,12 +1,12 @@
 
 namespace pxsim.pxtcore {
     // general purpose message sending mechanism
-    export function sendMessage(channel: string, message: RefBuffer) {
+    export function sendMessage(channel: string, message: RefBuffer, noBroadcast?: boolean) {
         if (!channel) return;
 
         Runtime.postMessage({
             type: "messagepacket",
-            broadcast: true,
+            broadcast: !noBroadcast,
             channel: channel,
             data: message && message.data
         } as SimulatorControlMessage)
@@ -17,7 +17,7 @@ namespace pxsim.pxtcore {
         const msg = state && state.peek();
         return msg && msg.channel;
     }
-    
+
     export function readMessageData(): RefBuffer {
         const state = getControlMessageState();
         const msg = state && state.read();
@@ -31,7 +31,7 @@ namespace pxsim {
         channel: string;
         data: Uint8Array;
     }
-    
+
     // keep in sync with ts
     export const CONTROL_MESSAGE_EVT_ID = 2999;
     export const CONTROL_MESSAGE_RECEIVED = 1;
@@ -43,7 +43,7 @@ namespace pxsim {
         constructor(private board: CommonBoard) {
             this.messages = [];
             this.enabled = false;
-            this.board.addMessageListener(msg => this.messageHandler(msg));            
+            this.board.addMessageListener(msg => this.messageHandler(msg));
         }
         private messageHandler(msg: SimulatorMessage) {
             if (msg.type == "messagepacket") {
@@ -63,7 +63,7 @@ namespace pxsim {
         }
     }
 
-    
+
     export interface ControlMessageBoard extends CommonBoard {
         controlMessageState: ControlMessageState;
     }


### PR DESCRIPTION
So it can just go to the parent, instead of creating a second simulator each time.

I don't see how the cpp side of things works here, so not sure if anything would be needed there? The only use of it I've seen right away is [here](https://github.com/microsoft/pxt-jacdac-services/commit/7cdcf8e2e78bed0f3ca14a7e40b7d190e2f8aba1#diff-52838880e988354f72feddfcd58faddb78dc93e73f050139f97cd377405cb2d7R15), is the behavior just that this shim only applies on hardware so the simulator goes through the function body / calls this api?

For reference, I was looking at using this here: https://github.com/jwunderl/arcade-tick-event/blob/master/main.ts#L48