### PR TITLE
Update configkeys.h to include new pins for Adafruit Grand Central M4

### DIFF
--- a/libs/base/configkeys.h
+++ b/libs/base/configkeys.h
@@ -385,6 +385,57 @@
 #define CFG_PIN_GROVE1 1041
 #define CFG_PIN_SS 1042
 
+// Adafruit Grand Central M4
+#define CFG_PIN_D33 = 183
+#define CFG_PIN_D34 = 184
+#define CFG_PIN_D35 = 185
+#define CFG_PIN_D36 = 186
+#define CFG_PIN_D37 = 187
+#define CFG_PIN_D38 = 188
+#define CFG_PIN_D39 = 189
+#define CFG_PIN_D40 = 190
+#define CFG_PIN_D41 = 191
+#define CFG_PIN_D42 = 192
+#define CFG_PIN_D43 = 193
+#define CFG_PIN_D44 = 194
+#define CFG_PIN_D45 = 195
+#define CFG_PIN_D46 = 196
+#define CFG_PIN_D47 = 197
+#define CFG_PIN_D48 = 198
+#define CFG_PIN_D49 = 199
+#define CFG_PIN_D50 = 259
+#define CFG_PIN_D51 = 260
+#define CFG_PIN_D52 = 261
+#define CFG_PIN_D53 = 262
+
+#define CFG_PIN_TX1 = 263
+#define CFG_PIN_TX2 = 264
+#define CFG_PIN_TX3 = 265
+#define CFG_PIN_RX1 = 266
+#define CFG_PIN_RX2 = 267
+#define CFG_PIN_RX3 = 268
+#define CFG_PIN_SCL1 = 269
+#define CFG_PIN_SDA1 = 270
+#define CFG_PIN_PCC_D0 = 271
+#define CFG_PIN_PCC_D1 = 272
+#define CFG_PIN_PCC_D2= 273
+#define CFG_PIN_PCC_D3 = 274
+#define CFG_PIN_PCC_D4 = 275
+#define CFG_PIN_PCC_D5 = 276
+#define CFG_PIN_PCC_D6 = 277
+#define CFG_PIN_PCC_D7 = 278
+#define CFG_PIN_PCC_D8 = 279
+#define CFG_PIN_PCC_D9 = 280
+#define CFG_PIN_PCC_D10 = 281
+#define CFG_PIN_PCC_D11 = 282
+#define CFG_PIN_PCC_D12 = 283
+#define CFG_PIN_PCC_D13 = 284
+#define CFG_PIN_CC_DEN1  = 285
+#define CFG_PIN_CC_DEN2 = 286
+#define CFG_PIN_CC_CLK = 287
+#define CFG_PIN_XCC_CLK = 288
+
+
 #define CFG_PIN_JDPWR_PRE_SENSE 1100
 #define CFG_PIN_JDPWR_GND_SENSE 1101
 #define CFG_PIN_JDPWR_PULSE 1102


### PR DESCRIPTION
on behalf of @lalauria2000.  Part 1 of 2.

See: https://github.com/microsoft/pxt-maker/pull/324