### PR TITLE
Sprite scaling reference pages

### DIFF
--- a/libs/game/docs/reference/sprites.md
+++ b/libs/game/docs/reference/sprites.md
@@ -23,6 +23,8 @@ sprites.create(null).setKind(0)
 sprites.create(null).kind()
 sprites.create(null).setBounceOnWall(false)
 sprites.create(null).setStayInScreen(false)
+sprites.create(null).setScale(1, ScaleAnchor.Middle)
+sprites.create(null).changeScale(1, ScaleAnchor.Middle)
 ```
 
 ## Sprite effects
@@ -55,7 +57,7 @@ sprites.onOverlap(0, 0, function (sprite, otherSprite) {})
 ### Physics
 
 * [**vx - velocity x**](/reference/sprites/sprite/vx)
-* [**vy- velocity y**](/reference/sprites/sprite/vy)
+* [**vy - velocity y**](/reference/sprites/sprite/vy)
 * [**ax - acceleration x**](/reference/sprites/sprite/ax)
 * [**ay - acceleration y**](/reference/sprites/sprite/ay)
 * [**fx - friction x**](/reference/sprites/sprite/fx)
@@ -67,6 +69,12 @@ sprites.onOverlap(0, 0, function (sprite, otherSprite) {})
 * [**width**](/reference/sprites/sprite/width)
 * [**height**](/reference/sprites/sprite/height)
 * [**lifespan**](/reference/sprites/sprite/lifespan)
+
+### Scaling
+
+* [**sx - scale x**](/reference/sprites/sprite/sx)
+* [**sy - scale y**](/reference/sprites/sprite/sy)
+* [**scale**](/reference/sprites/sprite/scale)
 
 ## See also
 
@@ -87,4 +95,6 @@ sprites.onOverlap(0, 0, function (sprite, otherSprite) {})
 [clear particles](/reference/sprites/sprite/clear-particles),
 [on created](/reference/sprites/on-created),
 [on destroyed](/reference/sprites/on-destroyed),
-[on overlap](/reference/sprites/on-overlap)
+[on overlap](/reference/sprites/on-overlap),
+[set scale](/reference/sprites/sprite/set-scale),
+[change scale](/reference/sprites/sprite/change-scale)

--- a/libs/game/docs/reference/sprites/sprite/change-scale.md
+++ b/libs/game/docs/reference/sprites/sprite/change-scale.md
@@ -1,0 +1,65 @@
+# change Scale
+
+Change the scale factor for a sprite by an increment or decrement.
+
+```sig
+sprites.create(null).changeScale(1, ScaleAnchor.Middle)
+```
+
+You can increase or decrease a sprite's size from it's current size by a certain amount. If a sprite's scale is `2` and you change it by `1`, then the sprite is now `3` times larger than it's original size. The sprite's size will shrink if you give a negative value. If you use `-2` for the change **value**, the sprite's new size will be half of what is was before.
+
+The **anchor** determines which direction the sprite will expand or shrink. If you increase the scale from the `middle`, the sprite will grow equally from it's center. If you choose to scale from the `bottom left`, the sprite will grow toward the top right of the screen.
+
+## Parameters
+
+* **value**: a [number](/types/number) to change the sprite's scale by.
+* **anchor**: an anchor point to scale the sprite from:
+>* `middle`
+>* `top`
+>* `left`
+>* `right`
+>* `bottom`
+>* `top left`
+>* `top right`
+>* `bottom right`
+>* `bottom left`
+
+## Examples #example
+
+### Rescale sprite
+
+Create a sprite with a square image. In a game update event, make the sprite grow and shrink continuously.
+
+```blocks
+let scaleFactor = 0
+let mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+game.onUpdateInterval(500, function () {
+    if (mySprite.scale == 1) {
+        scaleFactor = 1
+    } else if (mySprite.scale == 7) {
+        scaleFactor = -1
+    }
+    mySprite.changeScale(scaleFactor, ScaleAnchor.Middle)
+})
+```
+
+## See also #seealso
+
+[set scale](/reference/sprites/sprite/set-scale)

--- a/libs/game/docs/reference/sprites/sprite/fx.md
+++ b/libs/game/docs/reference/sprites/sprite/fx.md
@@ -1,52 +1,52 @@
-# fy (property)
+# fx (property)
 
-Get or set the friction opposing a sprite's motion in the vertical direction.
+Get or set the friction opposing a sprite's motion in the horizontal direction.
 
 ## Get
 
-Get the vertical friction on the sprite.
+Get the horizontal friction on the sprite.
 
 ```block
 let mySprite: Sprite = null
 
-let horzAccel = mySprite.fy
+let horzAccel = mySprite.fx
 ```
 
 ```typescript-ignorelet
