### PR TITLE
Don't unregister melody if stopped and restarted

### DIFF
--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -250,7 +250,11 @@ namespace music {
                     if (!loop)
                         break
                 }
-                this.unregisterMelody();
+                // Unregister the melody if it was stopped and not restarted.
+                // (It was restarted if this._player is a new MelodyPlayer.)
+                if (!this._player) {
+                    this.unregisterMelody();
+                }
             })
         }
 

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -247,13 +247,16 @@ namespace music {
             control.runInParallel(() => {
                 while (this._player == p) {
                     p.play(volume)
-                    if (!loop)
+                    if (!loop) {
+                        // Unregister the melody when done playing, but
+                        // only if it hasn't been restarted. (Looping
+                        // melodies never stop on their own, they only
+                        // get unregistered via stop().)
+                        if (this._player == p) {
+                            this.unregisterMelody();
+                        }
                         break
-                }
-                // Unregister the melody if it was stopped and not restarted.
-                // (It was restarted if this._player is a new MelodyPlayer.)
-                if (!this._player) {
-                    this.unregisterMelody();
+                    }
                 }
             })
         }


### PR DESCRIPTION
If a melody is stopped and restarted while playing, it must
not be unregistered by the playCore handler to avoid keeping
unstoppable melodies running in the background.

Fixes microsoft/pxt-arcade#2541