### PR TITLE
destroyed sprites cannot collide with other sprites

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -779,9 +779,9 @@ class Sprite extends sprites.BaseSprite {
     overlapsWith(other: Sprite) {
         control.enablePerfCounter("overlapsCPP")
         if (other == this) return false;
-        if (this.flags & (SpriteFlag.GhostThroughSprites | SpriteFlag.RelativeToCamera))
+        if (this.flags & SPRITE_NO_SPRITE_OVERLAPS)
             return false
-        if (other.flags & (SpriteFlag.GhostThroughSprites | SpriteFlag.RelativeToCamera))
+        if (other.flags & SPRITE_NO_SPRITE_OVERLAPS)
             return false
         return other._image.overlapsWith(this._image, this.left - other.left, this.top - other.top)
     }


### PR DESCRIPTION
fix https://forum.makecode.com/t/sprites-still-overlap-after-being-destroyed/7668