### PR TITLE
Fix unload not working when map is undefined

### DIFF
--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -116,7 +116,6 @@ namespace scene {
         if (!scene.tileMap)
             scene.tileMap = new tiles.TileMap();
         scene.tileMap.setData(map);
-        scene.tileMap.scale = map.scale;
     }
 
      /**

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -365,6 +365,9 @@ namespace tiles {
             }
 
             this._map = map;
+            if (map) {
+                this._scale = map.scale;
+            }
 
             if (this.handlerState && previous !== map && map) {
                 for (const eventHandler of this.handlerState) {

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -357,11 +357,9 @@ namespace tiles {
             const previous = this._map;
 
             if (this.handlerState && previous !== map && previous) {
-                if (map) {
-                    for (const eventHandler of this.handlerState) {
-                        if (eventHandler.event === TileMapEvent.Unloaded) {
-                            eventHandler.callback(previous);
-                        }
+                for (const eventHandler of this.handlerState) {
+                    if (eventHandler.event === TileMapEvent.Unloaded) {
+                        eventHandler.callback(previous);
                     }
                 }
             }


### PR DESCRIPTION
Fixing a dumb bug that I made when I was refactoring this code. We don't need to check if map is defined to fire the unloaded event.

Also fixes the scale being wrong during the tilemap load event