### PR TITLE
Update projectile ref pages

### DIFF
--- a/libs/game/docs/reference/sprites.md
+++ b/libs/game/docs/reference/sprites.md
@@ -5,8 +5,9 @@ Create and move game objects. Handle overlaps between objects.
 ## Create sprites
 
 ```cards
-sprites.create(img`.`)
-sprites.createProjectile(img`.`, 0, 0, 0)
+sprites.create(img`.`, SpriteKind.Player)
+sprites.createProjectileFromSprite(img`.`, null, 50, 50)
+sprites.createProjectileFromSide(img`.`, 50, 50)
 ```
 
 ## Sprite actions
@@ -68,7 +69,8 @@ sprites.onOverlap(0, 0, function (sprite, otherSprite) {})
 ## See also
 
 [create](/reference/sprites/create),
-[create projectile](/reference/sprites/create-projectile),
+[create projectile from side](/reference/sprites/create-projectile-from-side),
+[create projectile from sprite](/reference/sprites/create-projectile-from-sprite),
 [say](/reference/sprites/sprite/say),
 [overlaps with](/reference/sprites/sprite/overlaps-with),
 [destroy](/reference/sprites/sprite/destroy),

--- a/libs/game/docs/reference/sprites/create-projectile-from-side.md
+++ b/libs/game/docs/reference/sprites/create-projectile-from-side.md
@@ -1,0 +1,94 @@
+# create Projectile From Side
+
+Create a new motion sprite that starts at the side of the screen.
+
+```sig
+sprites.createProjectileFromSide(img`.`, 50, 50)
+```
+
+A projectile is a motion sprite that moves from the location it's created at. It moves with speeds (velocities `vx` and `vy`) that you set in both the horizontal and vertical directions.
+
+The side of the screen that the projectile starts from depends on the direction of the velocity values it's given. The `vx` and `vy` velocities have either positive or negative values which determine the direction. The projectile starts from a side of the screen based on the velocity direction shown in the following table.
+
+|Side|vx|vy|
+|-|-|-|
+|upper left|positive|positive|
+|lower left|positive|negative|
+|upper right|negative|positive|
+|lower right|negative|negative|
+<br/>
+
+The projectile has many of the same properties that a non-moving sprite has. It will overlap with other sprites, hit and overlap tiles.
+
+Projectiles are destroyed when they move off of the screen.
+
+## Parameters
+
+* **img**: an [image](/types/image) for the projectile sprite.
+* **vx**: the speed in the horizontal direction for the sprite to move at.
+* **vy**: the speed in the vertical direction for the sprite to move at.
+
+## Returns
+
+* a new projectile [sprite](/types/sprite) that moves with set velocities.
+
+## Examples #example
+
+### Create a projectile at the bottom left #ex1
+
+Start a projectile sprite from the bottom left of the screen. Make it bounce on the sides of the screen.
+
+```blocks
+let projectile = sprites.createProjectileFromSide(img`
+    . . . . 5 5 5 5 5 5 5 5 . . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+    . 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+    5 5 5 5 5 5 . . . . 5 5 5 5 5 5 
+    5 5 5 5 5 . . . . . . 5 5 5 5 5 
+    5 5 5 5 . . . . . . . . 5 5 5 5 
+    5 5 5 5 . . . . . . . . 5 5 5 5 
+    5 5 5 5 . . . . . . . . 5 5 5 5 
+    5 5 5 5 . . . . . . . . 5 5 5 5 
+    5 5 5 5 5 . . . . . . 5 5 5 5 5 
+    5 5 5 5 5 5 . . . . 5 5 5 5 5 5 
+    . 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+    . 5 5 5 5 5 5 5 5 5 5 5 5 5 5 . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . . 5 5 5 5 5 5 5 5 . . . . 
+    `, 40, -30)
+projectile.setFlag(SpriteFlag.BounceOnWall, true)
+```
+
+### Create projectiles for all sides #ex2
+
+Create projectiles that start randomly from all sides of the screen. Show the projectile direction by displaying the physics properties.
+
+```blocks
+let projectile: Sprite = null
+game.onUpdateInterval(2000, function () {
+    projectile = sprites.createProjectileFromSide(img`
+        . 7 7 7 7 7 7 7 7 7 7 7 7 7 7 . 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 7 
+        . 7 7 7 7 7 7 7 7 7 7 7 7 7 7 . 
+        `, randint(-50, 50), randint(-50, 50))
+    projectile.setFlag(SpriteFlag.ShowPhysics, true)
+})
+```
+
+## See also #seealso
+
+[create](/reference/sprites/create), [create projectile from sprite](/reference/sprites/create-projectile-from-sprite)

