### PR TITLE
Tilemap ref page updates part 1

### DIFF
--- a/libs/game/docs/reference/scene.md
+++ b/libs/game/docs/reference/scene.md
@@ -16,16 +16,17 @@ scene.backgroundImage()
 ## Tiles and Tilemaps
 
 ```cards
-scene.setTile(0, null)
-scene.setTileMap(null)
-scene.setTileAt(null, 0)
-scene.getTile(0, 0)
-scene.getTilesByType(0)
-scene.getTile(0, 0).place(null)
-scene.placeOnRandomTile(null, 0)
-scene.onHitTile(0, 0, function (sprite) {})
-sprites.create(null).isHittingTile(CollisionDirection.Left)
-sprites.create(null).tileHitFrom(CollisionDirection.Left)
+tiles.setTileAt(null, tiles.getTileLocation(0, 0))
+tiles.setWallAt(tiles.getTileLocation(0, 0), false)
+tiles.getTileLocation(0, 0)
+tiles.getTilesByType(null)
+tiles.placeOnTile(null, tiles.getTileLocation(0, 0))
+tiles.placeOnRandomTile(null, null)
+scene.onOverlapTile(SpriteKind.Player, null, function (sprite, location) {})
+scene.onHitWall(SpriteKind.Player, function (sprite, location) { })
+tiles.tileAtLocationEquals(location, null)
+sprites.create(null).isHittingTile(CollisionDirection.Right)
+sprites.create(null).tileKindAt(TileDirection.Right, null)
 ```
 
 ## Screen Effects
@@ -51,16 +52,17 @@ scene.cameraShake(4,500)
 [set background image](/reference/scene/set-background-image),
 [background color](/reference/scene/background-color),
 [background image](/reference/scene/background-image),
-[set tile](/reference/scene/set-tile),
-[set tile map](/reference/scene/set-tile-map),
 [set tile at](/reference/scene/set-tile-at),
-[get tile](/reference/scene/get-tile),
+[set wall at](/reference/scene/set-wall-at),
+[get tile location](/reference/scene/get-tile-location),
 [get tiles by type](/reference/scene/get-tiles-by-type),
-[place](/reference/scene/place),
+[place on tile](/reference/scene/place-on-tile,)
 [place on random tile](/reference/scene/place-on-random-tile),
-[on hit tile](/reference/scene/on-hit-tile),
+[on overlap tile](/reference/scene/on-overlap-tile),
+[on hit wall](/reference/scene/on-hit-wall),
+[tile at location equals](/reference/scene/tile-at-location-equals),
 [is hitting tile](/reference/sprites/sprite-is-hittint-tile),
-[tile hit from](/reference/sprites/sprite/tile-hit-from),
+[tile kind at](/reference/sprites/sprite/tile-kind-at),
 [start screen effect](/reference/scene/start-screen-effect),
 [end screen effect](/reference/scene/end-screen-effect),
 [camera follow sprite](/reference/scene/camera-follow-sprite),

