### PR TITLE
Update 'placeOnRandomTile' ref page

### DIFF
--- a/libs/game/docs/reference/scene/place-on-random-tile.md
+++ b/libs/game/docs/reference/scene/place-on-random-tile.md
@@ -3,7 +3,7 @@
 Move a sprite's position to the center of a random tile in the scene.
 
 ```sig
-scene.placeOnRandomTile(null, 0)
+tiles.placeOnRandomTile(null, null)
 ```
 
 You can make a sprite locate itself right on top of a random tile in the tilemap. Choose a tile in the tilemap to indicate which type of tile to have the sprite randomly placed on. If there is only one tile of that type, the sprite will always go to that tile. If multiple tiles of the same type are in the tilemap, then the sprite will randomly locate on any one of them.

--- a/libs/game/docs/reference/scene/place-on-random-tile.md
+++ b/libs/game/docs/reference/scene/place-on-random-tile.md
@@ -6,60 +6,114 @@ Move a sprite's position to the center of a random tile in the scene.
 scene.placeOnRandomTile(null, 0)
 ```
 
-You a can make a sprite to locate itself right on top of a random tile in the tile map. Use the color number of type of tile to select for the sprite to locate on one of them.
-
+You can make a sprite locate itself right on top of a random tile in the tile map. Use the color number of type of tile to select for the sprite to locate on one of them.
 
 ## Parameters
 
 * **sprite**: the sprite to move onto the tile.
-* **color**: the color [number](/types/number) of a tile to randomly select.
+* **tile**: the tile type in the tilemap to randomly select.
 
 ## Example #example
 
-Make a tilemap with several different tiles. Create a round shaped sprite. Ramdomly place the sprite on a tile with color number `8`.
+Make a tilemap with several different tiles. Create a round shaped sprite. Ramdomly place the sprite on a blue tile.
 
 ```blocks
-enum SpriteKind {
-    Player,
-    Enemy
-}
-let mySprite: Sprite = null
-scene.setTileMap(img`
-. . . . . . . . 3 . 
-. 2 . . . . . . . . 
-. . . . . 8 . . . . 
-. . . . . . . b . . 
-. . 8 . 6 . . . . . 
-. . . . . . 4 . . . 
-. a . . . . . . . . 
-. . . . . . . . e . 
-`)
-mySprite = sprites.create(img`
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . 7 7 7 7 7 7 . . . . . 
-. . . 7 7 7 7 7 7 7 7 7 7 . . . 
-. . . 7 7 7 7 7 7 7 7 7 7 . . . 
-. . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
-. . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
-. . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
-. . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
-. . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
-. . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
-. . . 7 7 7 7 7 7 7 7 7 7 . . . 
-. . . 7 7 7 7 7 7 7 7 7 7 . . . 
-. . . . . 7 7 7 7 7 7 . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-`, SpriteKind.Player)
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 7 7 7 7 7 7 . . . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . . . 7 7 7 7 7 7 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
 pause(1000)
-scene.placeOnRandomTile(mySprite, 8)
+tiles.placeOnRandomTile(mySprite, assets.tile`myTile`)
 ```
 
 ## See also #seealso
 
 [get tile](/reference/scene/get-tile)
 
-```package
-color-coded-tilemap
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile7": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile5"
+    },
+    "tile1": {
+        "data": "hwQQABAAAACIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile3": {
+        "data": "hwQQABAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile4": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "tile6": {
+        "data": "hwQQABAAAACZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile4"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDAwMDAzMDAwMDAwMDAwMDA2MDAwMDAwMDAwMDAyMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDMwMDAwMDAwMDAwMDAwMDA1MDAwMDAwMDAwMTAwMDAwMDAwMDAwMDA0MDAwMDAwMDAwMDAwMDYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5",
+            "myTiles.tile6",
+            "myTiles.tile7"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
 ```

--- a/libs/game/docs/reference/scene/place-on-random-tile.md
+++ b/libs/game/docs/reference/scene/place-on-random-tile.md
@@ -6,7 +6,7 @@ Move a sprite's position to the center of a random tile in the scene.
 scene.placeOnRandomTile(null, 0)
 ```
 
-You can make a sprite locate itself right on top of a random tile in the tile map. Use the color number of type of tile to select for the sprite to locate on one of them.
+You can make a sprite locate itself right on top of a random tile in the tilemap. Choose a tile in the tilemap to indicate which type of tile to have the sprite randomly placed on. If there is only one tile of that type, the sprite will always go to that tile. If multiple tiles of the same type are in the tilemap, then the sprite will randomly locate on any one of them.
 
 ## Parameters
 

--- a/libs/game/docs/reference/scene/place-on-random-tile.md
+++ b/libs/game/docs/reference/scene/place-on-random-tile.md
@@ -11,7 +11,7 @@ You can make a sprite locate itself right on top of a random tile in the tile ma
 ## Parameters
 
 * **sprite**: the sprite to move onto the tile.
-* **tile**: the tile type in the tilemap to randomly select.
+* **tile**: the tile type to randomly select in the tilemap.
 
 ## Example #example
 


### PR DESCRIPTION
This is a typo fix for https://github.com/microsoft/pxt-arcade/issues/3881 along with a some updates for the new api. This really should be part of the fixes need later for https://github.com/microsoft/pxt-arcade/issues/2728.

**Note:** The "See also" link is stale but I'll leave it in until the new 'set' and 'place' ref docs are in.

Fixes https://github.com/microsoft/pxt-arcade/issues/3881