### PR TITLE
Check if a sprite was destroyed before registering another obstacle

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -428,7 +428,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     );
 
                     for (const tile of collidedTiles) {
-                        if(!(s.flags & sprites.Flag.Destroyed)) {
+                        if(!(s.flags & SPRITE_NO_WALL_COLLISION)) {
                             s.registerObstacle(collisionDirection, tile, tm);
                         }
                     }

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -428,7 +428,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     );
 
                     for (const tile of collidedTiles) {
-                        s.registerObstacle(collisionDirection, tile, tm);
+                        if(!(s.flags & sprites.Flag.Destroyed)) {
+                            s.registerObstacle(collisionDirection, tile, tm);
+                        }
                     }
 
                     if (s.flags & sprites.Flag.DestroyOnWall) {
@@ -507,7 +509,9 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     );
 
                     for (const tile of collidedTiles) {
-                        s.registerObstacle(collisionDirection, tile, tm);
+                        if(!(s.flags & sprites.Flag.Destroyed)) {
+                            s.registerObstacle(collisionDirection, tile, tm);
+                        }
                     }
 
                     if (s.flags & sprites.Flag.DestroyOnWall) {

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -509,7 +509,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                     );
 
                     for (const tile of collidedTiles) {
-                        if(!(s.flags & sprites.Flag.Destroyed)) {
+                        if(!(s.flags & SPRITE_NO_WALL_COLLISION)) {
                             s.registerObstacle(collisionDirection, tile, tm);
                         }
                     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2053