### PR TITLE
Fix for drift when scaling sprite

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1112,14 +1112,14 @@ class Sprite extends sprites.BaseSprite {
         if (anchor & (ScaleAnchor.Left | ScaleAnchor.Right)) {
             const newW = this.width;
             const diff = newW - oldW;
-            const diffOver2 = (diff / 2) | 0;
+            const diffOver2 = diff / 2;
             if (anchor & ScaleAnchor.Left) { this.x += diffOver2; }
             if (anchor & ScaleAnchor.Right) { this.x -= diffOver2; }
         }
         if (anchor & (ScaleAnchor.Top | ScaleAnchor.Bottom)) {
             const newH = this.height;
             const diff = newH - oldH;
-            const diffOver2 = (diff / 2) | 0;
+            const diffOver2 = diff / 2;
             if (anchor & ScaleAnchor.Top) { this.y += diffOver2; }
             if (anchor & ScaleAnchor.Bottom) { this.y -= diffOver2; }
         }

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1131,7 +1131,7 @@ class Sprite extends sprites.BaseSprite {
     //% inlineInputMode=inline
     //% value.defl=1
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite/set-scale
+    //% help=sprites/sprite/scale
     //% group="Scale" weight=90
     setScale(value: number, anchor?: ScaleAnchor): void {
         const direction = ScaleDirection.Uniformly;
@@ -1152,7 +1152,7 @@ class Sprite extends sprites.BaseSprite {
     //% inlineInputMode=inline
     //% value.defl=1
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite/change-scale
+    //% help=sprites/sprite/scale
     //% group="Scale" weight=90
     changeScale(value: number, anchor?: ScaleAnchor): void {
         const direction = ScaleDirection.Uniformly;

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -1,5 +1,4 @@
 //% color="#7B2CBF" weight=100 icon="\uf021" block="Sprite Scaling"
-//% advanced=true
 namespace scaling {
     //% blockId=sprite_set_scale_ex
     //% block="set $sprite=variables_get(mySprite) scale to $value || $direction anchor $anchor"

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -1,4 +1,4 @@
-//% color="#7B2CBF" weight=100 icon="\uf021" block="Sprite Scaling"
+//% color="#7B2CBF" weight=99 icon="\u2195" block="Sprite Scaling"
 namespace scaling {
     //% blockId=sprite_set_scale_ex
     //% block="set $sprite=variables_get(mySprite) scale to $value || $direction anchor $anchor"
@@ -67,7 +67,8 @@ namespace scaling {
     export function growByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         direction = direction || ScaleDirection.Horizontally;
         anchor = anchor || ScaleAnchor.Middle;
-        if (typeof proportional !== 'boolean') proportional = direction === ScaleDirection.Uniformly;
+
+        if (proportional == null) proportional = direction === ScaleDirection.Uniformly;
 
         let sx: number;
         let sy: number;

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -7,7 +7,7 @@ namespace scaling {
     //% value.defl=1
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite-scaling/set-scale
+    //% help=sprites/sprite-scaling/scale
     export function setScale(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         direction = direction || ScaleDirection.Uniformly;
         anchor = anchor || ScaleAnchor.Middle;
@@ -28,7 +28,7 @@ namespace scaling {
     //% amount.defl=10
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite-scaling/grow-by-amount
+    //% help=sprites/sprite-scaling/scale
     export function growByPercent(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         amount /= 100;
         direction = direction || ScaleDirection.Uniformly;
@@ -50,7 +50,7 @@ namespace scaling {
     //% amount.defl=10
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite-scaling/shrink-by-percent
+    //% help=sprites/sprite-scaling/scale
     export function shrinkByPercent(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         growByPercent(sprite, -amount, direction, anchor);
     }
@@ -63,7 +63,7 @@ namespace scaling {
     //% direction.defl=ScaleDirection.Horizontally
     //% anchor.defl=ScaleAnchor.Middle
     //% proportional.defl=0
-    //% help=sprites/sprite-scaling/grow-by-pixels
+    //% help=sprites/sprite-scaling/scale
     export function growByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         direction = direction || ScaleDirection.Horizontally;
         anchor = anchor || ScaleAnchor.Middle;
@@ -96,7 +96,7 @@ namespace scaling {
     //% direction.defl=ScaleDirection.Horizontally
     //% anchor.defl=ScaleAnchor.Middle
     //% proportional.defl=0
-    //% help=sprites/sprite-scaling/grow-by-pixels
+    //% help=sprites/sprite-scaling/scale
     export function shrinkByPixels(sprite: Sprite, amount: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         growByPixels(sprite, -amount, direction, anchor, proportional);
     }


### PR DESCRIPTION
Also, show scaling extension in main toolbox.

Fixes https://github.com/microsoft/pxt-arcade/issues/4547