### PR TITLE
Copy stack on context switch in VM

### DIFF
--- a/libs/core---vm/vm.h
+++ b/libs/core---vm/vm.h
@@ -136,6 +136,13 @@ struct VMImage {
     const OpcodeDesc **opcodeDescs;
     RefAction *entryPoint;
 
+    // every fiber's sp starts at stackTop and goes towards stackBase
+    // stackTop > stackBase
+    // stackLimit is close to stackBase
+    TValue *stackBase;
+    TValue *stackTop;
+    TValue *stackLimit;
+
     uint32_t numSections;
     uint32_t numNumberLiterals;
     uint32_t numConfigDataEntries;
@@ -146,14 +153,6 @@ struct VMImage {
     int toStringKey;
 
     int execLock;
-};
-
-// not doing this, likely
-struct StackFrame {
-    StackFrame *caller;
-    uint32_t *retPC;
-    TValue *stackBase;
-    uint32_t *fnbase;
 };
 
 typedef TValue (*fiber_resume_t)(void *);
@@ -174,8 +173,8 @@ struct FiberContext {
     TValue thrownValue;
     jmp_buf loopjmp;
 
-    TValue *stackBase;
-    TValue *stackLimit;
+    TValue *stackCopy;
+    int stackCopySize;
 
     // wait_for_event
     int waitSource;


### PR DESCRIPTION
This lets us avoid statically allocating 4k of stack for every fiber (important for jacdac command handlers)