--- a/libs/game/docs/reference/sprites/create-projectile-from-sprite.md
+++ b/libs/game/docs/reference/sprites/create-projectile-from-sprite.md
@@ -8,7 +8,7 @@ sprites.createProjectileFromSprite(img`.`, null, 50, 50)
 
 A projectile is a motion sprite that moves from the location it's created at. It moves with speeds (velocities `vx` and `vy`) that you set in both the horizontal and vertical directions.
 
-The projectile sprite starts from the center of a `sprite` that you set for it. The `vx` and `vy` velocities have either positive or negative values which determine the direction the projectile moves in.
+The projectile sprite starts from the center of a `sprite` that you set for it. The `vx` and `vy` velocities have either positive or negative values which determine the direction that the projectile moves in.
 
 The projectile has many of the same properties that a non-moving sprite has. It will overlap with other sprites, hit and overlap tiles.
 

--- a/libs/game/docs/reference/sprites/create-projectile-from-sprite.md
+++ b/libs/game/docs/reference/sprites/create-projectile-from-sprite.md
@@ -1,0 +1,132 @@
+# create Projectile From Sprite
+
+Create a new motion sprite that starts from the center of another sprite.
+
+```sig
+sprites.createProjectileFromSprite(img`.`, null, 50, 50)
+```
+
+A projectile is a motion sprite that moves from the location it's created at. It moves with speeds (velocities `vx` and `vy`) that you set in both the horizontal and vertical directions.
+
+The projectile sprite starts from the center of a `sprite` that you set for it. The `vx` and `vy` velocities have either positive or negative values which determine the direction the projectile moves in.
+
+The projectile has many of the same properties that a non-moving sprite has. It will overlap with other sprites, hit and overlap tiles.
+
+Projectiles are destroyed when they move off of the screen.
+
+## Parameters
+
+* **img**: an [image](/types/image) for the projectile sprite.
+* **sprite**: the [sprite](/types/sprite) to start the projectile from.
+* **vx**: the speed in the horizontal direction for the sprite to move at.
+* **vy**: the speed in the vertical direction for the sprite to move at.
+
+## Returns
+
+* a new projectile [sprite](/types/sprite) that moves with set velocities.
+
+## Examples #example
+
+### Send projectiles out of the box #ex1
+
+Create a sprite in the shape of a box. Send projectiles out in random directions from the center of the box.
+
+```blocks
+let projectile: Sprite = null
+let mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 . . . . . . . . . . . . . . 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    projectile = sprites.createProjectileFromSprite(img`
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . 8 8 8 8 . . . . . . 
+        . . . . . 8 8 8 8 8 8 . . . . . 
+        . . . . . 8 8 a a 8 8 . . . . . 
+        . . . . . 8 8 a a 8 8 . . . . . 
+        . . . . . 8 8 8 8 8 8 . . . . . 
+        . . . . . . 8 8 8 8 . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        `, mySprite, randint(-50, 50), randint(-50, 50))
+})
+```
+
+### Photon blaster #ex2
+
+Send photons from a spaceship when the ``B`` button is pressed.
+
+```blocks
+let photon: Sprite = null
+let target = sprites.create(img`
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    e e e e e e e . . . . . . . . . 
+    `, SpriteKind.Enemy)
+let ship = sprites.create(img`
+    .....bbbbbbbbbb...........
+    bbbbbbddddddddbbbb........
+    bbdddddddddddddddbbbb.....
+    .bdddddffffffdddddddbbbb..
+    .bdddddddddddddddffddddbb.
+    .bbddddddddddddddffdddddbb
+    ..bdddfffffffffddddddddbb.
+    ..bddddddddddddddddbbbbb..
+    .bbdddddddddddddbbbb......
+    .bddddddddddbbbb..........
+    bbddbbbbbdbbb.............
+    bbbbb...bbb...............
+    `, SpriteKind.Player)
+ship.x = 20
+target.x = scene.screenWidth() - 10
+controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
+    photon = sprites.createProjectileFromSprite(img`
+        . . . . . . 1 1 1 . . 
+        . . . 1 1 1 1 1 1 1 . 
+        1 1 1 1 1 1 1 1 1 1 1 
+        . . . 1 1 1 1 1 1 1 . 
+        . . . . . . 1 1 1 . . 
+        `, ship, 150, 0)
+})
+sprites.onOverlap(SpriteKind.Projectile, SpriteKind.Enemy, function (sprite, otherSprite) {
+    sprite.startEffect(effects.disintegrate, 100)
+})
+```
+
+## See also #seealso
+
+[create](/reference/sprites/create), [create projectile from side](/reference/sprites/create-projectile-from-side)


### PR DESCRIPTION
Add new reference pages for **createProjectileFromSide** and **createProjectileFromSprite**.

Closes https://github.com/microsoft/pxt-arcade/issues/2730