### PR TITLE
define ble_running for non-microbit NRF-based boards

### DIFF
--- a/libs/core/usb.cpp
+++ b/libs/core/usb.cpp
@@ -76,6 +76,9 @@ void set_usb_strings(const char *uf2_info) {
             string_descriptors[0] = dev;
             string_descriptors[1] = dev;
         }
+    } else {
+        string_descriptors[0] = "Unknown Corp.";
+        string_descriptors[1] = "PXT Device (app)";
     }
 
     string_descriptors[2] = serial;
@@ -98,7 +101,6 @@ void usb_init() {
     // so we add a dummy interface
     usb.add(dummyIface);
 #endif
-
 
 #if CONFIG_ENABLED(DEVICE_MOUSE)
     usb.add(mouse);
@@ -133,7 +135,7 @@ bool isUSBInitialized() {
     return false;
 #endif
 }
-}
+} // namespace control
 
 namespace pxt {
 static void (*pSendToUART)(const char *data, int len) = NULL;

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1156,8 +1156,9 @@ extern "C" void *memcpy(void *dst, const void *src, size_t sz) {
         src = s;
     }
 
-    uint8_t *dd = (uint8_t *)dst;
-    uint8_t *ss = (uint8_t *)src;
+    // see comment in memset() below (have not seen optimization here, but better safe than sorry)
+    volatile uint8_t *dd = (uint8_t *)dst;
+    volatile uint8_t *ss = (uint8_t *)src;
 
     while (sz--) {
         *dd++ = *ss++;
@@ -1179,7 +1180,8 @@ extern "C" void *memset(void *dst, int v, size_t sz) {
         dst = d;
     }
 
-    uint8_t *dd = (uint8_t *)dst;
+    // without volatile here, GCC may optimize the loop to memset() call which is obviously not great
+    volatile uint8_t *dd = (uint8_t *)dst;
 
     while (sz--) {
         *dd++ = v;

--- a/libs/settings/NRF52Flash.cpp
+++ b/libs/settings/NRF52Flash.cpp
@@ -27,11 +27,7 @@ NRF_SDH_SOC_OBSERVER(nrfflash_soc_observer, 0, nvmc_event_handler, NULL);
 bool ble_running()
 {
     uint8_t t = 0;
-
-#ifdef SOFTDEVICE_PRESENT
     sd_softdevice_is_enabled(&t);
-#endif
-
     return t==1;
 }
 #endif

--- a/libs/settings/NRF52Flash.cpp
+++ b/libs/settings/NRF52Flash.cpp
@@ -13,6 +13,7 @@ static volatile bool flash_op_complete = false;
 
 #ifdef SOFTDEVICE_PRESENT
 #include "nrf_sdh_soc.h"
+#include "nrf_sdm.h"
 
 static void nvmc_event_handler(uint32_t sys_evt, void *)
 {
@@ -21,6 +22,19 @@ static void nvmc_event_handler(uint32_t sys_evt, void *)
 }
 
 NRF_SDH_SOC_OBSERVER(nrfflash_soc_observer, 0, nvmc_event_handler, NULL);
+
+#ifndef MICROBIT_CODAL
+bool ble_running()
+{
+    uint8_t t = 0;
+
+#ifdef SOFTDEVICE_PRESENT
+    sd_softdevice_is_enabled(&t);
+#endif
+
+    return t==1;
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
ble_running is defined by MicroBitDevice.h and everything compiles successfully. For other boards with softdevice, ble_running is now defined here.