### PR TITLE
define animation blockIdentity so animations temp strings decompile in docs

### DIFF
--- a/libs/game/assetTemplates.ts
+++ b/libs/game/assetTemplates.ts
@@ -31,6 +31,7 @@ namespace assets {
 
     //% helper=getAnimationByName
     //% pyConvertToTaggedTemplate
+    //% blockIdentity="animation._animationFrames"
     export function animation(lits: any, ...args: any[]): Image[] { return null }
 }
 


### PR DESCRIPTION
Define the blockIdentity for animations so they decompile properly for the docs svgs (instead of just being gray blocks). re: https://github.com/microsoft/pxt/pull/7784

As far as I can tell this was left off because the block is in an extension, but that would just mean it fails out to a gray block here https://github.com/microsoft/pxt/blob/0beaeb3e7690664ec50e571a5591edca75561878/pxtcompiler/emitter/decompiler.ts#L3410 instead of the check before when the animations extension isn't loaded, which seems fine.