-horzAccel = mySprite.fy
+horzAccel = mySprite.fx
 ```
 
 ### Returns
 
-* a [number](/types/number) that is the current vertical friction of the sprite.
+* a [number](/types/number) that is the current horizontal friction of the sprite.
 
 ## Set
 
-Set the vertical friction for the sprite.
+Set the horizontal friction for the sprite.
 
 ```block
 let mySprite: Sprite = null
 
-mySprite.fy = 0
+mySprite.fx = 0
 ```
 
 ```typescript-ignore
-mySprite.fy = 0
+mySprite.fx = 0
 ```
 
 ### Parameter
 
-* **value**: the new vertical friction opposing the sprite's motion in pixels per second, per second.
+* **value**: the new horizontal friction opposing the sprite's motion in pixels per second, per second.
 
-## Sprite vertical friction
+## Sprite horizontal friction
 
-Friction is an opposing force against the motion of a sprite. If a sprite has a vertical velocity (`vy`), it's friction will slow the sprite down until it's vertical velocity becomes `0`. This is similar to setting an opposite vertical acceleration but the opposite acceleration goes away once the sprite stops.
+Friction is an opposing force against the motion of a sprite. If a sprite has a horizontal velocity (`vx`), it's friction will slow the sprite down until it's horizontal velocity becomes `0`. This is similar to setting an opposite horizontal acceleration but the opposite acceleration goes away once the sprite stops.
 
 ## Examples #example
 
 ### Measure stopping time #ex1
 
-Move the sprite from top to bottom across the screen. Use the correct amount of friction (`fy`) to make the sprite stop at `3` seconds.
+Move the sprite from left to right across the screen. Use the correct amount of friction (`fx`) to make the sprite stop at `3` seconds.
 
 ```blocks
 let stopTime = 0
@@ -70,13 +70,13 @@ let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     `, SpriteKind.Player)
 mySprite.setStayInScreen(true)
-mySprite.top = 0
-mySprite.fy = 20
-mySprite.vy = 60
+mySprite.left = 0
+mySprite.fx = 30
+mySprite.vx = 90
 game.onUpdateInterval(100, function () {
     if (counting) {
         stopTime += 0.1
-        if (mySprite.vy == 0) {
+        if (mySprite.vx == 0) {
             counting = false
             mySprite.sayText("" + stopTime + "sec", 5000, false)
         }
@@ -86,7 +86,7 @@ game.onUpdateInterval(100, function () {
 
 ### Skipppng sprite #ex2
 
-Make a sprite move from the top to the bottom. Make it skip to the right once every second.
+Make a sprite move from the left to the right. Make it skip to the right once every second.
 
 ```blocks
 let mySprite = sprites.create(img`
@@ -108,16 +108,16 @@ let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     `, SpriteKind.Player)
 mySprite.setStayInScreen(true)
-mySprite.top = 0
-mySprite.fy = 60
-mySprite.vy = 60
+mySprite.left = 0
+mySprite.fx = 80
+mySprite.vx = 80
 for (let index = 0; index < 3; index++) {
-    mySprite.vy = 60
+    mySprite.vx = 80
     pause(1000)
 }
 ```
 
 ## See also #seealso
 
-[fx](/reference/sprites/sprite/fx),
-[ay](/reference/sprites/sprite/ay)
+[fy](/reference/sprites/sprite/fy),
+[ax](/reference/sprites/sprite/ax)

--- a/libs/game/docs/reference/sprites/sprite/fx.md
+++ b/libs/game/docs/reference/sprites/sprite/fx.md
@@ -84,7 +84,7 @@ game.onUpdateInterval(100, function () {
 })
 ```
 
-### Skipppng sprite #ex2
+### Skipping sprite #ex2
 
 Make a sprite move from the left to the right. Make it skip to the right once every second.
 

--- a/libs/game/docs/reference/sprites/sprite/fy.md
+++ b/libs/game/docs/reference/sprites/sprite/fy.md
@@ -1,52 +1,52 @@
 # fy (property)
 
-Get or set the friction opposing a sprite's motion in the horizontal direction.
+Get or set the friction opposing a sprite's motion in the vertical direction.
 
 ## Get
 
-Get the horizontal friction on the sprite.
+Get the vertical friction on the sprite.
 
 ```block
 let mySprite: Sprite = null
 
-let horzAccel = mySprite.fx
+let horzAccel = mySprite.fy
 ```
 
 ```typescript-ignorelet
-horzAccel = mySprite.fx
+horzAccel = mySprite.fy
 ```
 
 ### Returns
 
