### PR TITLE
Fill in some missing tilemap location reference pages

### DIFF
--- a/libs/game/docs/reference/scene/get-neighboring-location.md
+++ b/libs/game/docs/reference/scene/get-neighboring-location.md
@@ -1,0 +1,121 @@
+# get Neighboring Location
+
+Get the location of a tile next to this one.
+
+```sig
+tiles.getTileLocation(0, 0).getNeighboringLocation(CollisionDirection.Top)
+```
+
+A neighboring tile is one that is immediately to the `left`, `right`, `top`, or `bottom` side of the current tile. You can specify the side of the neighboring tile you want the location for.
+
+## Parameters
+
+* **direction**: the direction side for the neighbor tile from this tile. The directions to choose from are `left`, `right`, `top`, or `bottom`.
+
+## Returns
+
+* a **location** object for the neighbor tile.
+
+## Example #example
+
+```blocks
+let nextSpot: tiles.Location = null
+let rotation = 0
+tiles.setCurrentTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . b b b b a a . . . . 
+    . . . . b b d d d 3 3 3 a a . . 
+    . . . b d d d 3 3 3 3 3 3 a a . 
+    . . b d d 3 3 3 3 3 3 3 3 3 a . 
+    . b 3 d 3 3 3 3 3 b 3 3 3 3 a b 
+    . b 3 3 3 3 3 a a 3 3 3 3 3 a b 
+    b 3 3 3 3 3 a a 3 3 3 3 d a 4 b 
+    b 3 3 3 3 b a 3 3 3 3 3 d a 4 b 
+    b 3 3 3 3 3 3 3 3 3 3 d a 4 4 e 
+    a 3 3 3 3 3 3 3 3 3 d a 4 4 4 e 
+    a 3 3 3 3 3 3 3 d d a 4 4 4 e . 
+    a a 3 3 3 d d d a a 4 4 4 e e . 
+    . e a a a a a a 4 4 4 4 e e . . 
+    . . e e b b 4 4 4 4 b e e . . . 
+    . . . e e e e e e e e . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.x = mySprite.x - mySprite.width
+game.onUpdateInterval(1000, function () {
+    if (rotation == 0) {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Right)
+    } else if (rotation == 1) {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Bottom)
+    } else if (rotation == 2) {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Left)
+    } else {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Top)
+    }
+    mySprite.setPosition(nextSpot.x, nextSpot.y)
+    rotation += 1
+    if (rotation > 3) {
+        rotation = 0
+    }
+})
+```
+
+## See also #seealso
+
+[get tile location](/reference/scene/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile3": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile4": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMzAyMDMwMjAzMDIwMzAyMDEwMTAyMDMwMjAzMDIwMzAyMDMwMTAxMDMwMjAzMDIwMzAyMDMwMjAxMDEwMjAzMDIwMzAyMDMwMjAzMDEwMTAzMDIwMzAyMDMwMjAzMDIwMTAxMDIwMzAyMDMwMjAzMDIwMzAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/get-neighboring-location.md
+++ b/libs/game/docs/reference/scene/get-neighboring-location.md
@@ -14,9 +14,11 @@ A neighboring tile is one that is immediately to the `left`, `right`, `top`, or 
 
 ## Returns
 
-* a **location** object for the neighbor tile.
+* a [location](/reference/scene/location) object for the neighbor tile.
 
 ## Example #example
+
+Rotate a donut sprite around adjacent tiles in a tilemap.
 
 ```blocks
 let nextSpot: tiles.Location = null

--- a/libs/game/docs/reference/scene/get-tile-location.md
+++ b/libs/game/docs/reference/scene/get-tile-location.md
@@ -15,7 +15,7 @@ A tile location object represents a column and a row position in the tilemap. Lo
 
 ## Returns
 
-* a tile location object for a given column and row in the tilemap.
+* a tile [location](/reference/scene/location) object for a given column and row in the tilemap.
 
 ## Example #example
 

--- a/libs/game/docs/reference/scene/get-tile-location.md
+++ b/libs/game/docs/reference/scene/get-tile-location.md
@@ -48,10 +48,6 @@ forever(function () {
 })
 ```
 
-## Returns
-
-* a tile location for the column and row specifed.
-
 ## See also #seealso
 
 [set tile at](/reference/scene/set-tile-at),

--- a/libs/game/docs/reference/scene/location.md
+++ b/libs/game/docs/reference/scene/location.md
@@ -1,0 +1,246 @@
+# Location
+
+The Location object contains the postition information of a game element on the tilemap.
+
+## column (property)
+
+Get a tile column position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let col = location.column
+```
+
+```typescript-ignore
+let col = location.column
+```
+
+### Returns
+
+* a [number](/types/number) that is the tile column position of object on the tilemap.
+
+## row (property)
+
+Get a tile row position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let row = location.row
+```
+
+```typescript-ignore
+let row = location.row
+```
+
+### Returns
+
+* a [number](/types/number) that is the tile row position of object on the tilemap.
+
+## x (property)
+
+Get the horizontal center position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let horz = location.x
+```
+
+```typescript-ignore
+let horz = location.x
+```
+
+### Returns
+
+* a [number](/types/number) that is the current horizontal center position, in pixels, of the object on the tilemap.
+
+## y (property)
+
+Get the vertical center position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let vert = location.y
+```
+
+```typescript-ignore
+let vert = location.y
+```
+
+### Returns
+
+* a [number](/types/number) that is the vertical center position, in pixels, of object on the tilemap.
+
+## left (property)
+
+Get the of position of left side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let left = location.left
+```
+
+```typescript-ignore
+let left = location.left
+```
+
+### Returns
+
+* a [number](/types/number) that is the left side, in pixels, of object on the tilemap.
+
+## right (property)
+
+Get the of position of right side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let right = location.right
+```
+
+```typescript-ignore
+let right = location.right
+```
+
+### Returns
+
+* a [number](/types/number) that is the right side, in pixels, of object on the tilemap.
+
+## top (property)
+
+Get the of position of top side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let top = location.top
+```
+
+```typescript-ignore
+let top = location.top
+```
+
+### Returns
+
+* a [number](/types/number) that is the right side, in pixels, of object on the tilemap.
+
+## bottom (property)
+
+Get the of position of bottom side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let bottom = location.bottom
+```
+
+```typescript-ignore
+let bottom = location.bottom
+```
+
+### Returns
+
+* a [number](/types/number) that is the right side, in pixels, of object on the tilemap.
+
+## Example #example
+
+Make checkered table cloth with tiles on a tilemap. Create a hamburger sprite and randomly locate it on the table cloth. Find out where the hamburger is and display its location.
+
+```blocks
+tiles.setCurrentTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    ...........ccccc66666...........
+    ........ccc4444444444666........
+    ......cc444444444bb4444466......
+    .....cb4444bb4444b5b444444b.....
+    ....eb4444b5b44444b44444444b....
+    ...ebb44444b4444444444b444446...
+    ..eb6bb444444444bb444b5b444446..
+    ..e6bb5b44444444b5b444b44bb44e..
+    .e66b4b4444444444b4444444b5b44e.
+    .e6bb444444444444444444444bb44e.
+    eb66b44444bb444444444444444444be
+    eb66bb444b5b44444444bb44444444be
+    fb666b444bb444444444b5b4444444bf
+    fcb666b44444444444444bb444444bcf
+    .fbb6666b44444444444444444444bf.
+    .efbb66666bb4444444444444444bfe.
+    .86fcbb66666bbb44444444444bcc688
+    8772effcbbbbbbbbbbbbbbbbcfc22778
+    87722222cccccccccccccccc22226678
+    f866622222222222222222222276686f
+    fef866677766667777776667777fffef
+    fbff877768f86777777666776fffffbf
+    fbeffeefffeff7766688effeeeefeb6f
+    f6bfffeffeeeeeeeeeeeeefeeeeebb6e
+    f66ddfffffeeeffeffeeeeeffeedb46e
+    .c66ddd4effffffeeeeeffff4ddb46e.
+    .fc6b4dddddddddddddddddddb444ee.
+    ..ff6bb444444444444444444444ee..
+    ....ffbbbb4444444444444444ee....
+    ......ffebbbbbb44444444eee......
+    .........fffffffcccccee.........
+    ................................
+    `, SpriteKind.Player)
+mySprite.setPosition(randint(16, 144), randint(16, 104))
+let location = mySprite.tilemapLocation()
+let displayString = "My hamburger is at "
+displayString = "" + displayString + "x = "
+displayString = "" + displayString + location.x + ", y = " + location.y
+displayString = "" + displayString + " and over the tile at column = "
+displayString = "" + displayString + location.column + ", row = " + location.row
+game.showLongText(displayString, DialogLayout.Bottom)
+```
+
+## See also #seealso
+
+[get neighboring location](/reference/scene/get-neighboring-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile3": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile4": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAzMDEwMzAxMDMwMTAzMDEwMzAxMDEwMzAyMDMwMjAzMDIwMzAyMDMwMzAyMDMwMjAzMDIwMzAyMDMwMTAxMDMwMjAzMDIwMzAyMDMwMjAzMDMwMjAzMDIwMzAyMDMwMjAzMDEwMTAzMDIwMzAyMDMwMjAzMDIwMzAzMDIwMzAyMDMwMjAzMDIwMzAxMDEwMzAxMDMwMTAzMDEwMzAxMDMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/tile-at-location-equals.md
+++ b/libs/game/docs/reference/scene/tile-at-location-equals.md
@@ -8,7 +8,7 @@ tiles.tileAtLocationEquals(tiles.getTileLocation(0, 0), null)
 
 ## Parameters
 
-* **location**: a location in the tilemap.
+* **location**: a [location](/reference/scene/location) in the tilemap.
 * **tile**: an [image](/types/image) that matches the tile you're looking for.
 
 ## Returns

--- a/libs/game/docs/reference/scene/tile-at-location-is-wall.md
+++ b/libs/game/docs/reference/scene/tile-at-location-is-wall.md
@@ -10,7 +10,7 @@ The tile in the tilemap at the location selected is checked to see if it is set 
 
 ## Parameters
 
-* **location**: the location object for the tile to check if it's a wall.
+* **location**: the [location](/reference/scene/location) object for the tile to check if it's a wall.
 
 ## Returns
 

--- a/libs/game/docs/reference/scene/tile-at-location-is-wall.md
+++ b/libs/game/docs/reference/scene/tile-at-location-is-wall.md
@@ -1,0 +1,98 @@
+# tile At Location Is Wall
+
+Check if a tile at a location in the tilemap is also a wall tile.
+
+```sig
+tiles.tileAtLocationIsWall(null)
+```
+
+The tile in the tilemap at the location selected is checked to see if it is set as a wall. After they are placed in the tilemap with the Tilemap Editor, tiles can be set as _wall_ tiles.
+
+## Parameters
+
+* **location**: the location object for the tile to check if it's a wall.
+
+## Returns
+
+* a [boolean](/types/boolean) value that is `true` if the tile at **location** is a wall. The value is `false` if the tile is not a wall.
+
+## Example #example
+
+Set a tilemap with two columns of the same tile. Make one of the columns be all wall tiles. Send a ghost sprite across both colunms so it can detect which one is the wall.
+
+```blocks
+scene.onOverlapTile(SpriteKind.Player, assets.tile`myTile0`, function (sprite, location) {
+    if (tiles.tileAtLocationIsWall(location)) {
+        mySprite.sayText("That's a wall!")
+    } else {
+        mySprite.sayText("Not a wall.")
+    }
+})
+let mySprite: Sprite = null
+scene.setBackgroundColor(11)
+tiles.setCurrentTilemap(tilemap`level1`)
+mySprite = sprites.create(img`
+    ........................
+    ........................
+    ........................
+    ........................
+    ..........ffff..........
+    ........ff1111ff........
+    .......fb111111bf.......
+    .......f11111111f.......
+    ......fd11111111df......
+    ......fd11111111df......
+    ......fddd1111dddf......
+    ......fbdbfddfbdbf......
+    ......fcdcf11fcdcf......
+    .......fb111111bf.......
+    ......fffcdb1bdffff.....
+    ....fc111cbfbfc111cf....
+    ....f1b1b1ffff1b1b1f....
+    ....fbfbffffffbfbfbf....
+    .........ffffff.........
+    ...........fff..........
+    ........................
+    ........................
+    ........................
+    ........................
+    `, SpriteKind.Player)
+mySprite.left = 0
+mySprite.setFlag(SpriteFlag.GhostThroughWalls, true)
+mySprite.vx = 30
+```
+
+## See also #seealso
+
+[get tile location](/reference/scene/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABmZmZmZmZmZmZvZmZmb2ZmZmZm9mZm9mZmZm9mb2ZmZvZmZmZmZm9mZmZmZmZmZmZmZmZmZmZmZmb2ZvZmb2Zm9mZmZmZm9mZmZmZmZmZmZmb2b2b2ZmZmZmZmZmZmZm9mZmb2ZmZmZmb2ZmZm9mZvZmZmZvZmZvZmZmZmZmZmZg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAxMDAwMDAxMDAwMDAwMDAwMDAwMDEwMDAwMDEwMDAwMDAwMDAwMDAwMTAwMDAwMTAwMDAwMDAwMDAwMDAxMDAwMDAxMDAwMDAwMDAwMDAwMDEwMDAwMDEwMDAwMDAwMDAwMDAwMTAwMDAwMTAwMDAwMDAwMDAwMDAxMDAwMDAxMDAwMDAwMDAwMDAwMDEwMDAwMDEwMDAwMDAwMDAwMDAwMjAwMDAwMDAwMDIwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMDAwMDAwMDIwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMDAwMDAwMDIwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/tile-image-at-location.md
+++ b/libs/game/docs/reference/scene/tile-image-at-location.md
@@ -1,0 +1,63 @@
+# tile Image At Location
+
+Get the image of the tile at a location in the tilemap.
+
+```sig
+tiles.tileImageAtLocation(tiles.getTileAtLocation(0, 0))
+```
+
+## Parameters
+
+* **location**: the location object for the tile to return it's image.
+
+## Returns
+
+* the [image](/types/image) of the tile at the **location** in the tilemap.
+
+## Example #example
+
+Make a tilemap with some smiley face tiles. Create a new sprite using the image from one of the smiley face tiles. Have the new sprite move across the screen and back.
+
+```blocks
+scene.onHitWall(SpriteKind.Player, function (sprite, location) {
+    sprite.startEffect(effects.bubbles, 500)
+})
+tiles.setCurrentTilemap(tilemap`level1`)
+let tileImage = tiles.tileImageAtLocation(tiles.getTileLocation(0, 0))
+let mySprite = sprites.create(tileImage, SpriteKind.Player)
+mySprite.setBounceOnWall(true)
+mySprite.vx = 50
+```
+
+## See also #seealso
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABERERERERERERERERERERERPT/RET/RERE9PRERERPRET0/0RERPRERERERERE9ERERERERET0RERERPRPRPRERERE9E9E9ERERERERET0RERERERERPRERPT/RERE9ERE9PRERERPRET0/0RE/0RERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDAwMTAwMDEwMDAxMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMTAwMDEwMDAxMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/tile-image-at-location.md
+++ b/libs/game/docs/reference/scene/tile-image-at-location.md
@@ -8,7 +8,7 @@ tiles.tileImageAtLocation(tiles.getTileAtLocation(0, 0))
 
 ## Parameters
 
-* **location**: the location object for the tile to return it's image.
+* **location**: the [location](/reference/scene/location) object for the tile to return it's image.
 
 ## Returns
 
@@ -30,6 +30,8 @@ mySprite.vx = 50
 ```
 
 ## See also #seealso
