### PR TITLE
Scaling extension: move blocks to own category

### DIFF
--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -1,14 +1,14 @@
-namespace sprites {
+//% color="#7B2CBF" weight=100 icon="\uf021" block="Sprite Scaling"
+//% advanced=true
+namespace scaling {
     //% blockId=sprite_set_scale_ex
     //% block="set $sprite=variables_get(mySprite) scale to $value || $direction anchor $anchor"
-    //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% value.defl=1
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
     //% help=sprites/sprite-scaling/set-scale
-    //% group="Scale" weight=90
     export function setScale(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         direction = direction || ScaleDirection.Uniformly;
         anchor = anchor || ScaleAnchor.Middle;
@@ -24,14 +24,12 @@ namespace sprites {
 
     //% blockId=sprite_grow_by_percent_ex
     //% block="grow $sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
-    //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% amount.defl=10
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
     //% help=sprites/sprite-scaling/grow-by-amount
-    //% group="Scale" weight=80
     export function growByPercent(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         amount /= 100;
         direction = direction || ScaleDirection.Uniformly;
@@ -48,21 +46,18 @@ namespace sprites {
 
     //% blockId=sprite_shrink_by_percent_ex
     //% block="shrink $sprite=variables_get(mySprite) by $amount percent || $direction anchor $anchor"
-    //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% amount.defl=10
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
     //% help=sprites/sprite-scaling/shrink-by-percent
-    //% group="Scale" weight=70
     export function shrinkByPercent(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         growByPercent(sprite, -amount, direction, anchor);
     }
 
     //% blockId=sprite_grow_by_pixels_ex
     //% block="grow $sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
-    //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% amount.defl=10
@@ -70,7 +65,6 @@ namespace sprites {
     //% anchor.defl=ScaleAnchor.Middle
     //% proportional.defl=0
     //% help=sprites/sprite-scaling/grow-by-pixels
-    //% group="Scale" weight=60
     export function growByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         direction = direction || ScaleDirection.Horizontally;
         anchor = anchor || ScaleAnchor.Middle;
@@ -94,9 +88,8 @@ namespace sprites {
         sprite.setScaleCore(sx, sy, anchor, proportional);
     }
 
-    //% blockId=sprite_shrink_by_pixels
+    //% blockId=sprite_shrink_by_pixels_ex
     //% block="shrink $sprite=variables_get(mySprite) by $amount pixels $direction || anchor $anchor proportional $proportional"
-    //% advanced=true
     //% expandableArgumentMode=enabled
     //% inlineInputMode=inline
     //% amount.defl=10
@@ -104,7 +97,6 @@ namespace sprites {
     //% anchor.defl=ScaleAnchor.Middle
     //% proportional.defl=0
     //% help=sprites/sprite-scaling/grow-by-pixels
-    //% group="Scale" weight=50
     export function shrinkByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         growByPixels(sprite, -amount, direction, anchor, proportional);
     }


### PR DESCRIPTION
Moved to own **Sprite Scaling** category, under **Advanced**.

Color is: 
![image](https://user-images.githubusercontent.com/12176807/151899447-29badb6d-1cca-4e80-97e7-5743a0cb4233.png)
