### PR TITLE
Reference fixes and pages for sprite accel and friction

### DIFF
--- a/libs/game/docs/reference/sprites/sprite/ax.md
+++ b/libs/game/docs/reference/sprites/sprite/ax.md
@@ -36,13 +36,15 @@ mySprite.ax = 0
 
 * **value**: the new horizontal acceleration for the sprite in pixels per second, per second.
 
-## Sprite acceleration
+## Sprite horizontal acceleration
 
-Acceleration of a sprite makes it speed up or slow down. The value for acceleration determines how quickly the speed  of the sprite will change. A positive value makes the sprite speed up as it moves. A negative value causes the sprite to slow down while it moves.
+The value for acceleration determines how quickly the speed of the sprite will change. Acceleration of a sprite makes it speed up in a direction toward the right or left. A positive value causes the sprite's speed in the `right` direction to increase. A negative value causes the sprite's speed in the `left` direction to increase.
+
+Acceleration can be used as an opposing force too. If a sprite is travelling toward the right at a certain speed and a negative horizontal acceleration is applied, the sprite will keep moving to the right but it will slow down. When the sprite's speed reaches `0`, the sprite will begin to move to the left.
 
 ### ~ hint
 
-**How speed changes**
+#### How speed changes
 
 Speed, or velocity, is how much distance an object moves during some period of time. Distance in your game is measured in pixels so the speed of a sprite is in _pixels per second_. Speed is changed by _accelerating_ an object. In your game, a sprite is accelerated by some amount of change in speed per second. So, acceleration is measured in _pixels per second per second_.
 
@@ -129,6 +131,35 @@ game.onUpdateInterval(1000, function () {
     }
     interval += 1
 })
+```
+
+### Opposite force #ex3
+
+Make a sprite move from the left side of the screen to the right side. Apply acceleration in the opposite direction to slow the sprite down and send back to the left.
+
+```blocks
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setStayInScreen(true)
+mySprite.left = 0
+mySprite.vx = 100
+mySprite.ax = -35
 ```
 
 ## See also #seealso

--- a/libs/game/docs/reference/sprites/sprite/ay.md
+++ b/libs/game/docs/reference/sprites/sprite/ay.md
@@ -36,13 +36,16 @@ mySprite.ay = 0
 
 * **value**: the new vertical acceleration for the sprite in pixels per second, per second.
 
-## Sprite acceleration
+## Sprite vertical acceleration
 
-Acceleration of a sprite makes it speed up or slow down. The value for acceleration determines how quickly the speed  of the sprite will change. A positive value makes the sprite speed up as it moves. A negative value causes the sprite to slow down while it moves.
+The value for acceleration determines how quickly the speed of the sprite will change. Acceleration of a sprite makes it speed up in a direction toward the bottom or top. A positive value causes the sprite's speed in the `bottom` direction to increase. A negative value causes the sprite's speed in the `top` direction to increase.
+
+Acceleration can be used as an opposing force too. If a sprite is travelling toward the bottom at a certain speed and a negative vertical acceleration is applied, the sprite will keep moving to the bottom but it will slow down. When the sprite's speed reaches `0`, the sprite will begin to move to the top.
+
 
 ### ~ hint
 
-**How speed changes**
+#### How speed changes
 
 Speed, or velocity, is how much distance an object moves during some period of time. Distance in your game is measured in pixels so the speed of a sprite is in _pixels per second_. Speed is changed by _accelerating_ an object. In your game, a sprite is accelerated by some amount of change in speed per second. So, acceleration is measured in _pixels per second per second_.
 
@@ -128,6 +131,34 @@ game.onUpdateInterval(1000, function () {
     }
     interval += 1
 })
+```
+### Opposite force #ex3
+
+Make a sprite move from the top of the screen to the bottom. Apply acceleration in the opposite direction to slow the sprite down and send back to the top.
+
+```blocks
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setStayInScreen(true)
+mySprite.top = 0
+mySprite.vy = 80
+mySprite.ay = -35
 ```
 
 ## See also #seealso