--- a/libs/game/docs/reference/scene/get-tile-location.md
+++ b/libs/game/docs/reference/scene/get-tile-location.md
@@ -1,0 +1,96 @@
+# get Tile Location
+
+Get the tile location object for a particular column and row position in the tilemap.
+
+```sig
+tiles.getTileLocation(0, 0)
+```
+
+A tile location object represents a column and a row position in the tilemap. Location objects are used to get and set tiles or tile information for specific places in the tilemap.
+
+## Parameters
+
+* **col**: a [number](/types/number) that is the tilemap column of the tile location.
+* **row**: a [number](/types/number) that is the tilemap row of the tile location.
+
+## Returns
+
+* a tile location object for a given column and row in the tilemap.
+
+## Example #example
+
+Make a grid tilemap with two tile colors. Create a round shaped sprite. Ramdomly choose a tile location to place the sprite at in the grid.
+
+```blocks
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 7 7 7 7 7 7 . . . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . . . 7 7 7 7 7 7 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+
+forever(function () {
+    tiles.placeOnTile(mySprite, tiles.getTileLocation(randint(0, 9), randint(0, 6)))
+    pause(500)
+})
+```
+
+## Returns
+
+* a tile location for the column and row specifed.
+
+## See also #seealso
+
+[set tile at](/reference/scene/set-tile-at),
+[place on tile](/reference/scene/place-on-tile)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3Q==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDIwMTAyMDEwMjAxMDIwMTAyMDIwMTAyMDEwMjAxMDIwMTAyMDEwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDEwMjAxMDIwMTAyMDEwMjAxMDIwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDIwMTAyMDEwMjAxMDIwMTAyMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/is-hitting-tile.md
+++ b/libs/game/docs/reference/scene/is-hitting-tile.md
@@ -1,25 +1,26 @@
-# get Tiles By Type
+# is Hitting Tile
 
-Return an array of tile locations from the tilemap that contain the specified tile.
+Check if a sprite is currently hitting a wall.
 
 ```sig
-tiles.getTilesByType(null)
+sprites.create(null).isHittingTile(CollisionDirection.Right)
 ```
+
+A wall is either a tile set as a wall or the edge of the scene if a tilemap is set.
 
 ## Parameters
 
-* **tile**: a tile [image](/types/image) to search the tilemap for.
+* **direction**: the direction the sprite moves toward when detecting a wall collision: `left`, `right`, `top`, or `bottom`.
 
 ## Returns
 
-* an [array](/types/array) of tile locations from the tilemap that have the tile specified in **tile**.
+* a [boolean](/types/boolean) value that is `true` if the sprite is hitting a wall on the chosen side or `false` if not.
 
 ## Example #example
 
-Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, find the column tiles in the tilemap and set them as either wall tiles or regular tiles.
+Make a tilemap with a wall going from top to bottom. Set a sprite in motion and make it say "Ouch!" when it hits the wall on its `right` side.
 
 ```blocks
-let isWall = false
 tiles.setTilemap(tilemap`level1`)
 let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
@@ -42,17 +43,17 @@ let mySprite = sprites.create(img`
 mySprite.setBounceOnWall(true)
 mySprite.vx = 80
 mySprite.vy = 70
