### PR TITLE
add standalone / non-blockSetVariable sprites.create

### DIFF
--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -48,6 +48,19 @@ namespace sprites {
     }
 
     /**
+     * Create a new sprite from an image
+     * @param img the image
+     */
+    //% group="Create"
+    //% blockId=spritescreatenoset block="sprite %img=screen_image_picker of kind %kind=spritekind"
+    //% blockAliasFor="sprites.create"
+    //% expandableArgumentMode=toggle
+    //% weight=99 help=sprites/create
+    export function __create(img: Image, kind?: number): Sprite {
+        return sprites.create(img, kind);
+    }
+
+    /**
      * Return an array of all sprites of the given kind.
      * @param kind the target kind
      */


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/3004

The `aliasFor` makes it so it compiles down to `sprites.create` instead of as a separate function

![image](https://user-images.githubusercontent.com/5615930/106673986-61b1a100-6567-11eb-86d8-f3eb7230fe10.png)
