### PR TITLE
Tilemap ref page updates part2

### DIFF
--- a/libs/game/docs/reference/scene.md
+++ b/libs/game/docs/reference/scene.md
@@ -16,6 +16,7 @@ scene.backgroundImage()
 ## Tiles and Tilemaps
 
 ```cards
+tiles.setTilemap(null)
 tiles.setTileAt(null, tiles.getTileLocation(0, 0))
 tiles.setWallAt(tiles.getTileLocation(0, 0), false)
 tiles.getTileLocation(0, 0)
@@ -52,6 +53,7 @@ scene.cameraShake(4,500)
 [set background image](/reference/scene/set-background-image),
 [background color](/reference/scene/background-color),
 [background image](/reference/scene/background-image),
+[set tilemap](/reference/scene/set-tilemap),
 [set tile at](/reference/scene/set-tile-at),
 [set wall at](/reference/scene/set-wall-at),
 [get tile location](/reference/scene/get-tile-location),

--- a/libs/game/docs/reference/scene/set-tilemap.md
+++ b/libs/game/docs/reference/scene/set-tilemap.md
@@ -1,0 +1,89 @@
+# set Tilemap
+
+Set a tilemap as the current tilemap for the game scene.
+
+```sig
+tiles.setTilemap(null)
+```
+
+A tilemap is complex data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
+
+Tilemaps aren't coded by the user but are created using a tilemap editor. Each tilemap in a game project is a named resource and is contained within the project's **assets** collection. A particular tilemap is specified with it's resource name like this:
+
+```typescript
+tiles.setTilemap(tilemap`level1`)
+```
+
+## Parameters
+
+* **tilemap**: the tilemap data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
+
+## Example #example
+
+Create a maze tilemap for a sprite to travel through. Set the tilemap as the scene for the game. Create a sprite and start it travelling in the maze.
+
+```blocks
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setPosition(0, 104)
+mySprite.vx = 16
+```
+
+## See also #seealso
+
+[set tile at](/reference/scene/set-tile-at)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDIwMjAyMDAwMjAyMDAwMTAxMDAwMjAwMDIwMDAyMDIwMDAwMDEwMDAyMDAwMjAwMDIwMDAwMDEwMTAwMDIwMDAyMDIwMjAwMDIwMTAwMDAwMDAwMDAwMDAyMDAwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEyMjIyMjIyMjIyMDIwMDAwMDAyMDAyMjIwMjIyMjAwMjAyMDIyMjAwMDIwMjAyMDIyMDAyMDIyMjAyMjIwMDAwMDAwMjIwMjIyMjIyMjIyMg==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "maze"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -545,7 +545,7 @@ namespace tiles {
     //% tilemap.fieldOptions.filter="tile"
     //% tilemap.fieldOptions.taggedTemplate="tilemap"
     //% blockNamespace="scene" duplicateShadowOnDrag
-    //% help=tiles/set-tile-map
+    //% help=scene/set-tilemap
     //% deprecated=1
     export function setTilemap(tilemap: TileMapData) {
         setCurrentTilemap(tilemap);


### PR DESCRIPTION
Second part of updating the tilemap ref pages. This contains a new page for `setTilemap()` , an update to the `scene` card page, and the help path.

I was going to do a tilemap overview page in here but I thought that would work better in the target doc set (tilemap editor discussions, etc.) if it's even necessary due to similar coverage in the courses content.

Closes https://github.com/microsoft/pxt-arcade/issues/2728