### PR TITLE
azure iot hub fixes/extensions

### DIFF
--- a/libs/azureiot/azureiot.ts
+++ b/libs/azureiot/azureiot.ts
@@ -1,7 +1,8 @@
 const enum AzureIotEvent {
     Connected = 1,
     Disconnected = 2,
-    Error = 3
+    Error = 3,
+    GotTwinResponse = 100,
 }
 
 namespace azureiot {
@@ -14,7 +15,7 @@ namespace azureiot {
 
     let _mqttClient: mqtt.Client;
     let _messageBusId: number;
-    let _receiveHandler: (msg: Json) => void;
+    let _receiveHandler: (msg: Json, sysProps: SMap<string>) => void;
     let _methodHandlers: SMap<(msg: Json) => Json>;
 
     function log(msg: string) {
@@ -27,19 +28,30 @@ namespace azureiot {
         return _mqttClient;
     }
 
+    function generateSasToken(resourceUri: string, signingKey: string, expiresEpoch: number) {
+        const key = Buffer.fromBase64(signingKey)
+        resourceUri = net.urlencode(resourceUri)
+        const toSign = resourceUri + "\n" + expiresEpoch
+        const sig = net.urlencode(crypto.sha256Hmac(key, Buffer.fromUTF8(toSign)).toBase64())
+        const token = `sr=${resourceUri}&se=${expiresEpoch}&sig=${sig}`
+        return token
+    }
+
     function createMQTTClient() {
-        _messageBusId = control.allocateNotifyEvent(); // TODO
+        _messageBusId = control.allocateEventSource();
 
         const connString = settings.programSecrets.readSecret(SECRETS_KEY, true);
         const connStringParts = parsePropertyBag(connString, ";");
         const iotHubHostName = connStringParts["HostName"];
-        const deviceId = connStringParts["DeviceName"];
-        const sasToken = connStringParts["SharedAccessSignature"];
+        const deviceId = connStringParts["DeviceId"];
+        let sasToken = connStringParts["SharedAccessSignature"];
+        if (!sasToken)
+            sasToken = generateSasToken(`${iotHubHostName}/devices/${deviceId}`, connStringParts["SharedAccessKey"], 4000000000)
 
         const opts: mqtt.IConnectionOptions = {
             host: iotHubHostName,
             /* port: 8883, overriden based on platform */
-            username: `${iotHubHostName}/${deviceId}/api-version=2018-06-30`,
+            username: `${iotHubHostName}/${deviceId}/?api-version=2018-06-30`,
             password: "SharedAccessSignature " + sasToken,
             clientId: deviceId
         }
@@ -71,25 +83,20 @@ namespace azureiot {
             return [kv.slice(0, i), kv.slice(i + 1)];
     }
 
-    function parsePropertyBag(msg: string, separator?: string): any {
-        let r: any = {};
+    function parsePropertyBag(msg: string, separator?: string): SMap<string> {
+        let r: SMap<string> = {};
         msg.split(separator || "&")
             .map(kv => splitPair(kv))
-            .forEach(parts => r[parts[0]] = parts[1]);
+            .forEach(parts => r[net.urldecode(parts[0])] = net.urldecode(parts[1]));
         return r;
     }
 
-    function decodeQuery(msg: string, separator?: string): any {
-        const r = parsePropertyBag(msg, separator);
-        // TODO uridecode
-        Object.keys(r).forEach(k => r[k] = JSON.parse(r[k]));
-        return r;
-    }
-
-    function encodeQuery(props: any): string {
-        // TODO uriencode
-        return Object.keys(props)
-            .map(k => `${k}=${JSON.stringify(props[k])}`)
+    function encodeQuery(props: SMap<string>): string {
+        const keys = Object.keys(props)
+        if (keys.length == 0)
+            return ""
+        return "?" + keys
+            .map(k => `${net.urlencode(k)}=${net.urlencode(props[k])}`)
             .join('&');
     }
 
@@ -129,7 +136,7 @@ namespace azureiot {
      * @param msg 
      */
     //%
-    export function publishMessage(msg: any, sysProps?: any) {
+    export function publishMessageJSON(msg: Json, sysProps?: SMap<string>) {
         const c = mqttClient();
         let topic = `devices/${c.opt.clientId}/messages/events/`;
         if (sysProps)
@@ -143,16 +150,13 @@ namespace azureiot {
      * @param handler 
      */
     //%
-    export function onMessageReceived(handler: (msg: any) => void) {
+    export function onMessageReceived(handler: (body: Json, sysProps: SMap<string>) => void) {
         const c = mqttClient();
         if (!_receiveHandler) {
             c.subscribe(`devices/${c.opt.clientId}/messages/devicebound/#`, handleDeviceBound);
 
             /*
-            c.subscribe(`devices/${c.opt.clientId}/messages/events/#`);
             c.subscribe('$iothub/twin/PATCH/properties/desired/#')
-            c.subscribe("$iothub/twin/res/#")
-            c.publish("$iothub/twin/GET/?$rid=foobar")
             */
         }
         _receiveHandler = handler;
@@ -168,8 +172,8 @@ namespace azureiot {
     function handleDeviceBound(packet: mqtt.IMessage) {
         if (!_receiveHandler) return; // nobody's listening
         // TODO this needs some testing
-        const props = parseTopicArgs(packet.topic)
-        _receiveHandler(props);
+        const sysProps = parseTopicArgs(packet.topic)
+        _receiveHandler(JSON.parse(packet.content.toString()), sysProps);
     }
 
     function handleMethod(msg: mqtt.IMessage) {
@@ -196,6 +200,56 @@ namespace azureiot {
 
         const c = mqttClient();
         c.publish('$iothub/methods/res/' + status + "/?$rid=" + props["$rid"], JSON.stringify(resp))
+    }
+
+    let twinRespHandlers: SMap<(status: number, body: any) => void>
+
+    // $iothub/twin/res/{status}/?$rid={request id}
+    function twinResponse(msg: mqtt.IMessage) {
+        const args = parseTopicArgs(msg.topic)
+        const h = twinRespHandlers[args["$rid"]]
+        const status = parseInt(msg.topic.slice(17))
+        log(`twin resp: ${status} ${msg.content.toString()}`)
+        if (h)
+            h(status, JSON.parse(msg.content.toString() || "{}"))
+    }
+
+    export class ValueAwaiter {
+        private evid: number
+        private value: any
+        constructor() {
+            this.evid = control.allocateNotifyEvent()
+        }
+        setValue(v: any) {
+            this.evid = -1
+            this.value = v
+            control.raiseEvent(DAL.DEVICE_ID_NOTIFY, this.evid)
+        }
+        wait() {
+            if (this.evid < 0) return this.value
+            control.waitForEvent(DAL.DEVICE_ID_NOTIFY, this.evid)
+            return this.value
+        }
+    }
+
+    export function getTwin(): Json {
+        const c = mqttClient();
+        if (!twinRespHandlers) {
+            twinRespHandlers = {}
+            c.subscribe("$iothub/twin/res/#", twinResponse)
+        }
+        const rid = Math.randomRange(100000000, 900000000) + ""
+        const va = new ValueAwaiter()
+        twinRespHandlers[rid] = (status, body) => {
+            if (status == 200) {
+                va.setValue(body)
+            } else {
+                log(`error on get twin -> ${status} ${JSON.stringify(body)}`)
+                va.setValue(null)
+            }
+        }
+        c.publish("$iothub/twin/GET/?$rid=" + rid)
+        return va.wait()
     }
 
     export function onMethod(methodName: string, handler: (msg: Json) => Json) {

--- a/libs/azureiot/azureiot.ts
+++ b/libs/azureiot/azureiot.ts
@@ -290,7 +290,6 @@ namespace azureiot {
             }
             const update = JSON.parse(msg.content.toString())
             updateJson(currTwin["desired"], update)
-            log(`new twin: ${JSON.stringify(currTwin)}`)
             handler(currTwin, update)
         })
         currTwin = getTwin()

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -82,6 +82,11 @@ namespace control {
         panic(108)
     }
 
+    let _evSource = 0x8000
+    export function allocateEventSource() {
+        return ++_evSource
+    }
+
     export class AnimationQueue {
         running: boolean;
         eventID: number;

--- a/libs/base/poll.ts
+++ b/libs/base/poll.ts
@@ -39,8 +39,8 @@ namespace control {
 
     export function __queuePollEvent(timeOut: number, condition: () => boolean, handler: () => void) {
         const ev = new PollEvent(
+            DAL.DEVICE_ID_NOTIFY,
             control.allocateNotifyEvent(),
-            1,
             control.millis(),
             timeOut,
             condition,

--- a/libs/core---esp32/crypto.cpp
+++ b/libs/core---esp32/crypto.cpp
@@ -1,6 +1,8 @@
 #include "pxt.h"
 #include "mbedtls/sha256.h"
 
+// https://eprint.iacr.org/2012/156.pdf - in case more hash functions are needed
+
 namespace crypto {
 
 /*

--- a/libs/core---esp32/usb.cpp
+++ b/libs/core---esp32/usb.cpp
@@ -316,3 +316,5 @@ void sendSerial(const char *data, int len) {
 #endif
 }
 } // namespace pxt
+
+// https://gist.github.com/brgaulin/2dec28baf5e9e11dfd7ef8354adf103d

--- a/libs/mqtt/mqtt.ts
+++ b/libs/mqtt/mqtt.ts
@@ -334,7 +334,7 @@ namespace mqtt {
 
             this.wdId = Constants.Uninitialized;
             this.piId = Constants.Uninitialized;
-            this.logPriority = ConsolePriority.Silent;
+            this.logPriority = ConsolePriority.Debug;
             this.connected = false;
             opt.port = opt.port || 8883;
             opt.clientId = opt.clientId;

--- a/libs/mqtt/mqtt.ts
+++ b/libs/mqtt/mqtt.ts
@@ -511,7 +511,7 @@ namespace mqtt {
 
             switch (controlPacketType) {
                 case ControlPacketType.ConnAck:
-                    const returnCode: number = payload[0];
+                    const returnCode: number = payload[1];
                     if (returnCode === ConnectReturnCode.Accepted) {
                         this.log('MQTT connection accepted.');
                         this.emit('connected');

--- a/libs/net/netutil.ts
+++ b/libs/net/netutil.ts
@@ -1,0 +1,44 @@
+namespace net {
+    export function urlencode(s: string) {
+        const buf = Buffer.fromUTF8(s)
+        let r = ""
+        for (let i = 0; i < buf.length; ++i) {
+            const c = buf[i]
+            if ((48 <= c && c <= 57) ||
+                (97 <= (c | 0x20) && (c | 0x20) <= 122) ||
+                (c == 45 || c == 46 || c == 95 || c == 126))
+                r += String.fromCharCode(c)
+            else
+                r += "%" + buf.slice(i, 1).toHex()
+        }
+        return r
+    }
+
+    export function urldecode(s: string) {
+        let r = ""
+        let isUtf8 = false
+        for (let i = 0; i < s.length; ++i) {
+            const c = s[i]
+            if (c == "%") {
+                const h = s.slice(i + 1, i + 3)
+                const chcode = parseInt(h, 16)
+                if (!isNaN(chcode)) {
+                    if (chcode > 127)
+                        isUtf8 = true
+                    r += String.fromCharCode(chcode)
+                    i += 2
+                    continue
+                }
+            }
+            r += c
+        }
+        if (isUtf8) {
+            const buf = Buffer.create(r.length)
+            for (let i = 0; i < buf.length; ++i)
+                buf[i] = r.charCodeAt(i)
+            return buf.toString()
+        } else {
+            return r
+        }
+    }
+}

--- a/libs/net/pxt.json
+++ b/libs/net/pxt.json
@@ -6,6 +6,7 @@
         "controller.ts",
         "controllersocket.ts",
         "net.ts",
+        "netutil.ts",
         "requests.ts"
     ],
     "public": true,

--- a/libs/net/requests.ts
+++ b/libs/net/requests.ts
@@ -167,14 +167,12 @@ read only when requested
             port = parseInt(tmp[1])
         }
 
-        let ipaddr = net.instance().hostByName(host)
-
         let sock: Socket;
         if (proto == "https:") {
             // for SSL we need to know the host name
             sock = net.instance().createSocket(host, port, true)
         } else {
-            sock = net.instance().createSocket(ipaddr, port, false)
+            sock = net.instance().createSocket(host, port, false)
         }
         // our response
         let resp = new Response(sock)

--- a/libs/tsconfig.json
+++ b/libs/tsconfig.json
@@ -4,9 +4,12 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "outDir": "../built",
-        "rootDir": ".",
         "newLine": "LF",
         "sourceMap": false,
         "types": []
-    }
+    },
+    "include": [
+        "*/*.ts",
+        "../../pxt/libs/pxt-common/*.ts"
+    ]
 }

--- a/libs/wifi---esp32/controller.ts
+++ b/libs/wifi---esp32/controller.ts
@@ -117,6 +117,11 @@ namespace net {
         connect(): boolean {
             if (this.isConnected) return true;
 
+            if (control.deviceDalVersion() == "sim") {
+                this.connectAP("", "")
+                return true
+            }
+
             const wifis = net.knownAccessPoints();
             const ssids = Object.keys(wifis);
 

--- a/libs/wifi---esp32/sim/tsconfig.json
+++ b/libs/wifi---esp32/sim/tsconfig.json
@@ -13,7 +13,7 @@
     },
     "include": [
         "*.ts",
-        "../*/sim/*.ts",
+        "../../*/sim/*.ts",
         "../../../../pxt/pxtsim/*.ts",
         "../../../../pxt/pxtsim/*/*.ts"
     ]

--- a/libs/wifi---esp32/sim/tsconfig.json
+++ b/libs/wifi---esp32/sim/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "es2017",
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ES2017"
+        ],
+        "newLine": "LF",
+        "sourceMap": false
+    },
+    "include": [
+        "*.ts",
+        "../*/sim/*.ts",
+        "../../../../pxt/pxtsim/*.ts",
+        "../../../../pxt/pxtsim/*/*.ts"
+    ]
+}

--- a/libs/wifi---esp32/sim/wifisockets.ts
+++ b/libs/wifi---esp32/sim/wifisockets.ts
@@ -1,0 +1,229 @@
+namespace pxsim {
+    export interface WifiSocketBoard extends CommonBoard {
+        wifiSocketState: WifiSocketState;
+    }
+
+    export class WifiSocket {
+        ws: WebSocket
+        _err: number
+        closed = false
+        buffers: Uint8Array[] = []
+        readers: (() => void)[] = []
+        bytesAvail = 0
+
+        constructor(private fd: number) { }
+
+        openWS(url: string, proto: string[]) {
+            this.ws = new WebSocket(url, proto)
+            this.ws.binaryType = "arraybuffer"
+            return new Promise<number>((resolve) => {
+                this.ws.onopen = () => {
+                    this.ws.onerror = err => {
+                        console.log("ws error", err)
+                        this._err = -2
+                    }
+                    resolve(0)
+                }
+                this.ws.onclose = () => {
+                    console.log("ws close")
+                    this._err = -20
+                }
+                this.ws.onmessage = ev => {
+                    let buf: Uint8Array
+                    if (ev.data instanceof ArrayBuffer) {
+                        buf = new Uint8Array(ev.data)
+                    } else {
+                        buf = U.stringToUint8Array(U.toUTF8(ev.data))
+                    }
+                    this.buffers.push(buf)
+                    if (buf.length && this.bytesAvail == 0)
+                        pxsim.control.raiseEvent(_wifi.eventID(), 1000 + this.fd, undefined)
+                    this.bytesAvail += buf.length
+                    const rr = this.readers
+                    this.readers = []
+                    for (const r of rr) r()
+                }
+                this.ws.onerror = () => resolve(-1)
+            })
+        }
+
+        waitRead() {
+            return new Promise<void>(resolve => {
+                this.readers.push(resolve)
+            })
+        }
+
+        read(maxlen: number) {
+            if (this._err)
+                return this._err
+            let b = this.buffers[0]
+            if (b) {
+                if (b.length <= maxlen) {
+                    this.buffers.shift()
+                } else {
+                    this.buffers[0] = b.slice(maxlen)
+                    b = b.slice(0, maxlen)
+                }
+                this.bytesAvail -= b.length
+                return new RefBuffer(b)
+            }
+            return null
+        }
+
+        write(buf: RefBuffer) {
+            if (this._err)
+                return this._err
+            this.ws.send(buf.data)
+            return 0
+        }
+
+        close() {
+            this.ws.close()
+        }
+    }
+
+    export class WifiSocketState {
+        sockets: WifiSocket[] = [null]
+    }
+}
+
+namespace pxsim._wifi {
+    type int32 = number
+    const MAX_SOCKET = 16
+    const WIFI_ID = 1234
+
+    function getState() {
+        const b = board() as WifiSocketBoard
+        if (!b.wifiSocketState)
+            b.wifiSocketState = new WifiSocketState()
+        return b.wifiSocketState
+    }
+
+    function getSock(fd: int32) {
+        if (fd < 0 || fd >= MAX_SOCKET)
+            return null
+        return getState().sockets[fd]
+    }
+
+    export function socketAlloc(): int32 {
+        const state = getState()
+        for (let i = 1; i < state.sockets.length; ++i) {
+            if (!state.sockets[i]) {
+                state.sockets[i] = new WifiSocket(i)
+                return i
+            }
+        }
+        const idx = state.sockets.length
+        if (idx > MAX_SOCKET)
+            return -1
+        state.sockets.push(new WifiSocket(idx))
+        return idx
+    }
+
+    export function socketConnectTLS(fd: int32, host: string, port: int32): Promise<int32> {
+        const sock = getSock(fd)
+        if (!sock)
+            return Promise.resolve(-11)
+        // TODO loosen this up in future
+        if (port == 8883 && /\.azure-devices.net$/.test(host)) {
+            return sock.openWS("wss://" + host + "/$iothub/websocket", ["mqtt"])
+        } else if (port == 443 && host == "microsoft.github.io") {
+            return Promise.resolve(-1)
+        } else {
+            console.log("invalid host: " + host)
+            return Promise.resolve(-1)
+        }
+    }
+
+    export function socketWrite(fd: int32, data: RefBuffer): int32 {
+        const sock = getSock(fd)
+        if (!sock)
+            return -11
+        return sock.write(data)
+    }
+
+    export async function socketRead(fd: int32, size: int32): Promise<number | RefBuffer> {
+        const sock = getSock(fd)
+        if (!sock)
+            return -11
+        for (; ;) {
+            const buf = sock.read(size)
+            if (buf)
+                return buf
+            await sock.waitRead()
+        }
+    }
+
+    export function socketBytesAvailable(fd: int32): int32 {
+        const sock = getSock(fd)
+        if (!sock)
+            return -11
+        return sock.bytesAvail
+    }
+
+    export function socketClose(fd: int32): int32 {
+        const sock = getSock(fd)
+        if (!sock)
+            return -11
+        sock.close()
+        return 0
+    }
+
+    export function eventID(): int32 {
+        return WIFI_ID
+    }
+
+    export function scanStart(): void {
+        _raiseEvent(WifiEvent.ScanDone)
+    }
+
+    export function scanResults(): RefBuffer {
+        const b = new Uint8Array(7)
+        b[0] = -20 // rssi
+        b[1] = 0  // authmode
+        b.set(U.stringToUint8Array("WiFi"), 2)
+        return new RefBuffer(b)
+    }
+
+    export function connect(ssid: string, pass: string): int32 { 
+        _raiseEvent(WifiEvent.GotIP)
+        return 0 
+    }
+    export function disconnect(): int32 { 
+        return 0 
+    }
+    export function isConnected(): boolean { return true }
+
+
+    declare const enum WifiEvent {
+        ScanDone = 1,
+        GotIP = 2,
+        Disconnected = 3,
+    }
+
+
+    export function _raiseEvent(id: number) {
+        pxsim.control.raiseEvent(_wifi.eventID(), id, undefined)
+    }
+}
+
+namespace pxsim.crypto {
+    export function _sha256(bufs: RefCollection): Promise<RefBuffer> {
+        let len = 0
+        const buffers = bufs.toArray().filter(e => e instanceof RefBuffer).map((b: RefBuffer) => {
+            len += b.data.length
+            return b.data
+        })
+        const concat = new Uint8Array(len)
+        len = 0
+        for (const b of buffers) {
+            concat.set(b, len)
+            len += b.length
+        }
+        const r = window?.crypto?.subtle?.digest("SHA-256", concat)
+        if (r)
+            return r.then(buf => new RefBuffer(new Uint8Array(buf)))
+        else
+            return Promise.resolve(undefined)
+    }
+}

--- a/libs/wifi---esp32/sim/wifisockets.ts
+++ b/libs/wifi---esp32/sim/wifisockets.ts
@@ -155,10 +155,18 @@ namespace pxsim._wifi {
     const MAX_SOCKET = 16
     const WIFI_ID = 1234
 
+    export function _allowed() {
+        const bid = board()?.runOptions?.boardDefinition?.id
+        return /esp32|-s2/.test(bid)
+    }
+
     function getState() {
         const b = board() as WifiSocketBoard
-        if (!b.wifiSocketState)
+        if (!b.wifiSocketState) {
+            if (!_allowed())
+                throw new Error("_wifi not enabled")
             b.wifiSocketState = new WifiSocketState()
+        }
         return b.wifiSocketState
     }
 

--- a/libs/wifi---esp32/sim/wifisockets.ts
+++ b/libs/wifi---esp32/sim/wifisockets.ts
@@ -126,7 +126,7 @@ namespace pxsim._wifi {
             return Promise.resolve(-11)
         // TODO loosen this up in future
         if (port == 8883 && /\.azure-devices.net$/.test(host)) {
-            return sock.openWS("wss://" + host + "/$iothub/websocket", ["mqtt"])
+            return sock.openWS("wss://" + host + "/$iothub/websocket?iothub-no-client-cert=true", ["mqtt"])
         } else if (port == 443 && host == "microsoft.github.io") {
             return Promise.resolve(-1)
         } else {

--- a/libs/wifi---esp32/socket.cpp
+++ b/libs/wifi---esp32/socket.cpp
@@ -145,7 +145,7 @@ static void worker_conn(conn_args *args) {
 }
 
 /** Connect with TLS */
-//%
+//% promise
 int socketConnectTLS(int fd, String host, int port) {
     memInfo();
     GET_SOCK();
@@ -241,7 +241,7 @@ static void worker_read(read_args *args) {
 }
 
 /** Read from a socket; the return type is really number|Buffer */
-//%
+//% promise
 int socketRead(int fd, int size) {
     GET_SOCK_SSL();
 

--- a/libs/wifi---esp32/socket.cpp
+++ b/libs/wifi---esp32/socket.cpp
@@ -177,7 +177,7 @@ static void worker_write(write_args *args) {
 }
 
 /** Write to socket */
-//%
+//% promise
 int socketWrite(int fd, Buffer data) {
     GET_SOCK_SSL();
 

--- a/libs/wifi---esp32/wifi.cpp
+++ b/libs/wifi---esp32/wifi.cpp
@@ -98,6 +98,7 @@ void scanStart() {
     scan_done = false;
     wifi_scan_config_t scan_config;
     memset(&scan_config, 0, sizeof(scan_config));
+    // scan_config.scan_time.active.max = 600;
     esp_err_t err = esp_wifi_scan_start(&scan_config, false);
     LOG("scan start: %d", err);
 }


### PR DESCRIPTION
* twin and SAS token support in azureiot; general fixes there
* add `control.allocateEventSource()` (as opposed to `control.allocateNotifyEvent()` which should be the second argument to `raiseEvent()`)
* mqtt fixes
* add `net.url(en|de)code()`
* add simulator support for iot-hub and https-req sockets (heavily restricted now)