-* a [number](/types/number) that is the current horizontal friction of the sprite.
+* a [number](/types/number) that is the current vertical friction of the sprite.
 
 ## Set
 
-Set the horizontal friction for the sprite.
+Set the vertical friction for the sprite.
 
 ```block
 let mySprite: Sprite = null
 
-mySprite.fx = 0
+mySprite.fy = 0
 ```
 
 ```typescript-ignore
-mySprite.fx = 0
+mySprite.fy = 0
 ```
 
 ### Parameter
 
-* **value**: the new horizontal friction opposing the sprite's motion in pixels per second, per second.
+* **value**: the new vertical friction opposing the sprite's motion in pixels per second, per second.
 
-## Sprite horizontal friction
+## Sprite vertical friction
 
-Friction is an opposing force against the motion of a sprite. If a sprite has a horizontal velocity (`vx`), it's friction will slow the sprite down until it's horizontal velocity becomes `0`. This is similar to setting an opposite horizontal acceleration but the opposite acceleration goes away once the sprite stops.
+Friction is an opposing force against the motion of a sprite. If a sprite has a vertical velocity (`vy`), it's friction will slow the sprite down until it's vertical velocity becomes `0`. This is similar to setting an opposite vertical acceleration but the opposite acceleration goes away once the sprite stops.
 
 ## Examples #example
 
 ### Measure stopping time #ex1
 
-Move the sprite from left to right across the screen. Use the correct amount of friction (`fx`) to make the sprite stop at `3` seconds.
+Move the sprite from top to bottom across the screen. Use the correct amount of friction (`fy`) to make the sprite stop at `3` seconds.
 
 ```blocks
 let stopTime = 0
@@ -70,13 +70,13 @@ let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     `, SpriteKind.Player)
 mySprite.setStayInScreen(true)
