### PR TITLE
Use min and max implementation from the pxt namespace

### DIFF
--- a/libs/base/buffer.cpp
+++ b/libs/base/buffer.cpp
@@ -54,7 +54,7 @@ int writeBuffer(Buffer buf, int dstOffset, Buffer src, int srcOffset = 0, int le
     if (srcOffset < 0 || dstOffset < 0 || dstOffset > buf->length)
         return -1;
 
-    length = min(src->length - srcOffset, buf->length - dstOffset);
+    length = pxt::min(src->length - srcOffset, buf->length - dstOffset);
 
     if (length < 0)
         return -1;
@@ -103,7 +103,7 @@ void fill(Buffer buf, int value, int offset = 0, int length = -1) {
         return; // DEVICE_INVALID_PARAMETER;
     if (length < 0)
         length = buf->length;
-    length = min(length, buf->length - offset);
+    length = pxt::min(length, buf->length - offset);
     memset(buf->data + offset, value, length);
 }
 
@@ -112,10 +112,10 @@ void fill(Buffer buf, int value, int offset = 0, int length = -1) {
  */
 //%
 Buffer slice(Buffer buf, int offset = 0, int length = -1) {
-    offset = min((int)buf->length, offset);
+    offset = pxt::min((int)buf->length, offset);
     if (length < 0)
         length = buf->length;
-    length = min(length, buf->length - offset);
+    length = pxt::min(length, buf->length - offset);
     return mkBuffer(buf->data + offset, length);
 }
 

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -615,8 +615,8 @@ String substr(String s, int start, int length) {
         return mkEmpty();
     auto slen = (int)s->getLength();
     if (start < 0)
-        start = max(slen + start, 0);
-    length = min(length, slen - start);
+        start = pxt::max(slen + start, 0);
+    length = pxt::min(length, slen - start);
     if (length <= 0)
         return mkEmpty();
     auto p = s->getUTF8DataAt(start);
@@ -1875,8 +1875,9 @@ STRING_VT(string_inline_utf8, NOOP, NOOP, 2 + p->utf8.size + 1, p->utf8.data, p-
           utf8Len(p->utf8.data, p->utf8.size), utf8Skip(p->utf8.data, p->utf8.size, idx))
 STRING_VT(string_skiplist16, NOOP, if (p->skip.list) gcMarkArray(p->skip.list), 2 * sizeof(void *),
           PXT_SKIP_DATA_IND(p), p->skip.size, p->skip.length, skipLookup(p, idx, 0))
-STRING_VT(string_skiplist16_packed, NOOP, NOOP, 2 + 2 + PXT_NUM_SKIP_ENTRIES(p) * 2 + p->skip.size + 1,
-          PXT_SKIP_DATA_PACK(p), p->skip.size, p->skip.length, skipLookup(p, idx, 1))
+STRING_VT(string_skiplist16_packed, NOOP, NOOP,
+          2 + 2 + PXT_NUM_SKIP_ENTRIES(p) * 2 + p->skip.size + 1, PXT_SKIP_DATA_PACK(p),
+          p->skip.size, p->skip.length, skipLookup(p, idx, 1))
 STRING_VT(string_cons, fixCons(p), (gcScan((TValue)p->cons.left), gcScan((TValue)p->cons.right)),
           2 * sizeof(void *), PXT_SKIP_DATA_IND(p), p->skip.size, p->skip.length,
           skipLookup(p, idx, 0))


### PR DESCRIPTION
Inside the file `pxtbase.h`, the function `min`, `max` and `swap` are redefined inside the namespace `pxt`. 
If you make use of a recent version of GCC or clang, there is an ambiguity with the standard definition.

To remove this ambiguity, I have just prefixed the use of these three functions to be sure to use only the one from the namespace `pxt`