### PR TITLE
Handle very large dialog frames

### DIFF
--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -17,6 +17,7 @@ namespace game {
     let dialogFrame: Image;
     let dialogCursor: Image;
     let dialogTextColor: number;
+    const MAX_FRAME_UNIT = 12;
 
     export class BaseDialog {
         image: Image;
@@ -167,11 +168,11 @@ namespace game {
         }
 
         protected textAreaWidth() {
-            return this.image.width - ((this.innerLeft + this.unit) << 1) - 2;
+            return this.image.width - ((this.innerLeft + Math.min(this.unit, MAX_FRAME_UNIT)) << 1) - 2;
         }
 
         protected textAreaHeight() {
-            return this.image.height - ((this.innerTop + this.unit) << 1) - 1;
+            return this.image.height - ((this.innerTop + Math.min(this.unit, MAX_FRAME_UNIT)) << 1) - 1;
         }
 
         protected setFont(font: image.Font) {
@@ -240,8 +241,11 @@ namespace game {
             const charactersPerRow = Math.floor(availableWidth / this.font.charWidth);
             const rowsOfCharacters = Math.floor(availableHeight / this.rowHeight());
 
-            const textLeft = 1 + this.innerLeft + this.unit + ((availableWidth - charactersPerRow * this.font.charWidth) >> 1);
-            const textTop = 1 + this.innerTop + this.unit + ((availableHeight - rowsOfCharacters * this.rowHeight()) >> 1);
+            if (this.unit > MAX_FRAME_UNIT) this.drawBorder();
+
+            const textLeft = 1 + this.innerLeft + Math.min(this.unit, MAX_FRAME_UNIT) + ((availableWidth - charactersPerRow * this.font.charWidth) >> 1);
+            const textTop = 1 + (this.image.height >> 1) - ((lines.length * this.rowHeight()) >> 1);
+            console.log(`top: ${textTop} inner: ${this.innerTop} rows: ${this.rows} avheight: ${availableHeight}`)
 
             for (let row = 0; row < lines.length; row++) {
                 this.image.print(

--- a/libs/game/textDialogs.ts
+++ b/libs/game/textDialogs.ts
@@ -245,7 +245,6 @@ namespace game {
 
             const textLeft = 1 + this.innerLeft + Math.min(this.unit, MAX_FRAME_UNIT) + ((availableWidth - charactersPerRow * this.font.charWidth) >> 1);
             const textTop = 1 + (this.image.height >> 1) - ((lines.length * this.rowHeight()) >> 1);
-            console.log(`top: ${textTop} inner: ${this.innerTop} rows: ${this.rows} avheight: ${availableHeight}`)
 
             for (let row = 0; row < lines.length; row++) {
                 this.image.print(


### PR DESCRIPTION
We have a problem right now when rendering text dialogs that are very large (bigger than 36x36). You can see it with the big leaf frame:

<img width="792" alt="Screen Shot 2021-04-26 at 11 42 31 AM" src="https://user-images.githubusercontent.com/13754588/116134191-7db77100-a684-11eb-9fd2-8c4b14e14ab2.png">

This fix just makes it so that we bleed into the border in this case instead of doing this. We have a bunch of big frames coming in soon


<img width="792" alt="Screen Shot 2021-04-26 at 11 45 57 AM" src="https://user-images.githubusercontent.com/13754588/116134644-ffa79a00-a684-11eb-900e-413edf9b37cf.png">