-mySprite.left = 0
-mySprite.fx = 30
-mySprite.vx = 90
+mySprite.top = 0
+mySprite.fy = 20
+mySprite.vy = 60
 game.onUpdateInterval(100, function () {
     if (counting) {
         stopTime += 0.1
-        if (mySprite.vx == 0) {
+        if (mySprite.vy == 0) {
             counting = false
             mySprite.sayText("" + stopTime + "sec", 5000, false)
         }
@@ -86,7 +86,7 @@ game.onUpdateInterval(100, function () {
 
 ### Skipppng sprite #ex2
 
-Make a sprite move from the left to the right. Make it skip to the right once every second.
+Make a sprite move from the top to the bottom. Make it skip to the right once every second.
 
 ```blocks
 let mySprite = sprites.create(img`
@@ -108,16 +108,16 @@ let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     `, SpriteKind.Player)
 mySprite.setStayInScreen(true)
-mySprite.left = 0
-mySprite.fx = 80
-mySprite.vx = 80
+mySprite.top = 0
+mySprite.fy = 60
+mySprite.vy = 60
 for (let index = 0; index < 3; index++) {
-    mySprite.vx = 80
+    mySprite.vy = 60
     pause(1000)
 }
 ```
 
 ## See also #seealso
 
-[fy](/reference/sprites/sprite/fy),
-[ax](/reference/sprites/sprite/ax)
+[fx](/reference/sprites/sprite/fx),
+[ay](/reference/sprites/sprite/ay)

--- a/libs/game/docs/reference/sprites/sprite/fy.md
+++ b/libs/game/docs/reference/sprites/sprite/fy.md
@@ -84,7 +84,7 @@ game.onUpdateInterval(100, function () {
 })
 ```
 
-### Skipppng sprite #ex2
+### Skipping sprite #ex2
 
 Make a sprite move from the top to the bottom. Make it skip to the right once every second.
 

--- a/libs/game/docs/reference/sprites/sprite/scale.md
+++ b/libs/game/docs/reference/sprites/sprite/scale.md
@@ -1,0 +1,80 @@
+# scale (property)
+
+Get or set the scaling factor for the width and height of a sprite.
+
+## Get
+
+Get the scale for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+let xScale = mySprite.scale
+```
+
+```typescript-ignorelet
+xScale = mySprite.scale
+```
+
+### Returns
+
+* a [number](/types/number) that is the current scale for the sprite.
+
+## Set
+
+Set the scale for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+mySprite.scale = 0
+```
+
+```typescript-ignore
+mySprite.scale = 0
+```
+
+### Parameter
+
+* **value**: the new scale factor for the size of the sprite.
+
+## Examples #example
+
+### Stretch and shrink size #ex1
+
+Scale a sprite's size by `1` more every second. Expand while it's small and contract when it's large.
+
+```blocks
+let expand = 0
+let mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    if (mySprite.scale == 1) {
+        expand = 1
+    } else if (mySprite.scale == 6) {
+        expand = -1
+    }
+    mySprite.scale += expand
+})
+```
+
+## See also #seealso
+
+[sx](/reference/sprites/sprite/sx),
+[sy](/reference/sprites/sprite/sy)

--- a/libs/game/docs/reference/sprites/sprite/set-scale.md
+++ b/libs/game/docs/reference/sprites/sprite/set-scale.md
@@ -1,0 +1,79 @@
+# set Scale
+
+Set the scale factor for a sprite based on an anchor point.
+
+```sig
+sprites.create(null).setScale(1, ScaleAnchor.Middle)
+```
+
+You can increase or decrease a sprite from it's current size to a new size by setting a scale value. If a sprite's scale is set to `2`, then the sprite's new size is two times larger than it's original size. The sprite's size will shrink if you give a negative value. If you use `-3` for the scale value, the sprite's new size will three times smaller than it's original size.
+
+The **anchor** determines which direction the sprite will expand or shrink. If you increase the scale from the `middle`, the sprite will grow equally from it's center. If you choose to scale from the `bottom left`, the sprite will grow toward the top right of the screen.
+
+## Parameters
+
+* **value**: a [number](/types/number) that is the scale factor for the sprite.
+* **anchor**: an anchor point to scale the sprite from:
+>* `middle`
+>* `top`
+>* `left`
+>* `right`
+>* `bottom`
+>* `top left`
+>* `top right`
+>* `bottom right`
+>* `bottom left`
+
+## Examples #example
+
+### Scale in 4 directions
+
+Create a sprite with a square image. Make the sprite grow and shrink by `3` in each of the 4 corner directions.
+
+```blocks
+let scaleZone = 0
+let mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+game.onUpdateInterval(500, function () {
+    if (scaleZone == 0) {
+        mySprite.setScale(3, ScaleAnchor.TopLeft)
+    } else if (scaleZone == 1) {
+        mySprite.setScale(1, ScaleAnchor.TopLeft)
+    } else if (scaleZone == 2) {
+        mySprite.setScale(3, ScaleAnchor.TopRight)
+    } else if (scaleZone == 3) {
+        mySprite.setScale(1, ScaleAnchor.TopRight)
+    } else if (scaleZone == 4) {
+        mySprite.setScale(3, ScaleAnchor.BottomRight)
+    } else if (scaleZone == 5) {
+        mySprite.setScale(1, ScaleAnchor.BottomRight)
+    } else if (scaleZone == 6) {
+        mySprite.setScale(3, ScaleAnchor.BottomLeft)
+    } else if (scaleZone == 7) {
+        mySprite.setScale(1, ScaleAnchor.BottomLeft)
+    } else {
+        scaleZone = -1
+    }
+    scaleZone += 1
+})
+```
+
+## See also #seealso
+
+[change scale](/reference/sprites/sprite/change-scale)

--- a/libs/game/docs/reference/sprites/sprite/sx.md
+++ b/libs/game/docs/reference/sprites/sprite/sx.md
@@ -1,0 +1,80 @@
+# sx (property)
+
+Get or set the scaling factor for the width of a sprite.
+
+## Get
+
+Get the width scale for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+let xScale = mySprite.sx
+```
+
+```typescript-ignorelet
+xScale = mySprite.sx
+```
+
+### Returns
+
+* a [number](/types/number) that is the current scale for the width of the sprite.
+
+## Set
+
+Set the width scale for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+mySprite.sx = 0
+```
+
+```typescript-ignore
+mySprite.sx = 0
+```
+
+### Parameter
+
+* **value**: the new width scale factor for the size of the sprite.
+
+## Examples #example
+
+### Stretch and shrink width #ex1
+
+Scale a sprite's width by `1` more size every second. Expand while it's small and contract when it's large.
+
+```blocks
+let expand = 0
+let mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    if (mySprite.sx == 1) {
+        expand = 1
+    } else if (mySprite.sx == 6) {
+        expand = -1
+    }
+    mySprite.sx += expand
+})
+```
+
+## See also #seealso
+
+[sy](/reference/sprites/sprite/sy),
+[scale](/reference/sprites/sprite/scale)

--- a/libs/game/docs/reference/sprites/sprite/sy.md
+++ b/libs/game/docs/reference/sprites/sprite/sy.md
@@ -1,0 +1,80 @@
+# sy (property)
+
+Get or set the scaling factor for the height of a sprite.
+
+## Get
+
+Get the height scale for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+let xScale = mySprite.sy
+```
+
+```typescript-ignorelet
+xScale = mySprite.sy
+```
+
+### Returns
+
+* a [number](/types/number) that is the current scale for the height of the sprite.
+
+## Set
+
+Set the height scale for the sprite.
+
+```block
+let mySprite: Sprite = null
+
+mySprite.sy = 0
+```
+
+```typescript-ignore
+mySprite.sy = 0
+```
+
+### Parameter
+
+* **value**: the new height scale factor for the size of the sprite.
+
+## Examples #example
+
+### Stretch and shrink height #ex1
+
+Scale a sprite's height by `1` more size every second. Expand while it's small and contract when it's large.
+
+```blocks
+let expand = 0
+let mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+game.onUpdateInterval(1000, function () {
+    if (mySprite.sy == 1) {
+        expand = 1
+    } else if (mySprite.sy == 6) {
+        expand = -1
+    }
+    mySprite.sy += expand
+})
+```
+
+## See also #seealso
+
+[sx](/reference/sprites/sprite/sx),
+[scale](/reference/sprites/sprite/scale)

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1131,7 +1131,7 @@ class Sprite extends sprites.BaseSprite {
     //% inlineInputMode=inline
     //% value.defl=1
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite/scale
+    //% help=sprites/sprite/set-scale
     //% group="Scale" weight=90
     setScale(value: number, anchor?: ScaleAnchor): void {
         const direction = ScaleDirection.Uniformly;
@@ -1152,7 +1152,7 @@ class Sprite extends sprites.BaseSprite {
     //% inlineInputMode=inline
     //% value.defl=1
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite/scale
+    //% help=sprites/sprite/change-scale
     //% group="Scale" weight=90
     changeScale(value: number, anchor?: ScaleAnchor): void {
         const direction = ScaleDirection.Uniformly;

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-percent.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-percent.md
@@ -1,0 +1,77 @@
+# scale By Percent
+
+Scale a sprite by a percentage of its current size in a direction from an anchor point.
+
+```sig
+scaling.scaleByPercent(null, 50, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+```
+
+A sprite can scale by a percentage of its original size in a direction from an anchor point. The scaling can be in just one direction or the sprite can scale uniformly.
+
+## Uniform scaling
+
+When the scaling **direction** is set to `uniformly`, the sprite is scaled so that the new size will have both the width and height changed by the same percentage **value**. If a sprite's current size is `64` x `32` and it's uniformly scaled by `50` percent, the new width is `32` and the new height is `16`.
+
+## Parameters
+
+* **sprite**: the sprite to scale by a percentage of its original size.
+* **value**: the [number](/types/number) that is the percentage to scale the sprite by.
+* **direction**: the direction to scale in:
+>* `horizontally`
+>* `vertically`
+>* `uniformly`
+* **anchor**: an anchor point to scale the sprite from:
+>* `middle`
+>* `top`
+>* `left`
+>* `right`
+>* `bottom`
+>* `top left`
+>* `top right`
+>* `bottom right`
+>* `bottom left`
+
+## Example #example
+
+### Scaling tester #ex1
+
+Make a program to test sprite scaling a sprite by expanding and shrinking it uniformly. Use the controller buttons to increase and decrease the scale of a sprite  by a percentage of its current size.
+
+```blocks
+controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleByPercent(mySprite, -50, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+    info.setScore(mySprite.width)
+})
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleByPercent(mySprite, 50, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+    info.setScore(mySprite.width)
+})
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    22222222222222222222222222222222
+    25557777777777777777777777775552
+    25577777777777777777777777777552
+    25777777777777777777777777777752
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777888877777777777772
+    27777777777777888877777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    25777777777777777777777777777752
+    25577777777777777777777777777552
+    25557777777777777777777777775552
+    22222222222222222222222222222222
+    `, SpriteKind.Player)
+info.setScore(mySprite.width)
+```
+
+## See also #seealso
+
+[scale to percent](/reference/sprites/scaling/scale-to-percent)
+
+```package
+sprite-scaling
+```

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-pixels.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-pixels.md
@@ -1,0 +1,140 @@
+# scale by Pixels
+
+Scale a sprite by a number of pixels in a direction from an anchor point.
+
+```sig
+scaling.scaleByPixels(null, 1, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+```
+
+A sprite can scale to a number of pixels in a direction from an anchor point. The scaling can be in just in the direction chosen, or the sprite can scale proportionally in the other direction too. 
+
+## Proportional scaling
+
+If the scale direction is `vertically` or `horizontally` but **proportional** is set to `false`, the sprite will scale to the number of pixels given in **value** only in the chosen direction. The sprite will expand in height but the width will stay the same or the sprite will expand in width but the height will stat the same.
+
+If the scaling direction is `vertically` and the `proportional` parameter is `true`, the width will also expand by the same ratio of change as the height. With this setting, expanding a `32` x `16` sprite in the vertical direction by `16` pixels will also expand the width by `32`. The same ratio scaling will happen for the height if the direction is `horizontally`.
+
+## Uniform scaling
+
+When the scaling **direction** is set to `uniformly`, the sprite is scaled so that the new size will have both the width and height change by the same amount. If a sprite's current size is `64` x `16` and it's uniformly scaled by `64`, the new width is `128` and the new height is `80`.
+
+## Parameters
+
+* **sprite**: the sprite to scale by a pixel amount.
+* **value**: the [number](/types/number) of pixels to scale the sprite by.
+* **direction**: the direction to scale in:
+>* `horizontally`
+>* `vertically`
+>* `uniformly`
+* **anchor**: an anchor point to scale the sprite from:
+>* `middle`
+>* `top`
+>* `left`
+>* `right`
+>* `bottom`
+>* `top left`
+>* `top right`
+>* `bottom right`
+>* `bottom left`
+* **proportional**: a [boolean](/types/boolean) value that when `true` will scale the sprite proportionally. If `false`, the sprite will only scale by **direction**. This parameter has no effect when **direction** is set to `uniformly`.
+
+## Example #example
+
+### Scaling tester #ex1
+
+Make a program to test sprite scaling in both directions for expanding and shrinking. Use the controller buttons to increase and decrease the scale. Use buttons to turn **proportional** to `true` or `false`.
+
+```blocks
+controller.up.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleByPixels(mySprite, pixelMin, ScaleDirection.Vertically, ScaleAnchor.Middle, proportion)
+})
+controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
+    proportion = false
+    game.showLongText("Proportional = FALSE", DialogLayout.Bottom)
+})
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    proportion = true
+    game.showLongText("Proportional = TRUE", DialogLayout.Bottom)
+})
+controller.left.onEvent(ControllerButtonEvent.Pressed, function () {
+    if (mySprite.width > pixelMin) {
+        scaling.scaleByPixels(mySprite, pixelMin * -1, ScaleDirection.Horizontally, ScaleAnchor.Middle, proportion)
+    }
+})
+controller.right.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleByPixels(mySprite, pixelMin, ScaleDirection.Horizontally, ScaleAnchor.Middle, proportion)
+})
+controller.down.onEvent(ControllerButtonEvent.Pressed, function () {
+    if (mySprite.width > pixelMin) {
+        scaling.scaleByPixels(mySprite, pixelMin * -1, ScaleDirection.Vertically, ScaleAnchor.Middle, proportion)
+    }
+})
+let proportion = false
+let pixelMin = 0
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+pixelMin = mySprite.width
+let pixelMax = pixelMin * 5
+game.showLongText("Proportional = FALSE", DialogLayout.Bottom)
+```
+
+### Uniformity tester #ex2
+
+Test uniformly scaling a nonsquare sprite. Use the controller buttons to change the increased or decreased scale.
+
+```blocks
+controller.up.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleByPixels(mySprite, pixelMax, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+    info.setScore(mySprite.width)
+})
+controller.down.onEvent(ControllerButtonEvent.Pressed, function () {
+    if (my)
+    scaling.scaleByPixels(mySprite, pixelMin * -1, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+    info.setScore(mySprite.width)
+})
+let pixelMax = 0
+let pixelMin = 0
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    22222222222222222222222222222222
+    25557777777777777777777777775552
+    25577777777777777777777777777552
+    25777777777777777777777777777752
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777888877777777777772
+    27777777777777888877777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    25777777777777777777777777777752
+    25577777777777777777777777777552
+    25557777777777777777777777775552
+    22222222222222222222222222222222
+    `, SpriteKind.Player)
+pixelMin = mySprite.height
+pixelMax = pixelMin * 5
+info.setScore(mySprite.width)
+```
+
+```package
+sprite-scaling
+```

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-pixels.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-pixels.md
@@ -135,6 +135,10 @@ pixelMax = pixelMin * 5
 info.setScore(mySprite.width)
 ```
 
+## See also #seealso
+
+[scale by pixels](/reference/sprites/scaling/scale-by-pixels)
+
 ```package
 sprite-scaling
 ```

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-percent.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-percent.md
@@ -1,0 +1,83 @@
+# scale To Percent
+
+Scale a sprite to a percentage of its original size in a direction from an anchor point.
+
+```sig
+scaling.scaleToPercent(null, 100, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+```
+
+A sprite can scale to a percentage of its original size in a direction from an anchor point. The scaling can be in just one direction or the sprite can scale uniformly.
+
+## Uniform scaling
+
+When the scaling **direction** is set to `uniformly`, the sprite is scaled so that the new size will have both the width and height changed by the same percentage **value**. If a sprite's original size is `64` x `32` and it's uniformly scaled to `50` percent, the new width is `32` and the new height is `16`.
+
+## Parameters
+
+* **sprite**: the sprite to scale to a percentage of its original size.
+* **value**: the [number](/types/number) that is the percentage to scale the sprite to.
+* **direction**: the direction to scale in:
+>* `horizontally`
+>* `vertically`
+>* `uniformly`
+* **anchor**: an anchor point to scale the sprite from:
+>* `middle`
+>* `top`
+>* `left`
+>* `right`
+>* `bottom`
+>* `top left`
+>* `top right`
+>* `bottom right`
+>* `bottom left`
+
+## Example #example
+
+### Scaling tester #ex1
+
+Make a program to test sprite scaling in both directions for expanding and shrinking. Use the controller buttons to increase and decrease the scale to a percentage of the original sprite by direction. Use button `A` to set the pixel back to its original size.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPercent(mySprite, 100, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+})
+controller.up.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPercent(mySprite, 200, ScaleDirection.Vertically, ScaleAnchor.Middle)
+})
+controller.left.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPercent(mySprite, 50, ScaleDirection.Horizontally, ScaleAnchor.Middle)
+})
+controller.right.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPercent(mySprite, 200, ScaleDirection.Horizontally, ScaleAnchor.Middle)
+})
+controller.down.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPercent(mySprite, 50, ScaleDirection.Vertically, ScaleAnchor.Middle)
+})
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    22222222222222222222222222222222
+    25557777777777777777777777775552
+    25577777777777777777777777777552
+    25777777777777777777777777777752
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777888877777777777772
+    27777777777777888877777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    25777777777777777777777777777752
+    25577777777777777777777777777552
+    25557777777777777777777777775552
+    22222222222222222222222222222222
+    `, SpriteKind.Player)
+```
+
+## See also #seealso
+
+[scale by percent](/reference/sprites/scaling/scale-by-percent)
+
+```package
+sprite-scaling
+```

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-pixels.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-pixels.md
@@ -1,0 +1,136 @@
+# scale To Pixels
+
+Scale a sprite to a number of pixels in a direction from an anchor point.
+
+```sig
+scaling.scaleToPixels(null, 1, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+```
+
+A sprite can scale to a number of pixels in a direction from an anchor point. The scaling can be in just in the direction chosen, or the sprite can scale proportionally in the other direction too. 
+
+## Proportional scaling
+
+If the scale direction is `vertically` or `horizontally` but **proportional** is set to `false`, the sprite will scale to the number of pixels given in **value** only in the chosen direction. The sprite will expand in height but the width will stay the same or the sprite will expand in width but the height will stat the same.
+
+If the scaling direction is `vertically` and the `proportional` parameter is `true`, the width will also expand by the same ratio of change as the height. With this setting, expanding a `32` x `16` sprite in the vertical direction to `32` pixels will also expand the width to `64`. The same ratio scaling will happen for the height if the direction is `horizontally`.
+
+## Uniform scaling
+
+When the scaling **direction** is set to `uniformly`, the sprite is scaled so that te new size will have both the width and height the same. If a sprite's current size is `64` x `16` and it's uniformly scaled to `128`, the new width and height will both be `128`.
+
+## Parameters
+
+* **sprite**: the sprite to scale to a pixel amount.
+* **value**: the [number](/types/number) of pixels to scale the sprite to.
+* **direction**: the direction to scale in:
+>* `horizontally`
+>* `vertically`
+>* `uniformly`
+* **anchor**: an anchor point to scale the sprite from:
+>* `middle`
+>* `top`
+>* `left`
+>* `right`
+>* `bottom`
+>* `top left`
+>* `top right`
+>* `bottom right`
+>* `bottom left`
+* **proportional**: a [boolean](/types/boolean) value that when `true` will scale the sprite proportionally. If `false`, the sprite will only scale by **direction**. This parameter has no effect when **direction** is set to `uniformly`.
+
+## Example #example
+
+### Scaling tester #ex1
+
+Make a program to test sprite scaling in both directions for expanding and shrinking. Use the controller buttons to increase and decrease the scale. Use buttons to turn **proportional** to `true` or `false`.
+
+```blocks
+controller.B.onEvent(ControllerButtonEvent.Pressed, function () {
+    proportion = false
+    game.showLongText("Proportional = FALSE", DialogLayout.Bottom)
+})
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    proportion = true
+    game.showLongText("Proportional = TRUE", DialogLayout.Bottom)
+})
+controller.left.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPixels(mySprite, pixelMin, ScaleDirection.Horizontally, ScaleAnchor.Middle, proportion)
+})
+controller.right.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPixels(mySprite, pixelMax, ScaleDirection.Horizontally, ScaleAnchor.Middle, proportion)
+})
+controller.up.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPixels(mySprite, pixelMax, ScaleDirection.Vertically, ScaleAnchor.Middle, proportion)
+})
+controller.down.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPixels(mySprite, pixelMin, ScaleDirection.Vertically, ScaleAnchor.Middle, proportion)
+})
+let proportion = false
+let pixelMax = 0
+let pixelMin = 0
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 8 8 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 7 7 7 7 7 7 7 7 7 7 7 7 7 7 2 
+    2 5 7 7 7 7 7 7 7 7 7 7 7 7 5 2 
+    2 5 5 7 7 7 7 7 7 7 7 7 7 5 5 2 
+    2 5 5 5 7 7 7 7 7 7 7 7 5 5 5 2 
+    2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 
+    `, SpriteKind.Player)
+pixelMin = mySprite.width
+pixelMax = pixelMin * 5
+game.showLongText("Proportional = FALSE", DialogLayout.Bottom)
+```
+
+### Uniformity tester #ex2
+
+Test uniformly scaling a nonsquare sprite. Use the `up` and `down` controller buttons to increase and decrease the scale.
+
+```blocks
+controller.up.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPixels(mySprite, pixelMax, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+    info.setScore(mySprite.width)
+})
+controller.down.onEvent(ControllerButtonEvent.Pressed, function () {
+    scaling.scaleToPixels(mySprite, pixelMin, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+    info.setScore(mySprite.width)
+})
+let pixelMax = 0
+let pixelMin = 0
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    22222222222222222222222222222222
+    25557777777777777777777777775552
+    25577777777777777777777777777552
+    25777777777777777777777777777752
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777888877777777777772
+    27777777777777888877777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    27777777777777777777777777777772
+    25777777777777777777777777777752
+    25577777777777777777777777777552
+    25557777777777777777777777775552
+    22222222222222222222222222222222
+    `, SpriteKind.Player)
+pixelMin = mySprite.height
+pixelMax = pixelMin * 5
+info.setScore(mySprite.width)
+```
+
+```package
+sprite-scaling
+```

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-pixels.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-pixels.md
@@ -131,6 +131,10 @@ pixelMax = pixelMin * 5
 info.setScore(mySprite.width)
 ```
 