--- a/libs/game/docs/reference/sprites/sprite/fx.md
+++ b/libs/game/docs/reference/sprites/sprite/fx.md
@@ -1,0 +1,123 @@
+# fy (property)
+
+Get or set the friction opposing a sprite's motion in the vertical direction.
+
+## Get
+
+Get the vertical friction on the sprite.
+
+```block
+let mySprite: Sprite = null
+
+let horzAccel = mySprite.fy
+```
+
+```typescript-ignorelet
+horzAccel = mySprite.fy
+```
+
+### Returns
+
+* a [number](/types/number) that is the current vertical friction of the sprite.
+
+## Set
+
+Set the vertical friction for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+mySprite.fy = 0
+```
+
+```typescript-ignore
+mySprite.fy = 0
+```
+
+### Parameter
+
+* **value**: the new vertical friction opposing the sprite's motion in pixels per second, per second.
+
+## Sprite vertical friction
+
+Friction is an opposing force against the motion of a sprite. If a sprite has a vertical velocity (`vy`), it's friction will slow the sprite down until it's vertical velocity becomes `0`. This is similar to setting an opposite vertical acceleration but the opposite acceleration goes away once the sprite stops.
+
+## Examples #example
+
+### Measure stopping time #ex1
+
+Move the sprite from top to bottom across the screen. Use the correct amount of friction (`fy`) to make the sprite stop at `3` seconds.
+
+```blocks
+let stopTime = 0
+let counting = true
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setStayInScreen(true)
+mySprite.top = 0
+mySprite.fy = 20
+mySprite.vy = 60
+game.onUpdateInterval(100, function () {
+    if (counting) {
+        stopTime += 0.1
+        if (mySprite.vy == 0) {
+            counting = false
+            mySprite.sayText("" + stopTime + "sec", 5000, false)
+        }
+    }
+})
+```
+
+### Skipppng sprite #ex2
+
+Make a sprite move from the top to the bottom. Make it skip to the right once every second.
+
+```blocks
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setStayInScreen(true)
+mySprite.top = 0
+mySprite.fy = 60
+mySprite.vy = 60
+for (let index = 0; index < 3; index++) {
+    mySprite.vy = 60
+    pause(1000)
+}
+```
+
+## See also #seealso
+
+[fx](/reference/sprites/sprite/fx),
+[ay](/reference/sprites/sprite/ay)

--- a/libs/game/docs/reference/sprites/sprite/fy.md
+++ b/libs/game/docs/reference/sprites/sprite/fy.md
@@ -1,0 +1,123 @@
+# fy (property)
+
+Get or set the friction opposing a sprite's motion in the horizontal direction.
+
+## Get
+
+Get the horizontal friction on the sprite.
+
+```block
+let mySprite: Sprite = null
+
+let horzAccel = mySprite.fx
+```
+
+```typescript-ignorelet
+horzAccel = mySprite.fx
+```
+
+### Returns
+
+* a [number](/types/number) that is the current horizontal friction of the sprite.
+
+## Set
+
+Set the horizontal friction for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+mySprite.fx = 0
+```
+
+```typescript-ignore
+mySprite.fx = 0
+```
+
+### Parameter
+
+* **value**: the new horizontal friction opposing the sprite's motion in pixels per second, per second.
+
+## Sprite horizontal friction
+
+Friction is an opposing force against the motion of a sprite. If a sprite has a horizontal velocity (`vx`), it's friction will slow the sprite down until it's horizontal velocity becomes `0`. This is similar to setting an opposite horizontal acceleration but the opposite acceleration goes away once the sprite stops.
+
+## Examples #example
+
+### Measure stopping time #ex1
+
+Move the sprite from left to right across the screen. Use the correct amount of friction (`fx`) to make the sprite stop at `3` seconds.
+
+```blocks
+let stopTime = 0
+let counting = true
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setStayInScreen(true)
+mySprite.left = 0
+mySprite.fx = 30
+mySprite.vx = 90
+game.onUpdateInterval(100, function () {
+    if (counting) {
+        stopTime += 0.1
+        if (mySprite.vx == 0) {
+            counting = false
+            mySprite.sayText("" + stopTime + "sec", 5000, false)
+        }
+    }
+})
+```
+
+### Skipppng sprite #ex2
+
+Make a sprite move from the left to the right. Make it skip to the right once every second.
+
+```blocks
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setStayInScreen(true)
+mySprite.left = 0
+mySprite.fx = 80
+mySprite.vx = 80
+for (let index = 0; index < 3; index++) {
+    mySprite.vx = 80
+    pause(1000)
+}
+```
+
+## See also #seealso
+
+[fy](/reference/sprites/sprite/fy),
+[ax](/reference/sprites/sprite/ax)


### PR DESCRIPTION
Redo the descriptions for directional acceleration. Also, add pages for the sprite `fx` and `fy` properties.