### PR TITLE
typo: milleseconds -> milliseconds

### DIFF
--- a/libs/animation/docs/reference/animation/create-animation.md
+++ b/libs/animation/docs/reference/animation/create-animation.md
@@ -23,7 +23,7 @@ Each frame in an animation is shown for some amount of time. This is set in the 
 ## Parameters
 
 * **action**: an action to relate the animation to. This could be an action like ``Walking`` or ``Jumping``.
-* **interval**: a [number](/types/number) that is the amount of time in milleseconds to show each frame in the animation.
+* **interval**: a [number](/types/number) that is the amount of time in milliseconds to show each frame in the animation.
 
 ## Returns
 

--- a/libs/core/docs/reference/pins/pulse-duration.md
+++ b/libs/core/docs/reference/pins/pulse-duration.md
@@ -18,7 +18,7 @@ you know which pin the pulse was on.
 
 ## Example #example
 
-Count every pulse on pin `D4` that is longer than 2 milleseconds in duration. Write the total
+Count every pulse on pin `D4` that is longer than 2 milliseconds in duration. Write the total
 number of pulses to the serial port every time the count adds another thousand pulses.
 
 ```blocks

--- a/libs/game/docs/reference/animation/run-movement-animation.md
+++ b/libs/game/docs/reference/animation/run-movement-animation.md
@@ -16,7 +16,7 @@ The animation runs for the amount of time you set for it. When the animation fin
 
 * **sprite**: a sprite to attach the animation to.
 * **pathString**: an name of a movement path to apply to a sprite.
-* **duration**: the [number](/types/number) of milleseconds to run the animation for.
+* **duration**: the [number](/types/number) of milliseconds to run the animation for.
 * **loop**: a [boolean](/types/boolean) value that if ``true`` will cause the sprite to return to its original position and restart the animation. If ``false``, the animation runs only once and the sprite remains at the last location of the animation.
 
 ## Example #example

--- a/libs/game/docs/reference/info/has-life.md
+++ b/libs/game/docs/reference/info/has-life.md
@@ -12,7 +12,7 @@ Returns a ``true`` value if the life count for the player is greater than zero.
 
 ## Example #Example
 
-Remove one life from the player every `100` milleseconds. When the player's lives reach 0, end the game early.
+Remove one life from the player every `100` milliseconds. When the player's lives reach 0, end the game early.
 
 ```blocks
 info.player2.setLife(20)

--- a/libs/music/music.ts
+++ b/libs/music/music.ts
@@ -147,7 +147,7 @@ namespace music {
     }
 
     /**
-    * Rest, or play silence, for some time (in milleseconds).
+    * Rest, or play silence, for some time (in milliseconds).
     * @param ms rest duration in milliseconds (ms), eg: BeatFraction.Half
     */
     //% help=music/rest


### PR DESCRIPTION
Fix the typo in doc