+
+[location](/reference/scene/location)
 
 ```jres
 {

--- a/libs/game/docs/reference/scene/tilemap-location.md
+++ b/libs/game/docs/reference/scene/tilemap-location.md
@@ -1,0 +1,83 @@
+# tilemap Location
+
+Get the location of a sprite on the tilemap.
+
+```sig
+sprites.create(null).tilemapLocation()
+```
+
+A tile location object represents a column and a row position in the tilemap. Location objects are used to get and set tiles or tile information for specific places in the tilemap.
+
+The tile that is under the center of the sprite is considered as the sprite's tilemap **location**. A sprite may overlap multiple tiles but the tile under the sprite's `x` and `y` coordinate properties is its tilemap location.
+
+## Returns
+
+* a tile location object for the location of the sprite on the tilemap.
+
+## Example #example
+
+Make a grid tilemap with two tile colors. Create a sprite to appear on the tilemap. Display the column and row postion of the sprite on the tilemap.
+
+```blocks
+tiles.setCurrentTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . 4 4 4 . . . . 4 4 4 . . . . 
+    . 4 5 5 5 e . . e 5 5 5 4 . . . 
+    4 5 5 5 5 5 e e 5 5 5 5 5 4 . . 
+    4 5 5 4 4 5 5 5 5 4 4 5 5 4 . . 
+    e 5 4 4 5 5 5 5 5 5 4 4 5 e . . 
+    . e e 5 5 5 5 5 5 5 5 e e . . . 
+    . . e 5 f 5 5 5 5 f 5 e . . . . 
+    . . f 5 5 5 4 4 5 5 5 f . . f f 
+    . . f 4 5 5 f f 5 5 6 f . f 5 f 
+    . . . f 6 6 6 6 6 6 4 4 f 5 5 f 
+    . . . f 4 5 5 5 5 5 5 4 4 5 f . 
+    . . . f 5 5 5 5 5 4 5 5 f f . . 
+    . . . f 5 f f f 5 f f 5 f . . . 
+    . . . f f . . f f . . f f . . . 
+    `, SpriteKind.Player)
+let tmLocation = mySprite.tilemapLocation()
+mySprite.sayText("col: " + tmLocation.column + " row: " + tmLocation.row)
+```
+
+## See also #seealso
+
+[get tile location](/reference/scene/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAACZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAyMDEwMjAxMDIwMTAyMDEwMjAxMDEwMjAxMDIwMTAyMDEwMjAxMDIwMjAxMDIwMTAyMDEwMjAxMDIwMTAxMDIwMTAyMDEwMjAxMDIwMTAyMDIwMTAyMDEwMjAxMDIwMTAyMDEwMTAyMDEwMjAxMDIwMTAyMDEwMjAyMDEwMjAxMDIwMTAyMDEwMjAxMDEwMjAxMDIwMTAyMDEwMjAxMDIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/scene/tilemap-location.md
+++ b/libs/game/docs/reference/scene/tilemap-location.md
@@ -12,7 +12,7 @@ The tile that is under the center of the sprite is considered as the sprite's ti
 
 ## Returns
 
-* a tile location object for the location of the sprite on the tilemap.
+* a tile [location](/reference/scene/location) object for the location of the sprite on the tilemap.
 
 ## Example #example
 

--- a/libs/game/docs/reference/sprites/destroy-all-sprites-of-kind.md
+++ b/libs/game/docs/reference/sprites/destroy-all-sprites-of-kind.md
@@ -1,0 +1,74 @@
+# destroy All Sprites Of Kind
+
+Destroy all the sprites of a certain kind.
+
+```sig
+sprites.destroyAllSpritesOfKind(SpriteKind.Enemy)
+```
+
+You can destroy all of the current sprites of a particular kind. For example, you could explode all of the `Enemy` sprites in your game by destroying them with a disintegrating particle effect.
+
+## Parameters
+
+* **kind**: the kind of the sprites you want to destroy, such as `Player` or `Enemy`.
+* **effect**: a particle effect to show when a sprite is destroyed.
+* **duration**: the time in milliseconds that the **effect** will show.
+
+## Example #example
+
+Make a game where your player must avoid contact with `Blob` sprites to stay alive. Send the blobs at random speeds from the right side of the screen. Give your player a superpower to zap all of the current blobs with one press of button `A`.
+
+```blocks
+namespace SpriteKind {
+    export const Blob = SpriteKind.create()
+}
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    sprites.destroyAllSpritesOfKind(SpriteKind.Blob, effects.disintegrate, 100)
+})
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Blob, function (sprite, otherSprite) {
+    info.changeLifeBy(-1)
+})
+let blob: Sprite = null
+info.setLife(3)
+let mySprite = sprites.create(img`
+    . . . . . f f f f . . . . . 
+    . . . f f 5 5 5 5 f f . . . 
+    . . f 5 5 5 5 5 5 5 5 f . . 
+    . f 5 5 5 5 5 5 5 5 5 5 f . 
+    . f 5 5 5 d b b d 5 5 5 f . 
+    f 5 5 5 b 4 4 4 4 b 5 5 5 f 
+    f 5 5 c c 4 4 4 4 c c 5 5 f 
+    f b b f b f 4 4 f b f b b f 
+    f b b 4 1 f d d f 1 4 b b f 
+    . f b f d d d d d d f b f . 
+    . f e f e 4 4 4 4 e f e f . 
+    . e 4 f 6 9 9 9 9 6 f 4 e . 
+    . 4 d c 9 9 9 9 9 9 c d 4 . 
+    . 4 f b 3 b 3 b 3 b b f 4 . 
+    . . f f 3 b 3 b 3 3 f f . . 
+    . . . . f f b b f f . . . . 
+    `, SpriteKind.Player)
+controller.moveSprite(mySprite)
+mySprite.left = 10
+game.onUpdateInterval(500, function () {
+    blob = sprites.create(img`
+        . 2 2 2 . 2 2 . 
+        2 2 5 2 2 2 2 2 
+        2 f 2 2 5 2 2 . 
+        2 2 2 2 2 2 2 2 
+        2 2 2 2 2 2 2 2 
+        2 2 f 2 f 2 2 2 
+        . 2 2 2 2 2 2 . 
+        . 2 . 2 2 5 2 . 
+        `, SpriteKind.Blob)
+    blob.setFlag(SpriteFlag.AutoDestroy, true)
+    blob.setPosition(scene.screenWidth(), randint(0, scene.screenHeight()))
+    blob.vx = randint(-10, -50)
+})
+```
+
+## See also #seealso
+
+[start effect](/reference/sprites/sprite/start-effect),
+[destroy](/reference/sprites/sprite/destroy),
+[on destroyed](/reference/sprites/on-destroyed),

--- a/libs/game/docs/reference/sprites/sprite/scale.md
+++ b/libs/game/docs/reference/sprites/sprite/scale.md
@@ -27,11 +27,11 @@ Set the scale for the sprite.
 ```block
 let mySprite: Sprite = null
 
-mySprite.scale = 0
+mySprite.scale = 2
 ```
 
 ```typescript-ignore
-mySprite.scale = 0
+mySprite.scale = 2
 ```
 
 ### Parameter

--- a/libs/game/docs/reference/sprites/sprite/sx.md
+++ b/libs/game/docs/reference/sprites/sprite/sx.md
@@ -27,11 +27,11 @@ Set the width scale for the sprite.
 ```block
 let mySprite: Sprite = null
 
-mySprite.sx = 0
+mySprite.sx = 2
 ```
 
 ```typescript-ignore
-mySprite.sx = 0
+mySprite.sx = 2
 ```
 
 ### Parameter

--- a/libs/game/docs/reference/sprites/sprite/sy.md
+++ b/libs/game/docs/reference/sprites/sprite/sy.md
@@ -27,11 +27,11 @@ Set the height scale for the sprite.
 ```block
 let mySprite: Sprite = null
 
-mySprite.sy = 0
+mySprite.sy = 2
 ```
 
 ```typescript-ignore
-mySprite.sy = 0
+mySprite.sy = 2
 ```
 
 ### Parameter

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -76,7 +76,7 @@ namespace sprites {
      * Destroys all sprites of the given kind.
      */
     //% group="Effects"
-    //% weight=79
+    //% weight=79 help=sprites/destroy-all-sprites-of-kind
     //% blockId=sprites_destroy_all_sprites_of_kind
     //% block="destroy all sprites of kind $kind || with $effect effect for $duration ms"
     //% kind.shadow=spritekind

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -662,7 +662,7 @@ namespace tiles {
     //% block="tile at $location is wall"
     //% location.shadow=mapgettile
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% weight=30
+    //% weight=30 help=scene/tile-at-location-is-wall
     export function tileAtLocationIsWall(location: Location): boolean {
         if (!location || !location.tileMap) return false;
         return location.isWall();
@@ -676,7 +676,7 @@ namespace tiles {
     //% blockId=tiles_image_at_location
     //% block="tile image at $location"
     //% location.shadow=mapgettile
-    //% weight=0
+    //% weight=0 help=scene/tile-image-at-location
     //% blockNamespace="scene" group="Locations"
     export function tileImageAtLocation(location: Location): Image {
         const scene = game.currentScene();
@@ -692,7 +692,7 @@ namespace tiles {
     //% blockId=mapplaceontile block="place $sprite=variables_get(mySprite) on top of $loc"
     //% loc.shadow=mapgettile
     //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
-    //% help=scene/place
+    //% help=scene/place-on-tile
     //% weight=100
     export function placeOnTile(sprite: Sprite, loc: Location): void {
         if (!sprite || !loc || !loc.tileMap) return;


### PR DESCRIPTION
Put in the missing reference pages for tilemap and sprites API updates.

- [x] Add new tilemap location API pages.
- [x] Add a page for `destroyAllSpritesOfKind()`
- [x] Add a `Location` object page describing it's props.
- [x] Update linking in location pages.
- [x] Set help paths for reference pages.

**Note:** A new page is included for `tiles.Location` but there is no way to link context help for it to this block-

![image](https://user-images.githubusercontent.com/27789908/153289187-69cf307f-58b5-4158-bd03-abc917ed7412.png)

This is the same as the situation with the sprite properties too.

Closes https://github.com/microsoft/pxt-arcade/issues/4590