### PR TITLE
Allow extension authors to register additional button handlers

### DIFF
--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -93,6 +93,7 @@ namespace scene {
         particleSources: particles.ParticleSource[];
         controlledSprites: controller.ControlledSprite[][];
         followingSprites: sprites.FollowingSprite[];
+        buttonEventHandlers: controller.ButtonEventHandlerState[];
 
         private _millis: number;
         private _data: any;
@@ -116,6 +117,7 @@ namespace scene {
             this.gameForeverHandlers = [];
             this.spritesByKind = {};
             this.controlledSprites = [];
+            this.buttonEventHandlers = [];
             this._data = {};
             this._millis = 0;
         }


### PR DESCRIPTION
I'd like to sneak this in for the patch release.

Currently only one event handler can be registered for each button; this means that extensions (like the storytelling extension) can't use any of the button events without overwriting the user's code. Thus, you have to resort to [terrible hacks](https://github.com/microsoft/arcade-storytelling/blob/main/menuState.ts#L93) to replicate this behavior.

This simply adds a JavaScript-only API that lets you add and remove event handlers in addition to the usual onEvent behavior. To the user, there will be absolutely no change. Registering more than one event for a button will override it.

I tested this pretty thoroughly in the sim, including:
* Registering multiple button handlers with onEvent to make sure they still get overwritten
* Doing lots of scene push/pop shenaningans to make sure events are saved/restored for the scene