### PR TITLE
add image blit method

### DIFF
--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1073,8 +1073,17 @@ void blit(Image_ dst, int xDst, int yDst, int wDst, int hDst, Image_ src, int xS
 }
 
 //%
-void _blit(Image_ dst, int xyDst, int whDst, Image_ src, int xySrc, int whSrc, bool transparent) {
-    blit(dst, XX(xyDst), YY(xyDst), XX(whDst), YY(whDst), src, XX(xySrc), YY(xySrc), XX(whSrc), YY(whSrc), transparent);
+void _blit(Image_ dst, Image_ src, RefCollection args) {
+    int xDst = toInt(args.getAt(0));
+    int yDst = toInt(args.getAt(1));
+    int wDst = toInt(args.getAt(2));
+    int hDst = toInt(args.getAt(3));
+    int xSrc = toInt(args.getAt(4));
+    int ySrc = toInt(args.getAt(5));
+    int wSrc = toInt(args.getAt(6));
+    int hSrc = toInt(args.getAt(7));
+    auto transparent = toBoolQuick(args.getAt(8));
+    blit(dst, xDst, yDst, wDst, hDst, src, xSrc, ySrc, wSrc, hSrc, transparent);
 }
 
 void fillCircle(Image_ img, int cx, int cy, int r, int c) {

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1068,6 +1068,15 @@ void _blitRow(Image_ img, int xy, Image_ from, int xh) {
     blitRow(img, XX(xy), YY(xy), from, XX(xh), YY(xh));
 }
 
+void blit(Image_ dst, int xDst, int yDst, int wDst, int hDst, Image_ src, int xSrc, int ySrc, int wSrc, int hSrc, bool transparent) {
+    // TODO
+}
+
+//%
+void _blit(Image_ dst, int xyDst, int whDst, Image_ src, int xySrc, int whSrc, bool transparent) {
+    blit(dst, XX(xyDst), YY(xyDst), XX(whDst), YY(whDst), src, XX(xySrc), YY(xySrc), XX(whSrc), YY(whSrc), transparent);
+}
+
 void fillCircle(Image_ img, int cx, int cy, int r, int c) {
     int x = r - 1;
     int y = 0;

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1093,6 +1093,8 @@ void blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
         return;
     }
 
+    dst->makeWritable();
+
     int xSrcStep = (wSrc << 16) / wDst;
     int ySrcStep = (hSrc << 16) / hDst;
 
@@ -1100,9 +1102,9 @@ void blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
     for (int yDstCur = yDst; yDstCur < yDst + hDst; ++yDstCur) {
         int ySrcCurI = ySrcCur >> 16;
         for (int xDstCur = xDst, xSrcCur = xSrc << 16; xDstCur < xDst + wDst; ++xDstCur, xSrcCur += xSrcStep) {
-            int c = getPixel(src, xSrcCur >> 16, ySrcCurI);
+            int c = getCore(src, xSrcCur >> 16, ySrcCurI);
             if (!transparent || c) {
-                setPixel(dst, xDstCur, yDstCur, c);
+                setCore(dst, xDstCur, yDstCur, c);
             }
         }
         ySrcCur += ySrcStep;

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -78,6 +78,13 @@ interface Image {
      */
     //% helper=imageBlitRow
     blitRow(dstX: number, dstY: number, from: Image, fromX: number, fromH: number): void;
+
+    /**
+     * Copy an image from a source rectangle to a destination rectangle, stretching or
+     * compressing to fit the dimensions of the destination rectangle, if necessary.
+     */
+    //% helper=imageBlit
+    blit(xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean): void;
 }
 
 interface ScreenImage extends Image {
@@ -118,8 +125,15 @@ namespace helpers {
     //% shim=ImageMethods::_blitRow
     declare function _blitRow(img: Image, xy: number, from: Image, xh: number): void;
 
+    //% shim=ImageMethods::_blit
+    declare function _blit(img: Image, xyDst: number, whDst: number, src: Image, xySrc: number, whSrc: number, transparent: boolean): void;
+
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
+    }
+
+    export function imageBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean) {
+        _blit(img, pack(xDst, yDst), pack(wDst, hDst), src, pack(xSrc, ySrc), pack(wSrc, hSrc), transparent);
     }
 
     export function imageBlitRow(img: Image, dstX: number, dstY: number, from: Image, fromX: number, fromH: number): void {

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -132,7 +132,7 @@ namespace helpers {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
     }
 
-    const _blitArgs: any[] = [];
+    const _blitArgs: any = [];
 
     export function imageBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean) {
         _blitArgs[0] = xDst;

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -126,14 +126,25 @@ namespace helpers {
     declare function _blitRow(img: Image, xy: number, from: Image, xh: number): void;
 
     //% shim=ImageMethods::_blit
-    declare function _blit(img: Image, xyDst: number, whDst: number, src: Image, xySrc: number, whSrc: number, transparent: boolean): void;
+    declare function _blit(img: Image, src: Image, args: any[]): void;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
     }
 
+    const _blitArgs: any[] = [];
+
     export function imageBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean) {
-        _blit(img, pack(xDst, yDst), pack(wDst, hDst), src, pack(xSrc, ySrc), pack(wSrc, hSrc), transparent);
+        _blitArgs[0] = xDst;
+        _blitArgs[1] = yDst;
+        _blitArgs[2] = wDst;
+        _blitArgs[3] = hDst;
+        _blitArgs[4] = xSrc;
+        _blitArgs[5] = ySrc;
+        _blitArgs[6] = wSrc;
+        _blitArgs[7] = hSrc;
+        _blitArgs[8] = transparent;
+        _blit(img, src, _blitArgs);
     }
 
     export function imageBlitRow(img: Image, dstX: number, dstY: number, from: Image, fromX: number, fromH: number): void {

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -126,24 +126,25 @@ namespace helpers {
     declare function _blitRow(img: Image, xy: number, from: Image, xh: number): void;
 
     //% shim=ImageMethods::_blit
-    declare function _blit(img: Image, src: Image, args: any[]): void;
+    declare function _blit(img: Image, src: Image, args: number[]): void;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
     }
 
-    const _blitArgs: any = [];
+    let _blitArgs: number[];
 
     export function imageBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean) {
-        _blitArgs[0] = xDst;
-        _blitArgs[1] = yDst;
-        _blitArgs[2] = wDst;
-        _blitArgs[3] = hDst;
-        _blitArgs[4] = xSrc;
-        _blitArgs[5] = ySrc;
-        _blitArgs[6] = wSrc;
-        _blitArgs[7] = hSrc;
-        _blitArgs[8] = transparent;
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = xDst | 0;
+        _blitArgs[1] = yDst | 0;
+        _blitArgs[2] = wDst | 0;
+        _blitArgs[3] = hDst | 0;
+        _blitArgs[4] = xSrc | 0;
+        _blitArgs[5] = ySrc | 0;
+        _blitArgs[6] = wSrc | 0;
+        _blitArgs[7] = hSrc | 0;
+        _blitArgs[8] = transparent ? 1 : 0;
         _blit(img, src, _blitArgs);
     }
 

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -634,24 +634,20 @@ namespace pxsim.ImageMethods {
         }
     }
 
-    export function _blit(img: RefImage, src: RefImage, args: any[]) {
+    export function _blit(img: RefImage, src: RefImage, args: RefCollection) {
         blit(img, src, args);
     }
 
-    export function blit(dst: RefImage, src: RefImage, args: any[]) {
-        let xDst = args[0] as number;
-        let yDst = args[1] as number;
-        let wDst = args[2] as number;
-        let hDst = args[3] as number;
-        let xSrc = args[4] as number;
-        let ySrc = args[5] as number;
-        let wSrc = args[6] as number;
-        let hSrc = args[7] as number;
-        let transparent = args[8] as boolean;
-
-        // Coerse to integers
-        xSrc |= 0; ySrc |= 0; wSrc |= 0; hSrc |= 0;
-        xDst |= 0; yDst |= 0; wDst |= 0; hDst |= 0;
+    export function blit(dst: RefImage, src: RefImage, args: RefCollection) {
+        const xDst = args.getAt(0) as number;
+        const yDst = args.getAt(1) as number;
+        const wDst = args.getAt(2) as number;
+        const hDst = args.getAt(3) as number;
+        const xSrc = args.getAt(4) as number;
+        const ySrc = args.getAt(5) as number;
+        const wSrc = args.getAt(6) as number;
+        const hSrc = args.getAt(7) as number;
+        const transparent = args.getAt(8) as number;
 
         if (xSrc < 0 || ySrc < 0 || wSrc <= 0 || hSrc <= 0 ||
             xSrc > src._width || ySrc > src._height ||

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -649,30 +649,26 @@ namespace pxsim.ImageMethods {
         const hSrc = args.getAt(7) as number;
         const transparent = args.getAt(8) as number;
 
-        if (xSrc < 0 || ySrc < 0 || wSrc <= 0 || hSrc <= 0 ||
-            xSrc > src._width || ySrc > src._height ||
-            xSrc + wSrc > src._width || ySrc + hSrc > src._height) {
-            // Would read outside src image
-            return;
-        }
+        const xDstStart = Math.max(0, xDst);
+        const yDstStart = Math.max(0, yDst);
+        const xDstEnd = Math.min(dst._width, xDst + wDst);
+        const yDstEnd = Math.min(dst._height, yDst + hDst);
 
-        if (xDst < 0 || yDst < 0 || wDst <= 0 || hDst <= 0 ||
-            xDst > dst._width || yDst > dst._height ||
-            xDst + wDst > dst._width || yDst + hDst > dst._height) {
-            // Would write outside dst image, or div by zero in step calculation (below)
-            return;
-        }
+        const xSrcStart = Math.max(0, xSrc) << 16;
+        const ySrcStart = Math.max(0, ySrc) << 16;
+        const xSrcEnd = Math.min(src._width, xSrc + wSrc) << 16;
+        const ySrcEnd = Math.min(src._height, ySrc + hSrc) << 16;
 
         const xSrcStep = ((wSrc << 16) / wDst) | 0;
         const ySrcStep = ((hSrc << 16) / hDst) | 0;
 
-        let ySrcCur = ySrc << 16;
-        for (let yDstCur = yDst; yDstCur < yDst + hDst; ++yDstCur) {
+        for (let yDstCur = yDstStart, ySrcCur = ySrcStart; yDstCur < yDstEnd && ySrcCur < ySrcEnd; ++yDstCur, ySrcCur += ySrcStep) {
             const ySrcCurI = ySrcCur >> 16;
-            for (let xDstCur = xDst, xSrcCur = xSrc << 16; xDstCur < xDst + wDst; ++xDstCur, xSrcCur += xSrcStep) {
-                const cSrc = src.data[src.pix(xSrcCur >> 16, ySrcCurI)];
+            for (let xDstCur = xDstStart, xSrcCur = xSrcStart; xDstCur < xDstEnd && xSrcCur < xSrcEnd; ++xDstCur, xSrcCur += xSrcStep) {
+                const xSrcCurI = xSrcCur >> 16;
+                const cSrc = getPixel(src, xSrcCurI, ySrcCurI);
                 if (!transparent || cSrc) {
-                    dst.data[dst.pix(xDstCur, yDstCur)] = cSrc;
+                    setPixel(dst, xDstCur, yDstCur, cSrc);
                 }
             }
             ySrcCur += ySrcStep;

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -634,11 +634,21 @@ namespace pxsim.ImageMethods {
         }
     }
 
-    export function _blit(img: RefImage, xyDst: number, whDst: number, src: RefImage, xySrc: number, whSrc: number, transparent: boolean) {
-        blit(img, XX(xyDst), YY(xyDst), XX(whDst), YY(whDst), src, XX(xySrc), YY(xySrc), XX(whSrc), YY(whSrc), transparent);
+    export function _blit(img: RefImage, src: RefImage, args: any[]) {
+        blit(img, src, args);
     }
 
-    export function blit(dst: RefImage, xDst: number, yDst: number, wDst: number, hDst: number, src: RefImage, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean) {
+    export function blit(dst: RefImage, src: RefImage, args: any[]) {
+        let xDst = args[0] as number;
+        let yDst = args[1] as number;
+        let wDst = args[2] as number;
+        let hDst = args[3] as number;
+        let xSrc = args[4] as number;
+        let ySrc = args[5] as number;
+        let wSrc = args[6] as number;
+        let hSrc = args[7] as number;
+        let transparent = args[8] as boolean;
+
         // Coerse to integers
         xSrc |= 0; ySrc |= 0; wSrc |= 0; hSrc |= 0;
         xDst |= 0; yDst |= 0; wDst |= 0; hDst |= 0;


### PR DESCRIPTION
**For your consideration.** When working in JavaScript I often want to write directly to the screen rather than use the Sprite system, and have found myself implementing this `blit` method multiple times. The method implemented here is modeled after the WinGDI's venerated [`StretchBlt`](https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-stretchblt).

This `blit` method copies an image from a source rectangle to a destination rectangle, stretching or compressing to fit the dimensions of the destination rectangle, if necessary.

If we think this is a useful addition to the runtime, then I'll implement the cpp side.

![blit](https://user-images.githubusercontent.com/12176807/121411282-50fba800-c918-11eb-805c-72f71bd7f55f.gif)
