### PR TITLE
Make tilemap data public

### DIFF
--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -319,7 +319,7 @@ namespace tiles {
             }
         }
 
-        protected get data(): TileMapData {
+        get data(): TileMapData {
             return this._map;
         }
 


### PR DESCRIPTION
This is correcting something we did wrong back in the day: making it so that you can access the current tilemap.

I do not remember why we ever restricted this, but I don't think there is any reason to do so now. Right @jwunderl?