-game.onUpdateInterval(5000, function () {
-    isWall = !(isWall)
-    for (let wallTile of tiles.getTilesByType(assets.tile`myTile`)) {
-        tiles.setWallAt(wallTile, isWall)
+forever(function () {
+    if (mySprite.isHittingTile(CollisionDirection.Right)) {
+        mySprite.sayText("Ouch!", 200, false)
     }
 })
 ```
 
 ## See also #seealso
 
-[get tile location](/reference/scene/get-tile-location)
+[tile kind at](/reference/scene/tile-kind-at),
+[set tile at](/reference/scene/set-tile-at)
 
 ```jres
 {
@@ -70,7 +71,7 @@ game.onUpdateInterval(5000, function () {
     "level1": {
         "id": "level1",
         "mimeType": "application/mkcd-tilemap",
-        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMDAwMDAwMDIwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMDAwMDAwMDIwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMA==",
         "tileset": [
             "myTiles.transparency16",
             "myTiles.tile1"

--- a/libs/game/docs/reference/scene/on-hit-wall.md
+++ b/libs/game/docs/reference/scene/on-hit-wall.md
@@ -1,25 +1,32 @@
-# get Tiles By Type
+# on Hit Wall
 
-Return an array of tile locations from the tilemap that contain the specified tile.
+Run code when a sprite contacts a wall tile.
 
 ```sig
-tiles.getTilesByType(null)
+scene.onHitWall(SpriteKind.Player, function (sprite, location) { })
 ```
+
+You can detect when a moving sprite contacts a wall tile in the tilemap. If your sprite touches a tile that is set as a wall, you can have some code that runs when that happens. You pick the sprite **kind** to check for.
+
+When a wall hit is detected by the sprite of the kind you asked for, it is given to you in the **sprite** parameter of **handler** along with contacted tile's **location**.
+
+A sprite hitting a wall is dectected when the outside edges of its image makes contact with the tile. If a sprite has it's ``ghost`` flag set, any contact with the wall tile isn't noticed.
 
 ## Parameters
 
-* **tile**: a tile [image](/types/image) to search the tilemap for.
-
-## Returns
-
-* an [array](/types/array) of tile locations from the tilemap that have the tile specified in **tile**.
+* **kind**: the type of sprite to check for a wall hit.
+* **handler**: the code to run when the sprite makes contact. The handler has these parameters passed to it:
+>* **sprite**: the sprite that hit the wall tile.
+>* **location**: the location of the wall the sprite contacted in the tilemap.
 
 ## Example #example
 
-Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, find the column tiles in the tilemap and set them as either wall tiles or regular tiles.
+Create a tilemap with wall tiles surrounding the sides of the scene. Set a sprite in motion and cause it to bounce on wall tiles. When the sprite contacts the wall tiles, make a short fire effect on the sprite.
 
 ```blocks
-let isWall = false
+scene.onHitWall(SpriteKind.Player, function (sprite, location) {
+    sprite.startEffect(effects.fire, 200)
+})
 tiles.setTilemap(tilemap`level1`)
 let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
@@ -42,17 +49,12 @@ let mySprite = sprites.create(img`
 mySprite.setBounceOnWall(true)
 mySprite.vx = 80
 mySprite.vy = 70
-game.onUpdateInterval(5000, function () {
-    isWall = !(isWall)
-    for (let wallTile of tiles.getTilesByType(assets.tile`myTile`)) {
-        tiles.setWallAt(wallTile, isWall)
-    }
-})
 ```
 
 ## See also #seealso
 
-[get tile location](/reference/scene/get-tile-location)
+[get tile location](/reference/scene/get-tile-location),
+[set wall at](/reference/scene/set-wall-at)
 
 ```jres
 {
@@ -70,7 +72,7 @@ game.onUpdateInterval(5000, function () {
     "level1": {
         "id": "level1",
         "mimeType": "application/mkcd-tilemap",
-        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDAwMDAwMDAwMDAwMDAwMTAxMDAwMDAwMDAwMDAwMDAwMDAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDAwMDAwMDAwMDAwMDAwMTAxMDAwMDAwMDAwMDAwMDAwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEyMjIyMjIyMjIyMDIwMDAwMDAyMDAyMDAwMDAwMjAwMjAwMDAwMDIwMDIwMDAwMDAyMDAyMDAwMDAwMjAwMjAwMDAwMDIwMjIyMjIyMjIyMg==",
         "tileset": [
             "myTiles.transparency16",
             "myTiles.tile1"

--- a/libs/game/docs/reference/scene/on-overlap-tile.md
+++ b/libs/game/docs/reference/scene/on-overlap-tile.md
@@ -1,25 +1,32 @@
-# get Tiles By Type
+# on Overlap Tile
 
-Return an array of tile locations from the tilemap that contain the specified tile.
+Run code when a sprite overlaps a tile.
 
 ```sig
-tiles.getTilesByType(null)
+scene.onOverlapTile(SpriteKind.Player, null, function (sprite, location) {})
 ```
+
+You can detect when a moving sprite overlaps a tile in the tilemap. If your sprite moves across a tile, you can have some code that runs when that happens. You pick the sprite **kind** to check for.
+
+When an overlap is detected by the sprite of the kind you asked for, it is given to you in the **sprite** parameter of **handler** along with overlapped tile's **location**.
+
+A sprite hitting a wall is dectected when the outside edges of its image makes starts to overlap the tile.
 
 ## Parameters
 
-* **tile**: a tile [image](/types/image) to search the tilemap for.
-
-## Returns
-
-* an [array](/types/array) of tile locations from the tilemap that have the tile specified in **tile**.
+* **kind**: the type of sprite to check for a overlap.
+* **handler**: the code to run when the sprite overlaps a tile. The handler has these parameters passed to it:
+>* **sprite**: the sprite that overlapped the tile.
+>* **location**: the location of the tile that the sprite overlapped in the tilemap.
 
 ## Example #example
 
-Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, find the column tiles in the tilemap and set them as either wall tiles or regular tiles.
+Create a tilemap with a section of tiles in the center of the scene. Set a sprite in motion and cause it to bounce on walls. When the sprite overlaps the tiles, make it trace a trail across the tiles.
 
 ```blocks
-let isWall = false
+scene.onOverlapTile(SpriteKind.Player, assets.tile`myTile`, function (sprite, location) {
+    sprite.startEffect(effects.trail, 100)
+})
 tiles.setTilemap(tilemap`level1`)
 let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
@@ -42,17 +49,12 @@ let mySprite = sprites.create(img`
 mySprite.setBounceOnWall(true)
 mySprite.vx = 80
 mySprite.vy = 70
-game.onUpdateInterval(5000, function () {
-    isWall = !(isWall)
-    for (let wallTile of tiles.getTilesByType(assets.tile`myTile`)) {
-        tiles.setWallAt(wallTile, isWall)
-    }
-})
 ```
 
 ## See also #seealso
 
-[get tile location](/reference/scene/get-tile-location)
+[get tile location](/reference/scene/get-tile-location),
+[on hit wall](/reference/scene/on-hit-wall)
 
 ```jres
 {
@@ -70,7 +72,7 @@ game.onUpdateInterval(5000, function () {
     "level1": {
         "id": "level1",
         "mimeType": "application/mkcd-tilemap",
-        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDEwMTAwMDAwMDAwMDAwMDAwMDAwMTAxMDAwMDAwMDAwMDAwMDAwMDAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDAwMDAwMDAwMDAwMDAwMTAxMDAwMDAwMDAwMDAwMDAwMDAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDAwMDAwMDAwMDAwMDAwMTAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
         "tileset": [
             "myTiles.transparency16",
             "myTiles.tile1"

--- a/libs/game/docs/reference/scene/place-on-tile.md
+++ b/libs/game/docs/reference/scene/place-on-tile.md
@@ -1,0 +1,88 @@
+# place On Tile
+
+Move a sprite's position to the center of a tile location in the tilemap.
+
+```sig
+tiles.placeOnTile(null, tiles.getTileLocation(0, 0))
+```
+
+A sprite will locate itself on top of a tile in the tilemap using a tilemap location object. A location object contains a tile row value and a tile column value.
+
+## Parameters
+
+* **sprite**: the sprite to move onto the tile.
+* **loc**: a tile location in the tilemap.
+
+## Example #example
+
+Make a grid tilemap with two tile colors. Create a round shaped sprite. Ramdomly place the sprite on a tile in the grid.
+
+```blocks
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 7 7 7 7 7 7 . . . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . 7 7 7 7 7 7 7 7 7 7 7 7 . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . 7 7 7 7 7 7 7 7 7 7 . . . 
+    . . . . . 7 7 7 7 7 7 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+
+forever(function () {
+    tiles.placeOnTile(mySprite, tiles.getTileLocation(randint(0, 9), randint(0, 6)))
+    pause(500)
+})
+```
+
+## See also #seealso
+
+[get tile location](/reference/scene/get-tile-location),
+[place on random tile](/reference/scene/place-on-random-tile)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADd3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3Q==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDIwMTAyMDEwMjAxMDIwMTAyMDIwMTAyMDEwMjAxMDIwMTAyMDEwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDEwMjAxMDIwMTAyMDEwMjAxMDIwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDIwMTAyMDEwMjAxMDIwMTAyMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/set-tile-at.md
+++ b/libs/game/docs/reference/scene/set-tile-at.md
@@ -1,61 +1,65 @@
 # set Tile At
 
-Change a tile in the tilemap to another tile.
+Set a tile at a location in the tilemap.
 
 ```sig
-scene.setTileAt(null, 0)
+tiles.setTileAt(null, tiles.getTileLocation(0, 0))
 ```
 
-A tile from the tile map has the [tile](/types/tile) type. You can change that tile by using it's object type, [tile](/types/tile), and the index of a different tile. The tile map is changed to have the new tile take the position in the tilemap where this one was.
+You can set a tile at a specific column and row in the tilemap using a tile location object. Specify a tile to set in the tilemap and a location for it.
 
 ## Parameters
 
-* **tile**: the [tile](/types/tile) object to be replaced.
-* **index**: the color index of the tile to replace the previous one.
+* **tile**: the to set in the tilemap.
+* **loc**: a tile location in the tilemap.
 
 ## Example #example
 
-Make a scene using a tilemap with border tiles and two tiles in the center. Replace the tiles in the center with the ones used for the border.
+Create an empty tilemap and a solid color tile. Set the solid color tile at different places in the tilemap and replace its previous location with a transparent tile.
 
 ```blocks
-scene.setTile(2, img`
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-`)
-scene.setTileMap(img`
-2 2 2 2 2 2 2 2 2 2 
-2 . . . . . . . . 2 
-2 . . . . . . . . 2 
-2 . . . 1 1 . . . 2 
-2 . . . . . . . . 2 
-2 . . . . . . . . 2 
-2 2 2 2 2 2 2 2 2 2 
-. . . . . . . . . . 
-`)
-pause(1000)
-scene.setTileAt(scene.getTile(4, 3), 2)
-pause(1000)
-scene.setTileAt(scene.getTile(5, 3), 2)
+tiles.setTilemap(tilemap`level1`)
+let spot = tiles.getTileLocation(0, 0)
+forever(function () {
+    tiles.setTileAt(spot, assets.tile`transparency16`)
+    spot = tiles.getTileLocation(randint(0, 9), randint(0, 6))
+    tiles.setTileAt(spot, assets.tile`myTile`)
+    pause(1000)
+})
 ```
 
 ## See also #seealso
 
-[set tile](/reference/scene/set-tile), [get tile](/reference/scene/get-tile)
+[get tile location](/reference/scene/get-tile-location),
+[place on tile](/reference/scene/place-on-tile)
 
-```package
-color-coded-tilemap
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
 ```

--- a/libs/game/docs/reference/scene/set-wall-at.md
+++ b/libs/game/docs/reference/scene/set-wall-at.md
@@ -1,22 +1,21 @@
-# get Tiles By Type
+# set Wall At
 
-Return an array of tile locations from the tilemap that contain the specified tile.
+Set a tile as a wall tile in the tilemap.
 
 ```sig
-tiles.getTilesByType(null)
+tiles.setWallAt(tiles.getTileLocation(0, 0), false)
 ```
+
+Wall tiles create a barrier for sprites so that they can't pass through tilemap at the tile location. You can set a tile location in the tilemap as a wall or turn it back to a regular tile.
 
 ## Parameters
 
-* **tile**: a tile [image](/types/image) to search the tilemap for.
-
-## Returns
-
-* an [array](/types/array) of tile locations from the tilemap that have the tile specified in **tile**.
+* **loc**: a tile location in the tilemap.
+* **on**: a [boolean](/types/boolean) value to set the tile location be a wall tile if `true` or a regular tile if `false`.
 
 ## Example #example
 
-Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, find the column tiles in the tilemap and set them as either wall tiles or regular tiles.
+Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, set the tiles  in the column to be wall tiles or regular tiles.
 
 ```blocks
 let isWall = false
@@ -52,7 +51,8 @@ game.onUpdateInterval(5000, function () {
 
 ## See also #seealso
 
-[get tile location](/reference/scene/get-tile-location)
+[get tile location](/reference/scene/get-tile-location),
+[on hit wall](/reference/scene/on-hit-wall)
 
 ```jres
 {

--- a/libs/game/docs/reference/scene/tile-at-location-equals.md
+++ b/libs/game/docs/reference/scene/tile-at-location-equals.md
@@ -1,0 +1,97 @@
+# tile At Location Equals
+
+Check if a location in the tilemap contains the tile you're looking for.
+
+```sig
+tiles.tileAtLocationEquals(location, null)
+```
+
+## Parameters
+
+* **location**: a location in the tilemap.
+* **tile**: an [image](/types/image) that matches the tile you're looking for.
+
+## Returns
+
+* a [boolean](/types/boolean) value that is `true` if the tile at **location** matches the **tile** you want to check for. If not, `false` is returned.
+
+## Example #example
+
+Make a tilemap with two columns of wall tiles with a different color for each.  Set a sprite in motion and cause it to bounce on walls. When the sprite contacts a tile, check to see what color the tile is.
+
+```blocks
+scene.onHitWall(SpriteKind.Player, function (sprite, location) {
+    if (tiles.tileAtLocationEquals(location, assets.tile`myTile0`)) {
+        mySprite.sayText("Blue", 500, false)
+    } else if (tiles.tileAtLocationEquals(location, assets.tile`myTile1`)) {
+        mySprite.sayText("Green", 500, false)
+    } else {
+        mySprite.startEffect(effects.fire, 200)
+    }
+})
+let mySprite: Sprite = null
+tiles.setTilemap(tilemap`level1`)
+mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setBounceOnWall(true)
+mySprite.vx = 40
+mySprite.vy = 35
+```
+
+## See also #seealso
+
+[get tile location](/reference/scene/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAACIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAyMDAwMDAwMDAwMDAwMDAwMDAxMDIwMDAwMDAwMDAwMDAwMDAwMDEwMjAwMDAwMDAwMDAwMDAwMDAwMTAyMDAwMDAwMDAwMDAwMDAwMDAxMDIwMDAwMDAwMDAwMDAwMDAwMDEwMjAwMDAwMDAwMDAwMDAwMDAwMTAyMDAwMDAwMDAwMDAwMDAwMDAxMDIwMDAwMDAwMDAwMDAwMDAwMDEwMjAwMDAwMDIwMDIwMDAwMDAyMDAyMDAwMDAwMjAwMjAwMDAwMDIwMDIwMDAwMDAyMDAyMDAwMDAwMjAwMjAwMDAwMDIwMDIwMDAwMDAyMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/tile-kind-at.md
+++ b/libs/game/docs/reference/scene/tile-kind-at.md
@@ -1,0 +1,118 @@
+# tile Kind At
+
+Check if the tile next to a sprite is the one you're looking for.
+
+```sig
+sprites.create(null).tileKindAt(TileDirection.Right, null)
+```
+
+A tile next to a sprite can be matched to a tile you want to check for. You choose the direction to check for to see if the tile is next to the sprite. If the tile matches the one you are looking for in that direction, it will detect it when the sprite is within one-half of it's dimension for that direction.
+
+## Parameters
+
+* **direction**: the direction from the sprite for the tile check: `left`, `right`, `top`, or `bottom`.
+* **tile**: an [image](/types/image) that matches the tile you're looking for.
+
+## Returns
+
+* a [boolean](/types/boolean) value that is `true` if the tile near the sprite at the **direction** matches the **tile** you want to check for. If not, `false` is returned.
+
+## Example #example
+
+Make a tilemap with three columns of tiles with a different color for each. Set a sprite in motion from left to right. When the sprite comes near a tile, check to see what color the tile is.
+
+```blocks
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . 1 1 9 9 9 9 9 9 1 1 . . . 
+    . . . 1 9 9 9 9 9 9 9 9 1 . . . 
+    . . 1 9 9 9 9 9 9 9 9 9 9 1 . . 
+    . . 1 9 9 9 9 9 9 9 9 9 9 1 . . 
+    . . 1 9 9 9 9 9 9 9 9 9 9 1 . . 
+    . . 1 9 9 9 9 9 9 9 9 9 9 1 . . 
+    . . 1 9 9 9 9 9 9 9 9 9 9 1 . . 
+    . . 1 9 9 9 9 9 9 9 9 9 9 1 . . 
+    . . . 1 9 9 9 9 9 9 9 9 1 . . . 
+    . . . 1 1 9 9 9 9 9 9 1 1 . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.x = 0
+game.onUpdateInterval(100, function () {
+    if (mySprite.tileKindAt(TileDirection.Right, assets.tile`myTile2`)) {
+        mySprite.sayText("red", 100, false)
+    } else if (mySprite.tileKindAt(TileDirection.Right, assets.tile`myTile1`)) {
+        mySprite.sayText("green", 100, false)
+    } else if (mySprite.tileKindAt(TileDirection.Right, assets.tile`myTile3`)) {
+        mySprite.sayText("yellow", 100, false)
+    } else if (mySprite.right >= scene.screenWidth()) {
+        mySprite.x = 0
+    }
+    mySprite.x += 2
+})
+```
+
+## See also #seealso
+
+[is hitting tile](/reference/scene/is-hitting-tile)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAACIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile3": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile4": {
+        "data": "hwQQABAAAAAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMTAwMDAwMzAwMDAwMjAwMDAwMDAxMDAwMDAzMDAwMDAyMDAwMDAwMDEwMDAwMDMwMDAwMDIwMDAwMDAwMTAwMDAwMzAwMDAwMjAwMDAwMDAxMDAwMDAzMDAwMDAyMDAwMDAwMDEwMDAwMDMwMDAwMDIwMDAwMDAwMTAwMDAwMzAwMDAwMjAwMDAwMDAxMDAwMDAzMDAwMDAyMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -706,7 +706,7 @@ class Sprite extends sprites.BaseSprite {
      */
     //% blockId=spritehasobstacle block="is %sprite(mySprite) hitting wall %direction"
     //% blockNamespace="scene" group="Locations" blockGap=24
-    //% help=sprites/sprite/is-hitting-tile
+    //% help=scene/is-hitting-tile
     //% weight=15
     isHittingTile(direction: CollisionDirection): boolean {
         return this._obstacles && !!this._obstacles[direction];
@@ -719,7 +719,7 @@ class Sprite extends sprites.BaseSprite {
     //% blockId=spritetileat block="tile to $direction of $this(mySprite) is $tile"
     //% tile.shadow=tileset_tile_picker
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% help=sprites/sprite/tile-kind-at
+    //% help=scene/tile-kind-at
     //% weight=20
     tileKindAt(direction: TileDirection, tile: Image): boolean {
         const tilemap = game.currentScene().tileMap;

--- a/libs/game/spriteevents.ts
+++ b/libs/game/spriteevents.ts
@@ -46,7 +46,7 @@ namespace sprites {
     //% group="Overlaps"
     //% weight=100 draggableParameters="reporter"
     //% blockId=spritesoverlap block="on $sprite of kind $kind=spritekind overlaps $otherSprite of kind $otherKind=spritekind"
-    //% help=sprites/on-overlap
+    //% help=scene/on-overlap
     //% blockGap=8
     export function onOverlap(kind: number, otherKind: number, handler: (sprite: Sprite, otherSprite: Sprite) => void) {
         if (kind == undefined || otherKind == undefined || !handler) return;
@@ -86,7 +86,7 @@ namespace scene {
     //% weight=120 draggableParameters="reporter" blockGap=8
     //% blockId=spriteshittile block="on $sprite of kind $kind=spritekind overlaps $tile at $location"
     //% tile.shadow=tileset_tile_picker
-    //% help=tiles/on-overlap-tile
+    //% help=scene/on-overlap-tile
     export function onOverlapTile(kind: number, tile: Image, handler: (sprite: Sprite, location: tiles.Location) => void) {
         if (kind == undefined || !tile || !handler) return;
 
@@ -108,7 +108,7 @@ namespace scene {
     //% group="Tilemaps"
     //% weight=100 draggableParameters="reporter" blockGap=8
     //% blockId=spriteshitwall block="on $sprite of kind $kind=spritekind hits wall at $location"
-    //% help=tiles/on-hit-wall
+    //% help=scene/on-hit-wall
     export function onHitWall(kind: number, handler: (sprite: Sprite, location: tiles.Location) => void) {
         if (kind == undefined || !handler) return;
 

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -574,7 +574,7 @@ namespace tiles {
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
-    //% help=tiles/set-tile-at
+    //% help=scene/set-tile-at
     //% weight=70
     export function setTileAt(loc: Location, tile: Image): void {
         const scene = game.currentScene();
@@ -592,7 +592,7 @@ namespace tiles {
     //% blockId=mapsetwallat block="set wall $on at $loc"
     //% on.shadow=toggleOnOff loc.shadow=mapgettile
     //% blockNamespace="scene" group="Tilemap Operations"
-    //% help=tiles/set-wall-at
+    //% help=scene/set-wall-at
     //% weight=60
     export function setWallAt(loc: Location, on: boolean): void {
         const scene = game.currentScene();
@@ -609,7 +609,7 @@ namespace tiles {
     //% blockId=mapgettile block="tilemap col $col row $row"
     //% blockNamespace="scene" group="Locations"
     //% weight=100 blockGap=8
-    //% help=tiles/get-tile-location
+    //% help=scene/get-tile-location
     export function getTileLocation(col: number, row: number): Location {
         const scene = game.currentScene();
         if (col == undefined || row == undefined || !scene.tileMap) return null;
@@ -646,7 +646,7 @@ namespace tiles {
     //% location.shadow=mapgettile
     //% tile.shadow=tileset_tile_picker tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% weight=40
+    //% weight=40 help=scene/tile-at-location-equals
     export function tileAtLocationEquals(location: Location, tile: Image): boolean {
         const scene = game.currentScene();
         if (!location || !tile || !scene.tileMap) return false;
@@ -692,7 +692,7 @@ namespace tiles {
     //% blockId=mapplaceontile block="place $sprite=variables_get(mySprite) on top of $loc"
     //% loc.shadow=mapgettile
     //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
-    //% help=tiles/place
+    //% help=scene/place
     //% weight=100
     export function placeOnTile(sprite: Sprite, loc: Location): void {
         if (!sprite || !loc || !loc.tileMap) return;
@@ -708,7 +708,7 @@ namespace tiles {
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tilemap Operations"
-    //% help=tiles/place-on-random-tile
+    //% help=scene/place-on-random-tile
     //% weight=90
     export function placeOnRandomTile(sprite: Sprite, tile: Image): void {
         if (!sprite || !game.currentScene().tileMap) return;
@@ -725,7 +725,7 @@ namespace tiles {
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% help=tiles/get-tiles-by-type
+    //% help=scene/get-tiles-by-type
     //% weight=10
     export function getTilesByType(tile: Image): Location[] {
         const scene = game.currentScene();


### PR DESCRIPTION
This adds/updates ref pages to the current tilemap exposed API. Exceptions are 'setTilemap()` and the "Tilemap" overview page which will come in a follow-on PR.

The pages are currently grouped under `./scene` to match the block namespace.

Finally getting the bulk of changes for https://github.com/microsoft/pxt-arcade/issues/2728 filled in.

RE: #1301