### PR TITLE
round sprite rendering consistently (floor instead of |0)

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -652,8 +652,8 @@ class Sprite extends sprites.BaseSprite {
         const ox = (this.flags & sprites.Flag.RelativeToCamera) ? 0 : camera.drawOffsetX;
         const oy = (this.flags & sprites.Flag.RelativeToCamera) ? 0 : camera.drawOffsetY;
 
-        const l = this.left - ox;
-        const t = this.top - oy;
+        const l = Math.floor(this.left - ox);
+        const t = Math.floor(this.top - oy);
 
         screen.drawTransparentImage(this._image, l, t)
 


### PR DESCRIPTION
Not a recent regression, but simple fix / I've seen it happen a lot before (don't think anyone's made explicit note of it that I've seen?)

in drawTransparentImage any decimal points are lopped off / treated as ints - sim side this is handled with an | 0 on each, hardware side it's just part of the ts->cpp layer. This causes any sprites whose positions have fraction components to be offset differently when those positions are positive vs negative, as `| 0` rounds towards 0. E.g. move to the right in this game and see the rectangles get offset when they are slightly off screen: https://makecode.com/_fwphzuhAxMjC

re: behavior not noted before, just read through the latest comment in https://forum.makecode.com/t/strange-recent-behavior-with-setposition-method/5615/6?u=jwunderl from them and they actually found the same thing as I did hah, so half reported!