### PR TITLE
Add sprite scaling support

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -73,8 +73,8 @@ class Sprite extends sprites.BaseSprite {
     _fy: Fx8 // friction
     _sx: Fx8 // scale
     _sy: Fx8 // scale
-    _width: Fx8
-    _height: Fx8
+    _width: Fx8 // scaled width
+    _height: Fx8 // scaled height
 
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x" callInDebugger
@@ -632,7 +632,16 @@ class Sprite extends sprites.BaseSprite {
         if (!this.isScaled())
             screen.drawTransparentImage(this._image, l, t);
         else
-            screen.blit(l, t, this.width, this.height, this._image, 0, 0, this._image.width, this._image.height, true, false);
+            screen.blit(
+                // dst rect in screen
+                l, t,
+                this.width,
+                this.height,
+                // src rect in sprite image
+                this._image,
+                0, 0,
+                this._image.width, this._image.height,
+                true, false);
 
         if (this.flags & SpriteFlag.ShowPhysics) {
             const font = image.font5;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -361,7 +361,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     private isScaled(): boolean {
-        return !(this._sx === Fx.oneFx8 || this._sy === Fx.oneFx8);
+        return this._sx !== Fx.oneFx8 || this._sy !== Fx.oneFx8;
     }
 
     //% group="Physics" blockSetVariable="mySprite"

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -109,7 +109,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x" callInDebugger
     get x(): number {
-        return Fx.toFloat(this._x) + (this.width / 2)
+        return Fx.toFloat(Fx.add(this._x, Fx.div(this._width, Fx.twoFx8)));
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="x"
@@ -120,7 +120,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y" callInDebugger
     get y(): number {
-        return Fx.toFloat(this._y) + (this.height / 2)
+        return Fx.toFloat(Fx.add(this._y, Fx.div(this._height, Fx.twoFx8)));
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="y"
@@ -262,7 +262,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="lifespan"
     lifespan: number;
-    _image: Image;
+    private _image: Image;
     private _obstacles: sprites.Obstacle[];
 
     private sayEndTime: number;
@@ -301,7 +301,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     __serialize(offset: number): Buffer {
-        const buf = control.createBuffer(offset + 12);
+        const buf = control.createBuffer(offset + 16);
         let k = offset;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._x)); k += 2;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._y)); k += 2;
@@ -331,7 +331,7 @@ class Sprite extends sprites.BaseSprite {
     //% blockId=spritesetimage block="set %sprite(mySprite) image to %img=screen_image_picker"
     //% weight=7 help=sprites/sprite/set-image
     setImage(img: Image) {
-        if (!img) return; // don't break the sprite
+        if (!img || img === this._image) return;
         this._image = img;
         this.recalcSize();
     }
@@ -1086,8 +1086,8 @@ class Sprite extends sprites.BaseSprite {
     setScaleCore(sx?: number, sy?: number, anchor?: ScaleAnchor, proportional?: boolean): void {
         anchor = anchor || ScaleAnchor.Middle;
 
-        const hasSx = typeof sx === 'number';
-        const hasSy = typeof sy === 'number';
+        const hasSx = sx != null;
+        const hasSy = sy != null;
 
         const oldW = this.width;
         const oldH = this.height;
@@ -1126,7 +1126,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     //% blockId=sprite_set_scale
-    //% block="set %sprite(mySprite) scale to $value, anchor on $anchor"
+    //% block="set %sprite(mySprite) scale to $value anchor $anchor"
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% value.defl=1
@@ -1147,7 +1147,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     //% blockId=sprite_change_scale
-    //% block="change %sprite(mySprite) scale by $value, anchor on $anchor"
+    //% block="change %sprite(mySprite) scale by $value anchor $anchor"
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% value.defl=1

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1171,7 +1171,7 @@ class Sprite extends sprites.BaseSprite {
     //% amount.defl=10
     //% direction.defl=ScaleDirection.Horizontally
     //% anchor.defl=ScaleAnchor.Middle
-    //% proportional.defl=false
+    //% proportional.defl=0
     //% help=sprites/sprite/grow-by-pixels
     //% group="Scale" weight=60
     growByPixels(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
@@ -1204,7 +1204,7 @@ class Sprite extends sprites.BaseSprite {
     //% amount.defl=10
     //% direction.defl=ScaleDirection.Horizontally
     //% anchor.defl=ScaleAnchor.Middle
-    //% proportional.defl=false
+    //% proportional.defl=0
     //% help=sprites/sprite/grow-by-pixels
     //% group="Scale" weight=50
     shrinkByPixels(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1057,22 +1057,11 @@ class Sprite extends sprites.BaseSprite {
     }
 
     //% blockId=sprite_get_scale
-    //% block="get %sprite(mySprite) scale || $direction"
-    //% expandableArgumentMode=enabled
-    //% direction.defl=ScaleDirection.Uniformly
+    //% block="%sprite(mySprite) scale"
     //% help=sprites/sprite/get-scale
     //% group="Scale" weight=100
-    getScale(direction?: ScaleDirection): number {
-        direction = direction || ScaleDirection.Uniformly;
-        if (direction === ScaleDirection.Uniformly) {
-            return Math.max(this.sx, this.sy); // best effort: return the larger scale
-        }
-        if (direction & ScaleDirection.Vertically) {
-            return this.sy;
-        }
-        else {
-            return this.sx;
-        }
+    getScale(): number {
+        return Math.max(this.sx, this.sy);
     }
 
     //% blockId=sprite_set_scale

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1175,7 +1175,7 @@ class Sprite extends sprites.BaseSprite {
     //% help=sprites/sprite/grow-by-pixels
     //% group="Scale" weight=60
     growByPixels(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
-        direction = direction || ScaleDirection.Uniformly;
+        direction = direction || ScaleDirection.Horizontally;
         anchor = anchor || ScaleAnchor.Middle;
         if (typeof proportional !== 'boolean') proportional = direction === ScaleDirection.Uniformly;
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -218,6 +218,16 @@ class Sprite extends sprites.BaseSprite {
         this.recalcSize();
         this.top = y - this.height / 2;
     }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="scale" callInDebugger
+    get scale(): number {
+        return Math.max(this.sx, this.sy);
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="scale"
+    set scale(v: number) {
+        this.sx = this.sy = v;
+    }
 
     private _data: any;
     /**
@@ -252,7 +262,7 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="lifespan"
     lifespan: number;
-    private _image: Image;
+    _image: Image;
     private _obstacles: sprites.Obstacle[];
 
     private sayEndTime: number;
@@ -1073,7 +1083,7 @@ class Sprite extends sprites.BaseSprite {
         }
     }
 
-    private setScaleCore(sx?: number, sy?: number, anchor?: ScaleAnchor, proportional?: boolean): void {
+    setScaleCore(sx?: number, sy?: number, anchor?: ScaleAnchor, proportional?: boolean): void {
         anchor = anchor || ScaleAnchor.Middle;
 
         const hasSx = typeof sx === 'number';
@@ -1115,25 +1125,16 @@ class Sprite extends sprites.BaseSprite {
         }
     }
 
-    //% blockId=sprite_get_scale
-    //% block="%sprite(mySprite) scale"
-    //% help=sprites/sprite/get-scale
-    //% group="Scale" weight=100
-    getScale(): number {
-        return Math.max(this.sx, this.sy);
-    }
-
     //% blockId=sprite_set_scale
-    //% block="set %sprite(mySprite) scale to $value || $direction anchor $anchor"
+    //% block="set %sprite(mySprite) scale to $value, anchor on $anchor"
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% value.defl=1
-    //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
     //% help=sprites/sprite/set-scale
     //% group="Scale" weight=90
-    setScale(value: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
-        direction = direction || ScaleDirection.Uniformly;
+    setScale(value: number, anchor?: ScaleAnchor): void {
+        const direction = ScaleDirection.Uniformly;
         anchor = anchor || ScaleAnchor.Middle;
 
         let sx: number;
@@ -1145,87 +1146,25 @@ class Sprite extends sprites.BaseSprite {
         this.setScaleCore(sx, sy, anchor);
     }
 
-    //% blockId=sprite_grow_by_percent
-    //% block="grow %sprite(mySprite) by $amount percent || $direction anchor $anchor"
+    //% blockId=sprite_change_scale
+    //% block="change %sprite(mySprite) scale by $value, anchor on $anchor"
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
-    //% amount.defl=10
-    //% direction.defl=ScaleDirection.Uniformly
+    //% value.defl=1
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite/grow-by-amount
-    //% group="Scale" weight=80
-    growByPercent(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
-        amount /= 100;
-        direction = direction || ScaleDirection.Uniformly;
+    //% help=sprites/sprite/change-scale
+    //% group="Scale" weight=90
+    changeScale(value: number, anchor?: ScaleAnchor): void {
+        const direction = ScaleDirection.Uniformly;
         anchor = anchor || ScaleAnchor.Middle;
 
         let sx: number;
         let sy: number;
 
-        if (direction & ScaleDirection.Horizontally) sx = this.sx + amount;
-        if (direction & ScaleDirection.Vertically) sy = this.sy + amount;
+        if (direction & ScaleDirection.Horizontally) sx = this.sx + value;
+        if (direction & ScaleDirection.Vertically) sy = this.sy + value;
 
         this.setScaleCore(sx, sy, anchor);
-    }
-
-    //% blockId=sprite_shrink_by_percent
-    //% block="shrink %sprite(mySprite) by $amount percent || $direction anchor $anchor"
-    //% expandableArgumentMode=enabled
-    //% inlineInputMode=inline
-    //% amount.defl=10
-    //% direction.defl=ScaleDirection.Uniformly
-    //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite/shrink-by-percent
-    //% group="Scale" weight=70
-    shrinkByPercent(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
-        this.growByPercent(-amount, direction, anchor);
-    }
-
-    //% blockId=sprite_grow_by_pixels
-    //% block="grow %sprite(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
-    //% expandableArgumentMode=enabled
-    //% inlineInputMode=inline
-    //% amount.defl=10
-    //% direction.defl=ScaleDirection.Horizontally
-    //% anchor.defl=ScaleAnchor.Middle
-    //% proportional.defl=0
-    //% help=sprites/sprite/grow-by-pixels
-    //% group="Scale" weight=60
-    growByPixels(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
-        direction = direction || ScaleDirection.Horizontally;
-        anchor = anchor || ScaleAnchor.Middle;
-        if (typeof proportional !== 'boolean') proportional = direction === ScaleDirection.Uniformly;
-
-        let sx: number;
-        let sy: number;
-
-        if (direction & ScaleDirection.Horizontally) {
-            const imgW = this._image.width;
-            const newW = this.width + amount;
-            sx = newW / imgW;
-        }
-
-        if (direction & ScaleDirection.Vertically) {
-            const imgH = this._image.height;
-            const newH = this.height + amount;
-            sy = newH / imgH;
-        }
-
-        this.setScaleCore(sx, sy, anchor, proportional);
-    }
-
-    //% blockId=sprite_shrink_by_pixels
-    //% block="shrink %sprite(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
-    //% expandableArgumentMode=enabled
-    //% inlineInputMode=inline
-    //% amount.defl=10
-    //% direction.defl=ScaleDirection.Horizontally
-    //% anchor.defl=ScaleAnchor.Middle
-    //% proportional.defl=0
-    //% help=sprites/sprite/grow-by-pixels
-    //% group="Scale" weight=50
-    shrinkByPixels(amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
-        this.growByPixels(-amount, direction, anchor, proportional);
     }
 
     toString() {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -762,18 +762,35 @@ class Sprite extends sprites.BaseSprite {
                 this.top - other.top)
         } else {
             if (this.sx == 0 || this.sy == 0 || other.sx == 0 || other.sy == 0) return false;
-            const scaleFactorX = this.sx / other.sx;
-            const scaleFactorY = this.sy / other.sy;
+
+            let A: Sprite;
+            let B: Sprite;
+
+            // Render larger-scaled sprite onto smaller-scaled one so that we don't
+            // skip over source pixels in the check.
+
+            // A is the smaller-scaled sprite
+            if (this.sx * this.sy < other.sx * other.sy) {
+                A = this;
+                B = other;
+            } else {
+                A = other;
+                B = this;
+            }
+
+            // Render B onto A
             return helpers.imageBlit(
-                this.image,
-                other.left * this.sx - this.left,
-                other.top * this.sy - this.top,
-                other.width * this.sx,
-                other.height * this.sy,
-                other.image,
+                A.image,
+                // Dst rect in A
+                (B.left - A.left) / A.sx,
+                (B.top - A.top) / A.sy,
+                B.width / A.sx,
+                B.height / A.sy,
+                B.image,
+                // Src rect in B
                 0, 0,
-                other.image.width,
-                other.image.height,
+                B.image.width,
+                B.image.height,
                 true, true);
         }
     }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1064,10 +1064,9 @@ class Sprite extends sprites.BaseSprite {
 
         const oldW = this.width;
         const oldH = this.height;
-        const oldSx = this.sx;
-        const oldSy = this.sy;
 
         if (hasSx) {
+            const oldSx = this.sx;
             this.sx = sx;
             if (!hasSy && proportional) {
                 const ratio = sx / oldSx;
@@ -1075,6 +1074,7 @@ class Sprite extends sprites.BaseSprite {
             }
         }
         if (hasSy) {
+            const oldSy = this.sy;
             this.sy = sy;
             if (!hasSx && proportional) {
                 const ratio = sy / oldSy;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1059,8 +1059,8 @@ class Sprite extends sprites.BaseSprite {
     private setScaleCore(sx?: number, sy?: number, anchor?: ScaleAnchor, proportional?: boolean): void {
         anchor = anchor || ScaleAnchor.Middle;
 
-        const hasSx = typeof sx !== 'undefined';
-        const hasSy = typeof sy !== 'undefined';
+        const hasSx = typeof sx === 'number';
+        const hasSy = typeof sy === 'number';
 
         const oldW = this.width;
         const oldH = this.height;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1125,7 +1125,7 @@ class Sprite extends sprites.BaseSprite {
         if (direction & ScaleDirection.Horizontally) sx = value;
         if (direction & ScaleDirection.Vertically) sy = value;
 
-        this.setScaleCore(sx, sy, anchor, undefined);
+        this.setScaleCore(sx, sy, anchor);
     }
 
     //% blockId=sprite_grow_by_percent
@@ -1148,7 +1148,7 @@ class Sprite extends sprites.BaseSprite {
         if (direction & ScaleDirection.Horizontally) sx = this.sx + amount;
         if (direction & ScaleDirection.Vertically) sy = this.sy + amount;
 
-        this.setScaleCore(sx, sy, anchor, undefined);
+        this.setScaleCore(sx, sy, anchor);
     }
 
     //% blockId=sprite_shrink_by_percent

--- a/libs/game/spritesay.ts
+++ b/libs/game/spritesay.ts
@@ -157,8 +157,8 @@ namespace sprites {
             // reuse previous sprite if possible
             const imgh = font.charHeight + bubblePadding;
             if (!this.sayBubbleSprite
-                || this.sayBubbleSprite.image.width != bubbleWidth
-                || this.sayBubbleSprite.image.height != imgh) {
+                || this.sayBubbleSprite.width != bubbleWidth
+                || this.sayBubbleSprite.height != imgh) {
                 const sayImg = image.create(bubbleWidth, imgh);
                 if (this.sayBubbleSprite) // sprite with same image size, we can reuse it
                     this.sayBubbleSprite.setImage(sayImg);

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1110,10 +1110,14 @@ bool blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
         for (int xDstCur = xDstStart, xSrcCur = xSrcStart; xDstCur < xDstEnd && xSrcCur < xSrcEnd; ++xDstCur, xSrcCur += xSrcStep) {
             int xSrcCurI = xSrcCur >> 16;
             int cSrc = getCore(src, xSrcCurI, ySrcCurI);
-            if (check) {
-                if (cSrc && getCore(dst, xDstCur, yDstCur))
+            if (check && cSrc) {
+                int cDst = getCore(dst, xDstCur, yDstCur);
+                if (cDst) {
                     return true;
-            } else if (!transparent || cSrc) {
+                }
+                continue;
+            }
+            if (!transparent || cSrc) {
                 setCore(dst, xDstCur, yDstCur, cSrc);
             }
         }

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1075,7 +1075,7 @@ void _blitRow(Image_ img, int xy, Image_ from, int xh) {
     blitRow(img, XX(xy), YY(xy), from, XX(xh), YY(xh));
 }
 
-void blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
+bool blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
     int xDst = pxt::toInt(args->getAt(0));
     int yDst = pxt::toInt(args->getAt(1));
     int wDst = pxt::toInt(args->getAt(2));
@@ -1085,6 +1085,7 @@ void blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
     int wSrc = pxt::toInt(args->getAt(6));
     int hSrc = pxt::toInt(args->getAt(7));
     bool transparent = pxt::toBoolQuick(args->getAt(8));
+    bool check = pxt::toBoolQuick(args->getAt(9));
 
     int xSrcStep = (wSrc << 16) / wDst;
     int ySrcStep = (hSrc << 16) / hDst;
@@ -1101,23 +1102,28 @@ void blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
     int xSrcEnd = min(src->width(), xSrc + wSrc) << 16;
     int ySrcEnd = min(src->height(), ySrc + hSrc) << 16;
 
-    dst->makeWritable();
+    if (!check)
+        dst->makeWritable();
 
     for (int yDstCur = yDstStart, ySrcCur = ySrcStart; yDstCur < yDstEnd && ySrcCur < ySrcEnd; ++yDstCur, ySrcCur += ySrcStep) {
         int ySrcCurI = ySrcCur >> 16;
         for (int xDstCur = xDstStart, xSrcCur = xSrcStart; xDstCur < xDstEnd && xSrcCur < xSrcEnd; ++xDstCur, xSrcCur += xSrcStep) {
             int xSrcCurI = xSrcCur >> 16;
             int cSrc = getCore(src, xSrcCurI, ySrcCurI);
-            if (!transparent || cSrc) {
+            if (check) {
+                if (cSrc && getCore(dst, xDstCur, yDstCur))
+                    return true;
+            } else if (!transparent || cSrc) {
                 setCore(dst, xDstCur, yDstCur, cSrc);
             }
         }
     }
+    return false;
 }
 
 //%
-void _blit(Image_ img, Image_ src, pxt::RefCollection *args) {
-    blit(img, src, args);
+bool _blit(Image_ img, Image_ src, pxt::RefCollection *args) {
+    return blit(img, src, args);
 }
 
 void fillCircle(Image_ img, int cx, int cy, int r, int c) {

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -84,7 +84,7 @@ interface Image {
      * compressing to fit the dimensions of the destination rectangle, if necessary.
      */
     //% helper=imageBlit
-    blit(xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean): void;
+    blit(xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean, check: boolean): boolean;
 }
 
 interface ScreenImage extends Image {
@@ -126,7 +126,7 @@ namespace helpers {
     declare function _blitRow(img: Image, xy: number, from: Image, xh: number): void;
 
     //% shim=ImageMethods::_blit
-    declare function _blit(img: Image, src: Image, args: number[]): void;
+    declare function _blit(img: Image, src: Image, args: number[]): boolean;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
@@ -134,7 +134,7 @@ namespace helpers {
 
     let _blitArgs: number[];
 
-    export function imageBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean) {
+    export function imageBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean, check: boolean): boolean {
         _blitArgs = _blitArgs || [];
         _blitArgs[0] = xDst | 0;
         _blitArgs[1] = yDst | 0;
@@ -145,7 +145,8 @@ namespace helpers {
         _blitArgs[6] = wSrc | 0;
         _blitArgs[7] = hSrc | 0;
         _blitArgs[8] = transparent ? 1 : 0;
-        _blit(img, src, _blitArgs);
+        _blitArgs[9] = check ? 1 : 0;
+        return _blit(img, src, _blitArgs);
     }
 
     export function imageBlitRow(img: Image, dstX: number, dstY: number, from: Image, fromX: number, fromH: number): void {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -683,7 +683,7 @@ namespace pxsim.ImageMethods {
                     if (cDst) {
                         return true;
                     }
-                    break;
+                    continue;
                 }
                 if (!transparent || cSrc) {
                     setPixel(dst, xDstCur, yDstCur, cSrc);

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -639,11 +639,11 @@ namespace pxsim.ImageMethods {
         }
     }
 
-    export function _blit(img: RefImage, src: RefImage, args: RefCollection) {
-        blit(img, src, args);
+    export function _blit(img: RefImage, src: RefImage, args: RefCollection): boolean {
+        return blit(img, src, args);
     }
 
-    export function blit(dst: RefImage, src: RefImage, args: RefCollection) {
+    export function blit(dst: RefImage, src: RefImage, args: RefCollection): boolean {
         const xDst = args.getAt(0) as number;
         const yDst = args.getAt(1) as number;
         const wDst = args.getAt(2) as number;
@@ -653,6 +653,7 @@ namespace pxsim.ImageMethods {
         const wSrc = args.getAt(6) as number;
         const hSrc = args.getAt(7) as number;
         const transparent = args.getAt(8) as number;
+        const check = args.getAt(9) as number;
 
         const xSrcStep = ((wSrc << 16) / wDst) | 0;
         const ySrcStep = ((hSrc << 16) / hDst) | 0;
@@ -669,16 +670,27 @@ namespace pxsim.ImageMethods {
         const xSrcEnd = Math.min(src._width, xSrc + wSrc) << 16;
         const ySrcEnd = Math.min(src._height, ySrc + hSrc) << 16;
 
+        if (!check)
+            dst.makeWritable();
+
         for (let yDstCur = yDstStart, ySrcCur = ySrcStart; yDstCur < yDstEnd && ySrcCur < ySrcEnd; ++yDstCur, ySrcCur += ySrcStep) {
             const ySrcCurI = ySrcCur >> 16;
             for (let xDstCur = xDstStart, xSrcCur = xSrcStart; xDstCur < xDstEnd && xSrcCur < xSrcEnd; ++xDstCur, xSrcCur += xSrcStep) {
                 const xSrcCurI = xSrcCur >> 16;
                 const cSrc = getPixel(src, xSrcCurI, ySrcCurI);
+                if (check && cSrc) {
+                    const cDst = getPixel(dst, xDstCur, yDstCur);
+                    if (cDst) {
+                        return true;
+                    }
+                    break;
+                }
                 if (!transparent || cSrc) {
                     setPixel(dst, xDstCur, yDstCur, cSrc);
                 }
             }
         }
+        return false;
     }
 }
 

--- a/libs/sprite-scaling/README.md
+++ b/libs/sprite-scaling/README.md
@@ -1,0 +1,3 @@
+# Sprite Scaling
+
+Additional sprite scaling methods.

--- a/libs/sprite-scaling/pxt.json
+++ b/libs/sprite-scaling/pxt.json
@@ -1,0 +1,16 @@
+{
+    "name": "sprite-scaling",
+    "description": "Additional scaling blocks for sprites",
+    "files": [
+        "README.md",
+        "scaling.ts",
+        "targetoverrides.ts"
+    ],
+    "testFiles": [
+        "test.ts"
+    ],
+    "public": true,
+    "dependencies": {
+        "game": "file:../game"
+    }
+}

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -1,0 +1,111 @@
+namespace sprites {
+    //% blockId=sprite_set_scale_ex
+    //% block="set %sprite=variables_get(mySprite) scale to $value || $direction anchor $anchor"
+    //% advanced=true
+    //% expandableArgumentMode=enabled
+    //% inlineInputMode=inline
+    //% value.defl=1
+    //% direction.defl=ScaleDirection.Uniformly
+    //% anchor.defl=ScaleAnchor.Middle
+    //% help=sprites/sprite-scaling/set-scale
+    //% group="Scale" weight=90
+    export function setScale(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
+        direction = direction || ScaleDirection.Uniformly;
+        anchor = anchor || ScaleAnchor.Middle;
+
+        let sx: number;
+        let sy: number;
+
+        if (direction & ScaleDirection.Horizontally) sx = value;
+        if (direction & ScaleDirection.Vertically) sy = value;
+
+        sprite.setScaleCore(sx, sy, anchor);
+    }
+
+    //% blockId=sprite_grow_by_percent_ex
+    //% block="grow %sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
+    //% advanced=true
+    //% expandableArgumentMode=enabled
+    //% inlineInputMode=inline
+    //% amount.defl=10
+    //% direction.defl=ScaleDirection.Uniformly
+    //% anchor.defl=ScaleAnchor.Middle
+    //% help=sprites/sprite-scaling/grow-by-amount
+    //% group="Scale" weight=80
+    export function growByPercent(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
+        amount /= 100;
+        direction = direction || ScaleDirection.Uniformly;
+        anchor = anchor || ScaleAnchor.Middle;
+
+        let sx: number;
+        let sy: number;
+
+        if (direction & ScaleDirection.Horizontally) sx = sprite.sx + amount;
+        if (direction & ScaleDirection.Vertically) sy = sprite.sy + amount;
+
+        sprite.setScaleCore(sx, sy, anchor);
+    }
+
+    //% blockId=sprite_shrink_by_percent_ex
+    //% block="shrink %sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
+    //% advanced=true
+    //% expandableArgumentMode=enabled
+    //% inlineInputMode=inline
+    //% amount.defl=10
+    //% direction.defl=ScaleDirection.Uniformly
+    //% anchor.defl=ScaleAnchor.Middle
+    //% help=sprites/sprite-scaling/shrink-by-percent
+    //% group="Scale" weight=70
+    export function shrinkByPercent(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
+        growByPercent(sprite, -amount, direction, anchor);
+    }
+
+    //% blockId=sprite_grow_by_pixels_ex
+    //% block="grow %sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
+    //% advanced=true
+    //% expandableArgumentMode=enabled
+    //% inlineInputMode=inline
+    //% amount.defl=10
+    //% direction.defl=ScaleDirection.Horizontally
+    //% anchor.defl=ScaleAnchor.Middle
+    //% proportional.defl=0
+    //% help=sprites/sprite-scaling/grow-by-pixels
+    //% group="Scale" weight=60
+    export function growByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
+        direction = direction || ScaleDirection.Horizontally;
+        anchor = anchor || ScaleAnchor.Middle;
+        if (typeof proportional !== 'boolean') proportional = direction === ScaleDirection.Uniformly;
+
+        let sx: number;
+        let sy: number;
+
+        if (direction & ScaleDirection.Horizontally) {
+            const imgW = sprite._image.width;
+            const newW = sprite.width + amount;
+            sx = newW / imgW;
+        }
+
+        if (direction & ScaleDirection.Vertically) {
+            const imgH = sprite._image.height;
+            const newH = sprite.height + amount;
+            sy = newH / imgH;
+        }
+
+        sprite.setScaleCore(sx, sy, anchor, proportional);
+    }
+
+    //% blockId=sprite_shrink_by_pixels
+    //% block="shrink %sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
+    //% advanced=true
+    //% expandableArgumentMode=enabled
+    //% inlineInputMode=inline
+    //% amount.defl=10
+    //% direction.defl=ScaleDirection.Horizontally
+    //% anchor.defl=ScaleAnchor.Middle
+    //% proportional.defl=0
+    //% help=sprites/sprite-scaling/grow-by-pixels
+    //% group="Scale" weight=50
+    export function shrinkByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
+        growByPixels(sprite, -amount, direction, anchor, proportional);
+    }
+}

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -1,6 +1,6 @@
 namespace sprites {
     //% blockId=sprite_set_scale_ex
-    //% block="set %sprite=variables_get(mySprite) scale to $value || $direction anchor $anchor"
+    //% block="set $sprite=variables_get(mySprite) scale to $value || $direction anchor $anchor"
     //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
@@ -23,7 +23,7 @@ namespace sprites {
     }
 
     //% blockId=sprite_grow_by_percent_ex
-    //% block="grow %sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
+    //% block="grow $sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
     //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
@@ -47,7 +47,7 @@ namespace sprites {
     }
 
     //% blockId=sprite_shrink_by_percent_ex
-    //% block="shrink %sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
+    //% block="shrink $sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
     //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
@@ -61,7 +61,7 @@ namespace sprites {
     }
 
     //% blockId=sprite_grow_by_pixels_ex
-    //% block="grow %sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
+    //% block="grow $sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
     //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
@@ -80,13 +80,13 @@ namespace sprites {
         let sy: number;
 
         if (direction & ScaleDirection.Horizontally) {
-            const imgW = sprite._image.width;
+            const imgW = sprite.image.width;
             const newW = sprite.width + amount;
             sx = newW / imgW;
         }
 
         if (direction & ScaleDirection.Vertically) {
-            const imgH = sprite._image.height;
+            const imgH = sprite.image.height;
             const newH = sprite.height + amount;
             sy = newH / imgH;
         }
@@ -95,7 +95,7 @@ namespace sprites {
     }
 
     //% blockId=sprite_shrink_by_pixels
-    //% block="shrink %sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
+    //% block="shrink $sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
     //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline

--- a/libs/sprite-scaling/targetoverrides.ts
+++ b/libs/sprite-scaling/targetoverrides.ts
@@ -1,0 +1,1 @@
+// TODO any platform specific overrides

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -52,6 +52,7 @@
         "libs/palette",
         "libs/radio",
         "libs/radio-broadcast",
-        "libs/matrix-keypad"
+        "libs/matrix-keypad",
+        "libs/sprite-scaling"
     ]
 }


### PR DESCRIPTION
Adds scale properties to Sprite class:
- `sx (scale x)`
- `sy (scale y)`
- `scale` (returns greater of sx and sy)

Adds a few built-in basic scaling blocks:
![image](https://user-images.githubusercontent.com/12176807/150702012-af684ef3-715f-484c-bf27-98e4bbb7229d.png)

And adds additional blocks for advanced scaling in an extension:
![image](https://user-images.githubusercontent.com/12176807/150702031-4077226b-8cef-4575-84ba-18b1cfc60c52.png)

![image](https://user-images.githubusercontent.com/12176807/150702120-4b0d3404-1ce3-4a7d-b56d-1c4e8f7eb9e4.png)

