### PR TITLE
Add new tilemap blocks and reorganize the scene category

### DIFF
--- a/libs/game/assetTemplates.ts
+++ b/libs/game/assetTemplates.ts
@@ -1,5 +1,6 @@
 //% helper=getTilemapByName
 //% pyConvertToTaggedTemplate
+//% blockIdentity="tiles._tilemapEditor"
 function tilemap(lits: any, ...args: any[]): tiles.TileMapData { return null }
 
 //% helper=getTilemapByName
@@ -17,6 +18,7 @@ function tilemap32(lits: any, ...args: any[]): tiles.TileMapData { return null }
 namespace assets {
     //% helper=getTilemapByName
     //% pyConvertToTaggedTemplate
+    //% blockIdentity="tiles._tilemapEditor"
     export function tilemap(lits: any, ...args: any[]): tiles.TileMapData { return null }
 
     //% helper=getImageByName

--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -597,7 +597,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
         const alreadyHandled: tiles.Location[] = [];
 
         for (const tile of overlappedTiles) {
-            if (alreadyHandled.some(l => l.col === tile.col && l.row === tile.row)) {
+            if (alreadyHandled.some(l => l.column === tile.column && l.row === tile.row)) {
                 continue;
             }
             alreadyHandled.push(tile);

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -18,7 +18,7 @@ enum CameraProperty {
 }
 
 //% weight=88 color="#4b6584" icon="\uf1bb"
-//% groups='["Screen", "Effects", "Tiles", "Collisions", "Camera"]'
+//% groups='["Screen", "Camera", "Tilemaps", "Operations", "Locations", "Effects"]'
 //% blockGap=8
 namespace scene {
     /**
@@ -128,6 +128,7 @@ namespace scene {
     //% duration.shadow=timePicker duration.defl=500
     //% group="Camera"
     //% help=scene/camera-shake
+    //% weight=90
     export function cameraShake(amplitude: number = 4, duration: number = 500) {
         const scene = game.currentScene();
         scene.camera.shake(amplitude, duration);
@@ -140,6 +141,7 @@ namespace scene {
     //% blockId=camerafollow block="camera follow sprite %sprite=variables_get(mySprite)"
     //% group="Camera"
     //% help=scene/camera-follow-sprite
+    //% weight=100
     export function cameraFollowSprite(sprite: Sprite) {
         const scene = game.currentScene();
         scene.camera.sprite = sprite;
@@ -152,6 +154,7 @@ namespace scene {
     //% blockId=camerapos block="center camera at x %x y %y"
     //% group="Camera"
     //% help=scene/center-camera-at
+    //% weight=80
     export function centerCameraAt(x: number, y: number) {
         const scene = game.currentScene();
         scene.camera.sprite = undefined;
@@ -190,6 +193,7 @@ namespace scene {
     //% blockId=cameraproperty block="camera $property"
     //% group="Camera"
     //% help=scene/camera-property
+    //% weight=70
     export function cameraProperty(property: CameraProperty): number {
         const scene = game.currentScene();
         switch (property) {

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -18,7 +18,7 @@ enum CameraProperty {
 }
 
 //% weight=88 color="#4b6584" icon="\uf1bb"
-//% groups='["Screen", "Camera", "Tilemaps", "Operations", "Locations", "Effects"]'
+//% groups='["Screen", "Camera", "Effects", "Tilemaps", "Tilemap Operations", "Locations"]'
 //% blockGap=8
 namespace scene {
     /**

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -705,8 +705,9 @@ class Sprite extends sprites.BaseSprite {
      * @param direction
      */
     //% blockId=spritehasobstacle block="is %sprite(mySprite) hitting wall %direction"
-    //% blockNamespace="scene" group="Tilemaps" blockGap=8
+    //% blockNamespace="scene" group="Locations" blockGap=24
     //% help=sprites/sprite/is-hitting-tile
+    //% weight=15
     isHittingTile(direction: CollisionDirection): boolean {
         return this._obstacles && !!this._obstacles[direction];
     }
@@ -717,7 +718,7 @@ class Sprite extends sprites.BaseSprite {
      */
     //% blockId=spritetileat block="tile to $direction of $this(mySprite) is $tile"
     //% tile.shadow=tileset_tile_picker
-    //% blockNamespace="scene" group="Locations" blockGap=24
+    //% blockNamespace="scene" group="Locations" blockGap=8
     //% help=sprites/sprite/tile-kind-at
     //% weight=20
     tileKindAt(direction: TileDirection, tile: Image): boolean {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -705,7 +705,7 @@ class Sprite extends sprites.BaseSprite {
      * @param direction
      */
     //% blockId=spritehasobstacle block="is %sprite(mySprite) hitting wall %direction"
-    //% blockNamespace="scene" group="Collisions" blockGap=8
+    //% blockNamespace="scene" group="Tilemaps" blockGap=8
     //% help=sprites/sprite/is-hitting-tile
     isHittingTile(direction: CollisionDirection): boolean {
         return this._obstacles && !!this._obstacles[direction];
@@ -717,8 +717,9 @@ class Sprite extends sprites.BaseSprite {
      */
     //% blockId=spritetileat block="tile to $direction of $this(mySprite) is $tile"
     //% tile.shadow=tileset_tile_picker
-    //% blockNamespace="scene" group="Collisions" blockGap=8
+    //% blockNamespace="scene" group="Locations" blockGap=24
     //% help=sprites/sprite/tile-kind-at
+    //% weight=20
     tileKindAt(direction: TileDirection, tile: Image): boolean {
         const tilemap = game.currentScene().tileMap;
         let x = this.x >> tilemap.scale;
@@ -748,11 +749,26 @@ class Sprite extends sprites.BaseSprite {
      * @param direction
      */
     //% blockId=spriteobstacle block="%sprite(mySprite) wall hit on %direction"
-    //% blockNamespace="scene" group="Collisions"
+    //% blockNamespace="scene" group="Locations"
+    //% direction.shadow=tiles_collision_direction_editor
     //% help=sprites/sprite/tile-hit-from
     //% deprecated=1
-    tileHitFrom(direction: CollisionDirection): number {
+    tileHitFrom(direction: number): number {
         return (this._obstacles && this._obstacles[direction]) ? this._obstacles[direction].tileIndex : -1;
+    }
+
+    /**
+     * Gets the tilemap location at the center of a sprite
+     */
+    //% block="tilemap location of $this"
+    //% blockId=tiles_location_of_sprite
+    //% this.shadow=variables_get
+    //% this.defl=mySprite
+    //% blockNamespace="scene" group="Locations" weight=90
+    tilemapLocation(): tiles.Location {
+        const scene = game.currentScene();
+        if (!scene.tileMap) return undefined;
+        return tiles.getTileLocation(this.x >> scene.tileMap.scale, this.y >> scene.tileMap.scale);
     }
 
     clearObstacles() {

--- a/libs/game/spriteevents.ts
+++ b/libs/game/spriteevents.ts
@@ -82,8 +82,8 @@ namespace scene {
      * @param tile
      * @param handler
      */
-    //% group="Tiles"
-    //% weight=100 draggableParameters="reporter" blockGap=8
+    //% group="Tilemaps"
+    //% weight=120 draggableParameters="reporter" blockGap=8
     //% blockId=spriteshittile block="on $sprite of kind $kind=spritekind overlaps $tile at $location"
     //% tile.shadow=tileset_tile_picker
     //% help=tiles/on-overlap-tile
@@ -105,8 +105,8 @@ namespace scene {
      * @param kind
      * @param handler
      */
-    //% group="Tiles"
-    //% weight=120 draggableParameters="reporter" blockGap=8
+    //% group="Tilemaps"
+    //% weight=100 draggableParameters="reporter" blockGap=8
     //% blockId=spriteshitwall block="on $sprite of kind $kind=spritekind hits wall at $location"
     //% help=tiles/on-hit-wall
     export function onHitWall(kind: number, handler: (sprite: Sprite, location: tiles.Location) => void) {

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -73,6 +73,22 @@ namespace sprites {
     }
 
     /**
+     * Destroys all sprites of the given kind.
+     */
+    //% group="Effects"
+    //% weight=79
+    //% blockId=sprites_destroy_all_sprites_of_kind
+    //% block="destroy all sprites of kind $kind || with $effect effect for $duration ms"
+    //% kind.shadow=spritekind
+    //% duration.shadow=timePicker
+    //% expandableArgumentMode="toggle"
+    export function destroyAllSpritesOfKind(kind: number, effect?: effects.ParticleEffect, duration?: number) {
+        for (const sprite of allOfKind(kind)) {
+            sprite.destroy(effect, duration);
+        }
+    }
+
+    /**
      * Create a new sprite with a given speed, and place it at the edge of the screen so it moves towards the middle.
      * The sprite auto-destroys when it leaves the screen. You can modify position after it's created.
      */

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -74,14 +74,14 @@ namespace tiles {
         //% blockCombine block="right"
         //% weight=100
         get right(): number {
-            return this.left + this.tileMap.scale;
+            return this.left + (1 << this.tileMap.scale);
         }
 
         //% group="Locations" blockSetVariable="location"
         //% blockCombine block="bottom"
         //% weight=100
         get bottom(): number {
-            return this.top + this.tileMap.scale;
+            return this.top + (1 << this.tileMap.scale);
         }
 
         get tileSet(): number {

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -34,7 +34,7 @@ namespace tiles {
         }
 
         //% group="Locations" blockSetVariable="location"
-        //% blockCombine block="column"
+        //% blockCombine block="row"
         //% weight=100
         get row() {
             return this._row;

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -173,7 +173,7 @@ namespace tiles {
          * @param sprite
          */
         //% blockId=gameplaceontile block="on top of %tile(myTile) place %sprite=variables_get(mySprite)"
-        //% blockNamespace="scene" group="Operations"
+        //% blockNamespace="scene" group="Tilemap Operations"
         //% weight=25
         //% help=tiles/place
         //% deprecated=1
@@ -573,7 +573,7 @@ namespace tiles {
     //% blockId=mapsettileat block="set $tile at $loc=mapgettile"
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
-    //% blockNamespace="scene" group="Operations" blockGap=8
+    //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
     //% help=tiles/set-tile-at
     //% weight=70
     export function setTileAt(loc: Location, tile: Image): void {
@@ -591,7 +591,7 @@ namespace tiles {
      */
     //% blockId=mapsetwallat block="set wall $on at $loc"
     //% on.shadow=toggleOnOff loc.shadow=mapgettile
-    //% blockNamespace="scene" group="Operations"
+    //% blockNamespace="scene" group="Tilemap Operations"
     //% help=tiles/set-wall-at
     //% weight=60
     export function setWallAt(loc: Location, on: boolean): void {
@@ -691,7 +691,7 @@ namespace tiles {
      */
     //% blockId=mapplaceontile block="place $sprite=variables_get(mySprite) on top of $loc"
     //% loc.shadow=mapgettile
-    //% blockNamespace="scene" group="Operations" blockGap=8
+    //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
     //% help=tiles/place
     //% weight=100
     export function placeOnTile(sprite: Sprite, loc: Location): void {
@@ -707,7 +707,7 @@ namespace tiles {
     //% blockId=mapplaceonrandomtile block="place $sprite=variables_get(mySprite) on top of random $tile"
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
-    //% blockNamespace="scene" group="Operations"
+    //% blockNamespace="scene" group="Tilemap Operations"
     //% help=tiles/place-on-random-tile
     //% weight=90
     export function placeOnRandomTile(sprite: Sprite, tile: Image): void {
@@ -724,7 +724,7 @@ namespace tiles {
     //% blockId=mapgettilestype block="array of all $tile locations"
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
-    //% blockNamespace="scene" group="Operations" blockGap=8
+    //% blockNamespace="scene" group="Locations" blockGap=8
     //% help=tiles/get-tiles-by-type
     //% weight=10
     export function getTilesByType(tile: Image): Location[] {


### PR DESCRIPTION
This PR does a few things:

1. Ports several blocks from the tilemap extension into the scene category
2. Reorders the scene groups. Mostly just swapped the "Camera" and "Effects" groups
3. Reordered the blocks in the "Camera" group. We never organized them in the first place; they were in random order. Now "camera follow sprite" is on top
4. Created some new groups for the tilemap-related blocks. They are "Tilemaps", "Operations", and "Locations"
5. Adds "destroy all sprites with effect" to the sprites category
6. Deprecates the old "set tilemap to" block and replaces it with a new one with a shadow block

None of these changes require upgrade rules.

There is one "gotcha" if you use this with the existing tilemaps extension where the tilemap shadow blocks from that extension are not compatible with the new blocks in the scene category. I can push a change to the tilemaps extension to fix this (that would require an upgrade rule, but just one that bumps the extension version).

Here is the "destroy all sprites" block:

![2021-09-14 10 41 55](https://user-images.githubusercontent.com/13754588/133307263-d17326d6-6878-4899-a206-5d245e87eb98.gif)


Here is how the toolbox looks now:

<img width="563" alt="Screen Shot 2021-09-14 at 10 36 37 AM" src="https://user-images.githubusercontent.com/13754588/133306588-8c532837-e8a8-4b5d-9efd-5df631e335ca.png">
<img width="571" alt="Screen Shot 2021-09-14 at 10 16 52 AM" src="https://user-images.githubusercontent.com/13754588/133306604-cea1808a-9497-4e10-b81e-35878d89c102.png">
<img width="545" alt="Screen Shot 2021-09-14 at 10 16 59 AM" src="https://user-images.githubusercontent.com/13754588/133306615-37562921-ea01-4c9d-9a67-182bd158822a.png">
<img width="554" alt="Screen Shot 2021-09-14 at 10 17 13 AM" src="https://user-images.githubusercontent.com/13754588/133306638-d6694752-6a97-4c41-9942-c12b752a9d28.png">


And here's an upload target: https://arcade.makecode.com/app/4ef11d7a279b78f072c186abf39a614d0b7df901-64b8e2dee4#editor