+## See also #seealso
+
+[scale by pixels](/reference/sprites/scaling/scale-to-pixels)
+
 ```package
 sprite-scaling
 ```

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -7,7 +7,7 @@ namespace scaling {
     //% value.defl=150
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite-scaling/scale
+    //% help=sprites/scaling/scale-to-percent
     export function scaleToPercent(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         value /= 100;
         direction = direction || ScaleDirection.Uniformly;
@@ -29,7 +29,7 @@ namespace scaling {
     //% value.defl=50
     //% direction.defl=ScaleDirection.Uniformly
     //% anchor.defl=ScaleAnchor.Middle
-    //% help=sprites/sprite-scaling/scale
+    //% help=sprites/scaling/scale-by-percent
     export function scaleByPercent(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor): void {
         value /= 100;
         direction = direction || ScaleDirection.Uniformly;
@@ -52,7 +52,7 @@ namespace scaling {
     //% direction.defl=ScaleDirection.Horizontally
     //% anchor.defl=ScaleAnchor.Middle
     //% proportional.defl=0
-    //% help=sprites/sprite-scaling/scale
+    //% help=sprites/scaling/scale-to-pixels
     export function scaleToPixels(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         direction = direction || ScaleDirection.Horizontally;
         anchor = anchor || ScaleAnchor.Middle;
@@ -85,7 +85,7 @@ namespace scaling {
     //% direction.defl=ScaleDirection.Horizontally
     //% anchor.defl=ScaleAnchor.Middle
     //% proportional.defl=0
-    //% help=sprites/sprite-scaling/scale
+    //% help=sprites/scaling/scale-by-pixels
     export function scaleByPixels(sprite: Sprite, value: number, direction?: ScaleDirection, anchor?: ScaleAnchor, proportional?: boolean): void {
         direction = direction || ScaleDirection.Horizontally;
         anchor = anchor || ScaleAnchor.Middle;


### PR DESCRIPTION
Sprite scaling reference pages:

- [x] Create reference pages for the sprite scaling props and methods.
- [x] Create reference pages for the sprite scaling extension methods.
- [x] A few fixes for the `fx` and `fy` pages too.

Closes https://github.com/microsoft/pxt-arcade/issues/4562

RE: https://github.com/microsoft/pxt-arcade/issues/4590