### PR TITLE
Move array of sprites of kind block to Sprites

### DIFF
--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -52,7 +52,6 @@ namespace sprites {
      * @param kind the target kind
      */
     //% blockId=allOfKind block="array of sprites of kind %kind=spritekind"
-    //% blockNamespace="arrays" blockSetVariable="sprite list"
     //% weight=87
     export function allOfKind(kind: number): Sprite[] {
         const spritesByKind = game.currentScene().spritesByKind;


### PR DESCRIPTION
Remove from "Arrays", move to "Sprites"

![image](https://user-images.githubusercontent.com/34112083/105222990-0f589500-5b10-11eb-8da2-060d9d195c69.png)

fixes https://github.com/microsoft/pxt-arcade/issues/1815#issuecomment-763854627