### PR TITLE
[stable8.8] Minor arcade ports

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -208,7 +208,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         }
     }
 
-    private createMovingSprite(sprite: Sprite, dtMs: number, dt2: number): MovingSprite {
+    protected createMovingSprite(sprite: Sprite, dtMs: number, dt2: number): MovingSprite {
         const ovx = this.constrain(sprite._vx);
         const ovy = this.constrain(sprite._vy);
         sprite._lastX = sprite._x;
@@ -300,7 +300,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         );
     }
 
-    private spriteCollisions(movedSprites: MovingSprite[], handlers: scene.OverlapHandler[]) {
+    protected spriteCollisions(movedSprites: MovingSprite[], handlers: scene.OverlapHandler[]) {
         control.enablePerfCounter("phys_collisions");
         if (!handlers.length) return;
 
@@ -346,7 +346,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         }
     }
 
-    private tilemapCollisions(movingSprite: MovingSprite, tm: tiles.TileMap) {
+    protected tilemapCollisions(movingSprite: MovingSprite, tm: tiles.TileMap) {
         const s = movingSprite.sprite;
         // if the sprite is already clipping into a wall,
         // allow free movement rather than randomly 'fixing' it
@@ -589,7 +589,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
      * @param sprite the sprite
      * @param overlappedTiles the list of tiles the sprite is overlapping
      */
-    private tilemapOverlaps(sprite: Sprite, overlappedTiles: tiles.Location[]) {
+    protected tilemapOverlaps(sprite: Sprite, overlappedTiles: tiles.Location[]) {
         const alreadyHandled: tiles.Location[] = [];
 
         for (const tile of overlappedTiles) {
@@ -724,7 +724,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         return false;
     }
 
-    private constrain(v: Fx8) {
+    protected constrain(v: Fx8) {
         return Fx.max(
             Fx.min(
                 this.maxVelocity,

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -779,9 +779,9 @@ class Sprite extends sprites.BaseSprite {
     overlapsWith(other: Sprite) {
         control.enablePerfCounter("overlapsCPP")
         if (other == this) return false;
-        if (this.flags & (SpriteFlag.GhostThroughSprites | SpriteFlag.RelativeToCamera))
+        if (this.flags & SPRITE_NO_SPRITE_OVERLAPS)
             return false
-        if (other.flags & (SpriteFlag.GhostThroughSprites | SpriteFlag.RelativeToCamera))
+        if (other.flags & SPRITE_NO_SPRITE_OVERLAPS)
             return false
         return other._image.overlapsWith(this._image, this.left - other.left, this.top - other.top)
     }

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -207,12 +207,13 @@ namespace tiles {
 
         protected _layer: number;
         protected _map: TileMapData;
+        renderable: scene.Renderable;
 
         constructor(scale: TileScale = TileScale.Sixteen) {
             this._layer = 1;
             this.scale = scale;
 
-            scene.createRenderable(
+            this.renderable = scene.createRenderable(
                 scene.TILE_MAP_Z,
                 (t, c) => this.draw(t, c)
             );


### PR DESCRIPTION

* port https://github.com/microsoft/pxt-common-packages/pull/1246 -- fix a few issues we ran into on stream which was making it tedious to subclass physics by exposing a few extra things
* port https://github.com/microsoft/pxt-common-packages/pull/1251 -- fix an issue with the boolean 'sprite overlaps with otherSprite' block (re: https://forum.makecode.com/t/sprites-still-overlap-after-being-destroyed/7668)