### PR TITLE
Fix parm errors in tilemap ref pages

### DIFF
--- a/libs/game/docs/reference/scene/set-tile-at.md
+++ b/libs/game/docs/reference/scene/set-tile-at.md
@@ -3,15 +3,15 @@
 Set a tile at a location in the tilemap.
 
 ```sig
-tiles.setTileAt(null, tiles.getTileLocation(0, 0))
+tiles.setTileAt(tiles.getTileLocation(0, 0), null)
 ```
 
 You can set a tile at a specific column and row in the tilemap using a tile location object. Specify a tile to set in the tilemap and a location for it.
 
 ## Parameters
 
-* **tile**: the to set in the tilemap.
 * **loc**: a tile location in the tilemap.
+* **tile**: the to set in the tilemap.
 
 ## Example #example
 

--- a/libs/game/docs/reference/scene/tile-at-location-equals.md
+++ b/libs/game/docs/reference/scene/tile-at-location-equals.md
@@ -3,7 +3,7 @@
 Check if a location in the tilemap contains the tile you're looking for.
 
 ```sig
-tiles.tileAtLocationEquals(location, null)
+tiles.tileAtLocationEquals(tiles.getTileLocation(0, 0), null)
 ```
 
 ## Parameters


### PR DESCRIPTION
Some parameter order errors in a couple of tilemap reference pages. Corresponds to fixes in #1305. 