### PR TITLE
sprites shouldn't float due to lag

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -277,27 +277,8 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         sprite._vx = this.constrain(sprite._vx);
         sprite._vy = this.constrain(sprite._vy);
 
-        const dx = Fx.idiv(
-            Fx.mul(
-                Fx.add(
-                    sprite._vx,
-                    ovx
-                ),
-                dt2
-            ),
-            1000
-        );
-
-        const dy = Fx.idiv(
-            Fx.mul(
-                Fx.add(
-                    sprite._vy,
-                    ovy
-                ),
-                dt2
-            ),
-            1000
-        );
+        const dx = Fx8(Fx.toFloat(Fx.add(sprite._vx, ovx)) * Fx.toInt(dt2) / 1000);
+        const dy = Fx8(Fx.toFloat(Fx.add(sprite._vy, ovy)) * Fx.toInt(dt2) / 1000);
 
         let xStep = dx;
         let yStep = dy;


### PR DESCRIPTION
Fix https://github.com/microsoft/pxt-arcade/issues/2320
fix https://github.com/microsoft/pxt-arcade/issues/2744


When there's a lot of lag and sprites have high speeds, it's possible to overflow fx8 in this calculation (or underflow it when the calculation is flipped). Replaces this one with a normal floating point normal mul / divide so that doesn't happen