### PR TITLE
fix typo breaking arcade build

### DIFF
--- a/libs/serial---linux/serial-target.cpp
+++ b/libs/serial---linux/serial-target.cpp
@@ -192,7 +192,7 @@ Buffer LinuxSerialDevice::readBuffer() {
     auto r = mkBuffer(NULL, sz);
     registerGCObj(r);
     int sz2 = readBuf(r->data, sz);
-    unegisterGCObj(r);
+    unregisterGCObj(r);
     if (sz != sz2)
         target_panic(999);
     pthread_mutex_unlock(&lock);


### PR DESCRIPTION
typo in https://github.com/microsoft/pxt-common-packages/pull/1193 breaking arcade serve; I don't think this would need to be ported to microbit/stable as it's just part of the linux build