### PR TITLE
[stable8.8] track revision count on images to fix perf for sprites mutated at run…

### DIFF
--- a/libs/base/pxtbase.h
+++ b/libs/base/pxtbase.h
@@ -818,6 +818,7 @@ struct ImageHeader {
 class RefImage : public RefObject {
   public:
     BoxedBuffer *buffer;
+    uint32_t revision;
 
     RefImage(BoxedBuffer *buf);
     RefImage(uint32_t sz);

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -1,5 +1,7 @@
 namespace game {
     export class Hitbox {
+        img: Image;
+        rev: number;
         parent: Sprite;
         ox: Fx8;
         oy: Fx8;
@@ -7,6 +9,8 @@ namespace game {
         height: Fx8;
 
         constructor(parent: Sprite, width: number, height: number, ox: number, oy: number) {
+            this.img = parent.image;
+            this.rev = parent.image.revision();
             this.parent = parent;
             this.width = Fx8(width);
             this.height = Fx8(height);
@@ -35,10 +39,17 @@ namespace game {
                 Fx.oneFx8
             );
         }
+
+        isValid() {
+            return this.img === this.parent.image && this.rev === this.parent.image.revision();
+        }
     }
 
 
     export function calculateHitBox(s: Sprite): Hitbox {
+        if (s._hitbox && s._hitbox.isValid())
+            return s._hitbox;
+
         const i = s.image;
         let minX = i.width;
         let minY = i.height;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -263,9 +263,9 @@ class Sprite extends sprites.BaseSprite {
     }
 
     setHitbox() {
-        let newHitBox = game.calculateHitBox(this);
+        const newHitBox = game.calculateHitBox(this);
 
-        if (!this._hitbox) {
+        if (!this._hitbox || this._hitbox.isValid()) {
             this._hitbox = newHitBox;
             return;
         }

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -28,6 +28,7 @@ int RefImage::wordHeight() {
 }
 
 void RefImage::makeWritable() {
+    ++revision;
     if (buffer->isReadOnly()) {
         buffer = mkBuffer(data(), length());
     }
@@ -47,6 +48,7 @@ void RefImage::clamp(int *x, int *y) {
 }
 
 RefImage::RefImage(BoxedBuffer *buf) : PXT_VTABLE_INIT(RefImage), buffer(buf) {
+    revision = 0;
     if (!buf)
         oops(21);
 }
@@ -143,6 +145,11 @@ bool isMono(Image_ img) {
 //% property
 bool isStatic(Image_ img) {
     return img->buffer->isReadOnly();
+}
+
+//% property
+bool revision(Image_ img) {
+    return img->revision;
 }
 
 /**

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -107,6 +107,9 @@ interface Image {
 
     //% shim=ImageMethods::isStatic
     isStatic(): boolean;
+
+    //% shim=ImageMethods::revision
+    revision(): number;
 }
 
 declare namespace image {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -5,9 +5,11 @@ namespace pxsim {
         _bpp: number;
         data: Uint8Array;
         isStatic = true;
+        revision: number;
 
         constructor(w: number, h: number, bpp: number) {
             super();
+            this.revision = 0;
             this.data = new Uint8Array(w * h)
             this._width = w
             this._height = h
@@ -48,6 +50,7 @@ namespace pxsim {
         }
 
         makeWritable() {
+            this.revision++;
             this.isStatic = false
         }
 
@@ -68,6 +71,8 @@ namespace pxsim.ImageMethods {
     export function isMono(img: RefImage) { return img._bpp == 1 }
 
     export function isStatic(img: RefImage) { return img.gcIsStatic() }
+
+    export function revision(img: RefImage) { return img.revision }
 
     export function setPixel(img: RefImage, x: number, y: number, c: number) {
         img.makeWritable()


### PR DESCRIPTION
port #1261

significant perf improvement (primarily on hardware) when game includes mutated images

(also need https://github.com/microsoft/pxt-common-packages/pull/1259 right?)