### PR TITLE
Update the base 'tilemap' ref pages

### DIFF
--- a/libs/game/docs/reference/tiles/set-current-tilemap.md
+++ b/libs/game/docs/reference/tiles/set-current-tilemap.md
@@ -1,0 +1,90 @@
+# set Current Tilemap
+
+Set a tilemap as the current tilemap for the game scene.
+
+```sig
+tiles.setCurrentTilemap(null)
+```
+
+A [tilemap](/refernece/tiles/tilemap) is a data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
+
+Tilemaps aren't coded by the user but are created using a tilemap editor. Each tilemap in a game project is a named resource and is contained within the project's **assets** collection. In code,a particular tilemap is specified with it's resource name like this:
+
+```typescript
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+## Parameters
+
+* **tilemap**: the [tilemap](/refernece/tiles/tilemap) data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
+
+## Example #example
+
+Create a maze tilemap for a sprite to travel through. Set the tilemap as the scene for the game. Create a sprite and start it travelling in the maze.
+
+```blocks
+tiles.setCurrentTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setPosition(0, 104)
+mySprite.vx = 16
+```
+
+## See also #seealso
+
+[tilemap](/refernece/tiles/tilemap),
+[set tile at](/reference/scene/set-tile-at)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDIwMjAyMDAwMjAyMDAwMTAxMDAwMjAwMDIwMDAyMDIwMDAwMDEwMDAyMDAwMjAwMDIwMDAwMDEwMTAwMDIwMDAyMDIwMjAwMDIwMTAwMDAwMDAwMDAwMDAyMDAwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEyMjIyMjIyMjIyMDIwMDAwMDAyMDAyMjIwMjIyMjAwMjAyMDIyMjAwMDIwMjAyMDIyMDAyMDIyMjAyMjIwMDAwMDAwMjIwMjIyMjIyMjIyMg==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "maze"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/set-current-tilemap.md
+++ b/libs/game/docs/reference/tiles/set-current-tilemap.md
@@ -6,7 +6,7 @@ Set a tilemap as the current tilemap for the game scene.
 tiles.setCurrentTilemap(null)
 ```
 
-A [tilemap](/refernece/tiles/tilemap) is a data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
+A [tilemap](/reference/tiles/tilemap) is a data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
 
 Tilemaps aren't coded by the user but are created using a tilemap editor. Each tilemap in a game project is a named resource and is contained within the project's **assets** collection. In code,a particular tilemap is specified with it's resource name like this:
 
@@ -16,7 +16,7 @@ tiles.setCurrentTilemap(tilemap`level1`)
 
 ## Parameters
 
-* **tilemap**: the [tilemap](/refernece/tiles/tilemap) data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
+* **tilemap**: the [tilemap](/reference/tiles/tilemap) data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
 
 ## Example #example
 
@@ -48,7 +48,7 @@ mySprite.vx = 16
 
 ## See also #seealso
 
-[tilemap](/refernece/tiles/tilemap),
+[tilemap](/reference/tiles/tilemap),
 [set tile at](/reference/scene/set-tile-at)
 
 ```jres

--- a/libs/game/docs/reference/tiles/set-tilemap.md
+++ b/libs/game/docs/reference/tiles/set-tilemap.md
@@ -6,7 +6,7 @@ Set a tilemap as the current tilemap for the game scene.
 tiles.setTilemap(null)
 ```
 
-A [tilemap](/refernece/tiles/tilemap) is a data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
+A [tilemap](/reference/tiles/tilemap) is a data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
 
 Tilemaps aren't coded by the user but are created using a tilemap editor. Each tilemap in a game project is a named resource and is contained within the project's **assets** collection. In code, a particular tilemap is specified with it's resource name like this:
 
@@ -16,7 +16,7 @@ tiles.setTilemap(tilemap`level1`)
 
 ## Parameters
 
-* **tilemap**: the [tilemap](/refernece/tiles/tilemap) data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
+* **tilemap**: the [tilemap](/reference/tiles/tilemap) data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
 
 ## Example #example
 
@@ -48,7 +48,7 @@ mySprite.vx = 16
 
 ## See also #seealso
 
