### PR TITLE
[Stable 9.4] Fix unload not working when map is undefined (#1328)

### DIFF
--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -116,7 +116,6 @@ namespace scene {
         if (!scene.tileMap)
             scene.tileMap = new tiles.TileMap();
         scene.tileMap.setData(map);
-        scene.tileMap.scale = map.scale;
     }
 
      /**

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -357,16 +357,17 @@ namespace tiles {
             const previous = this._map;
 
             if (this.handlerState && previous !== map && previous) {
-                if (map) {
-                    for (const eventHandler of this.handlerState) {
-                        if (eventHandler.event === TileMapEvent.Unloaded) {
-                            eventHandler.callback(previous);
-                        }
+                for (const eventHandler of this.handlerState) {
+                    if (eventHandler.event === TileMapEvent.Unloaded) {
+                        eventHandler.callback(previous);
                     }
                 }
             }
 
             this._map = map;
+            if (map) {
+                this._scale = map.scale;
+            }
 
             if (this.handlerState && previous !== map && map) {
                 for (const eventHandler of this.handlerState) {


### PR DESCRIPTION
Cherry picking a couple of bug fixes I made while implementing the new tilemap extension