### PR TITLE
Ensure hitbox pos matches scaled sprite pos

### DIFF
--- a/libs/base/fixed.ts
+++ b/libs/base/fixed.ts
@@ -60,6 +60,12 @@ namespace Fx {
         else
             return b
     }
+    export function floor(v: Fx8): Fx8 {
+        return ((v as any as number) & ~0xff) as any as Fx8;
+    }
+    export function ceil(v: Fx8): Fx8 {
+        return (v as any as number) & 0xff ? Fx.floor(Fx.add(v, Fx.oneFx8)) : v;
+    }
     export function leftShift(a: Fx8, n: number) {
         return (a as any as number << n) as any as Fx8
     }

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -12,16 +12,16 @@ namespace game {
             this.parent = parent;
             this.width = width;
             this.height = height;
-            this.ox = ox;
-            this.oy = oy;
+            this.ox = Fx.floor(ox);
+            this.oy = Fx.floor(oy);
         }
 
         get left() {
-            return Fx.add(this.ox, this.parent._x);
+            return Fx.add(this.ox, Fx.floor(this.parent._x));
         }
 
         get top() {
-            return Fx.add(this.oy, this.parent._y);
+            return Fx.add(this.oy, Fx.floor(this.parent._y));
         }
 
         get right() {
@@ -85,8 +85,8 @@ namespace game {
         minY = Fx.mul(minY, s._sy);
         maxX = Fx.mul(maxX, s._sx);
         maxY = Fx.mul(maxY, s._sy);
-        const width  = Fx.add(Fx.sub(maxX, minX), Fx.oneFx8);
-        const height = Fx.add(Fx.sub(maxY, minY), Fx.oneFx8);
+        const width  = Fx.add(Fx.sub(maxX, minX), s._sx);
+        const height = Fx.add(Fx.sub(maxY, minY), s._sy);
 
         return new Hitbox(s, width, height, minX, minY);
     }

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -12,8 +12,8 @@ namespace game {
             this.parent = parent;
             this.width = width;
             this.height = height;
-            this.ox = Fx.floor(ox);
-            this.oy = Fx.floor(oy);
+            this.ox = ox;
+            this.oy = oy;
         }
 
         get left() {
@@ -88,6 +88,6 @@ namespace game {
         const width  = Fx.add(Fx.sub(maxX, minX), s._sx);
         const height = Fx.add(Fx.sub(maxY, minY), s._sy);
 
-        return new Hitbox(s, width, height, minX, minY);
+        return new Hitbox(s, width, height, Fx.floor(minX), Fx.floor(minY));
     }
 }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -301,7 +301,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     __serialize(offset: number): Buffer {
-        const buf = control.createBuffer(offset + 16);
+        const buf = control.createBuffer(offset + 20);
         let k = offset;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._x)); k += 2;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._y)); k += 2;
@@ -309,8 +309,8 @@ class Sprite extends sprites.BaseSprite {
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._vy)); k += 2;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._ax)); k += 2;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._ay)); k += 2;
-        buf.setNumber(NumberFormat.Int16LE, k, Fx.toFloat(this._sx)); k += 2;
-        buf.setNumber(NumberFormat.Int16LE, k, Fx.toFloat(this._sy)); k += 2;
+        buf.setNumber(NumberFormat.Float32LE, k, Fx.toFloat(this._sx)); k += 4;
+        buf.setNumber(NumberFormat.Float32LE, k, Fx.toFloat(this._sy)); k += 4;
         return buf;
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -376,11 +376,11 @@ class Sprite extends sprites.BaseSprite {
         // If it's just a small change to the hitbox on one axis,
         // don't change the dimensions to avoid random clipping
         this._hitbox = newHitBox;
-        if (xDiff <= Fx.mul(Fx.twoFx8, this._sx)) {
+        if (xDiff <= Fx.twoFx8) {
             this._hitbox.ox = oMinX;
             this._hitbox.width = Fx.sub(oMaxX, oMinX);
         }
-        if (yDiff <= Fx.mul(Fx.twoFx8, this._sy)) {
+        if (yDiff <= Fx.twoFx8) {
             this._hitbox.oy = oMinY;
             this._hitbox.height = Fx.sub(oMaxY, oMinY);
         }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -309,8 +309,8 @@ class Sprite extends sprites.BaseSprite {
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._vy)); k += 2;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._ax)); k += 2;
         buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._ay)); k += 2;
-        buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._sx)); k += 2;
-        buf.setNumber(NumberFormat.Int16LE, k, Fx.toInt(this._sy)); k += 2;
+        buf.setNumber(NumberFormat.Int16LE, k, Fx.toFloat(this._sx)); k += 2;
+        buf.setNumber(NumberFormat.Int16LE, k, Fx.toFloat(this._sy)); k += 2;
         return buf;
     }
 
@@ -407,12 +407,12 @@ class Sprite extends sprites.BaseSprite {
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="width" callInDebugger
     get width() {
-        return Fx.toInt(this._width);
+        return Fx.toFloat(this._width);
     }
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="height" callInDebugger
     get height() {
-        return Fx.toInt(this._height);
+        return Fx.toFloat(this._height);
     }
 
     //% group="Physics" blockSetVariable="mySprite"

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -376,11 +376,11 @@ class Sprite extends sprites.BaseSprite {
         // If it's just a small change to the hitbox on one axis,
         // don't change the dimensions to avoid random clipping
         this._hitbox = newHitBox;
-        if (xDiff <= Fx.twoFx8) {
+        if (xDiff <= Fx.mul(Fx.twoFx8, this._sx)) {
             this._hitbox.ox = oMinX;
             this._hitbox.width = Fx.sub(oMaxX, oMinX);
         }
-        if (yDiff <= Fx.twoFx8) {
+        if (yDiff <= Fx.mul(Fx.twoFx8, this._sy)) {
             this._hitbox.oy = oMinY;
             this._hitbox.height = Fx.sub(oMaxY, oMinY);
         }


### PR DESCRIPTION
Sprite's `left` and `top` accessors each return a float. When the sprite is rendered, these values are floored to get the sprite's pixel coordinates. This wasn't happening in the hitbox calculation, which doesn't matter much at scale=1, but at larger scales it becomes noticeable. I fixed the issue by correspondingly flooring the left and top values passed to the hitbox.

Other changes in this PR:
- Account for scale in a few places where I wasn't, but should have been
- Changed Sprite `width` and `height` to return float rather than int. This seems more correct (again, it didn't matter so much at scale=1)
- Changed Sprite serialize to write scale values as float rather than int

Tagging @mmoskal for the `fixed.ts` additions and Sprite serialization changes

Fixes https://github.com/microsoft/pxt-arcade/issues/4546