-[tilemap](/refernece/tiles/tilemap),
+[tilemap](/reference/tiles/tilemap),
 [set tile at](/reference/scene/set-tile-at)
 
 ```jres

--- a/libs/game/docs/reference/tiles/set-tilemap.md
+++ b/libs/game/docs/reference/tiles/set-tilemap.md
@@ -1,0 +1,90 @@
+# set Tilemap
+
+Set a tilemap as the current tilemap for the game scene.
+
+```sig
+tiles.setTilemap(null)
+```
+
+A [tilemap](/refernece/tiles/tilemap) is a data object that contains the dimensions, layers, and tile list for a tile mapping to set as the scene for a game. A game program can have more than one tilemap defined and the game's scene or _level_ can change by setting a different tilemap at certain times during a game.
+
+Tilemaps aren't coded by the user but are created using a tilemap editor. Each tilemap in a game project is a named resource and is contained within the project's **assets** collection. In code, a particular tilemap is specified with it's resource name like this:
+
+```typescript
+tiles.setTilemap(tilemap`level1`)
+```
+
+## Parameters
+
+* **tilemap**: the [tilemap](/refernece/tiles/tilemap) data containing the tilemap layout and tiles to set for the game scene. The tilemap can be specified by it's resource name, such as: `` tilemap`level1` ``.
+
+## Example #example
+
+Create a maze tilemap for a sprite to travel through. Set the tilemap as the scene for the game. Create a sprite and start it travelling in the maze.
+
+```blocks
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . 5 5 5 5 5 5 5 5 5 5 5 5 . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . 5 5 5 5 5 5 5 5 5 5 . . . 
+    . . . . . 5 5 5 5 5 5 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setPosition(0, 104)
+mySprite.vx = 16
+```
+
+## See also #seealso
+
+[tilemap](/refernece/tiles/tilemap),
+[set tile at](/reference/scene/set-tile-at)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDEwMTAwMDIwMjAyMDAwMjAyMDAwMTAxMDAwMjAwMDIwMDAyMDIwMDAwMDEwMDAyMDAwMjAwMDIwMDAwMDEwMTAwMDIwMDAyMDIwMjAwMDIwMTAwMDAwMDAwMDAwMDAyMDAwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEyMjIyMjIyMjIyMDIwMDAwMDAyMDAyMjIwMjIyMjAwMjAyMDIyMjAwMDIwMjAyMDIyMDAyMDIyMjAyMjIwMDAwMDAwMjIwMjIyMjIyMjIyMg==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "maze"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/tilemap.md
+++ b/libs/game/docs/reference/tiles/tilemap.md
@@ -1,0 +1,145 @@
+# tilemap
+
+A tilemap object that defines a player level for the game scene.
+
+```sig
+tiles._tilemapEditor(null)
+```
+
+A **tilemap** is a data object that contains the dimensions, layers, and tiles for a tile mapping used to set the scene of a game.
+
+## Creating and using tilemaps
+
+Tilemaps aren't coded by the user but are created using a tilemap editor. When you add a tilemap to your project, it contains a default layout having all of it rows and columns filled with transparent tiles.
+
+```block
+tiles.setCurrentTilemap(tilemap`level2`)
+```
+
+You modify the tilemap using the Tilemap Editor. When coding with blocks, the Tilemap Editor will open when you click on the map image in the tilemap block. If you're editing code, the Tilemap Editor opens by clicking the map symbol in the line of code where you use the tilemap.
+
+You design your game scene, or _level_, using the tiles your create or by chosing some from the tile library. You also can set the tilemap size and tile attributes. The example here shows a tilemap created for a maze game: 
+
+```block
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+After editing, a tilemap is saved as a project asset. The tilemap is defined as a level and assigned an identifier like `level1`. In code, you use the tilemap with its identifier like this:
+
+```typescript-ignore
+tiles.setCurrentTilemap(tilemap`level1`)
+```
+
+You can use a tilemap directly in scene and tile operations, or as an assigned variable:
+
+```block
+let myTilemap = tilemap`level1`
+tiles.setCurrentTilemap(myTilemap)
+```
+
+## The tilemap object
+
+Tilemaps are complex data objects and are defined as levels which contain tiles at various row and column locations. When a tilemap is added to a project, the project assets will include both the tilemap and its tiles. A tilemap's asset data might look like the following:
+
+```typescript-ignore
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile3": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAyMDAwMDAwMDEwMTAwMDMwMzAwMDIwMjAwMDAwMDAxMDAwMDAzMDAwMDAwMDAwMDAxMDEwMDAwMDAwMDAzMDAwMDAwMDEwMDAwMDIwMDAwMDMwMDAzMDAwMTAxMDAwMjAyMDAwMDAwMDMwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```
+
+## See also
+
+[set current tilemap](/reference/tiles/set-current-tilemap)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile3": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"    
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAyMDAwMDAwMDEwMTAwMDMwMzAwMDIwMjAwMDAwMDAxMDAwMDAzMDAwMDAwMDAwMDAxMDEwMDAwMDAwMDAzMDAwMDAwMDEwMDAwMDIwMDAwMDMwMDAzMDAwMTAxMDAwMjAyMDAwMDAwMDMwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3"
+        ],
+        "displayName": "level1"
+    },
+    "level2": {
+        "id": "level2",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16"
+        ],
+        "displayName": "level4"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -596,7 +596,7 @@ namespace tiles {
     //% tilemap.fieldOptions.filter="tile"
     //% tilemap.fieldOptions.taggedTemplate="tilemap"
     //% blockNamespace="scene" duplicateShadowOnDrag
-    //% help=scene/set-tilemap
+    //% help=tiles/set-tilemap
     //% deprecated=1
     export function setTilemap(tilemap: TileMapData) {
         setCurrentTilemap(tilemap);
@@ -611,7 +611,7 @@ namespace tiles {
     //% weight=201 blockGap=8
     //% tilemap.shadow=tiles_tilemap_editor
     //% blockNamespace="scene" group="Tilemaps" duplicateShadowOnDrag
-    //% help=tiles/set-tile-map
+    //% help=tiles/set-current-tilemap
     export function setCurrentTilemap(tilemap: TileMapData) {
         scene.setTileMapLevel(tilemap);
     }
@@ -809,6 +809,7 @@ namespace tiles {
     //% tilemap.fieldOptions.filter="tile"
     //% tilemap.fieldOptions.taggedTemplate="tilemap"
     //% blockNamespace="scene" group="Tilemaps" duplicateShadowOnDrag
+    //% help=tiles/tilemap
     export function _tilemapEditor(tilemap: TileMapData): TileMapData {
         return tilemap;
     }


### PR DESCRIPTION
Needed to update the 'set' tilemap pages and move them to `./tiles`. Also, I added a `tilemap` object reference page in order to link it from the other pages. I think we'll migrate the other tile docs from the `./scene` to folder to `./tiles`  in a follow on PR.