### PR TITLE
Tiles reference pages migrate

### DIFF
--- a/libs/game/docs/reference/tiles/get-neighboring-location.md
+++ b/libs/game/docs/reference/tiles/get-neighboring-location.md
@@ -1,0 +1,123 @@
+# get Neighboring Location
+
+Get the location of a tile next to this one.
+
+```sig
+tiles.getTileLocation(0, 0).getNeighboringLocation(CollisionDirection.Top)
+```
+
+A neighboring tile is one that is immediately to the `left`, `right`, `top`, or `bottom` side of the current tile. You can specify the side of the neighboring tile you want the location for.
+
+## Parameters
+
+* **direction**: the direction side for the neighbor tile from this tile. The directions to choose from are `left`, `right`, `top`, or `bottom`.
+
+## Returns
+
+* a [location](/reference/tiles/location) object for the neighbor tile.
+
+## Example #example
+
+Rotate a donut sprite around adjacent tiles in a tilemap.
+
+```blocks
+let nextSpot: tiles.Location = null
+let rotation = 0
+tiles.setCurrentTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . b b b b a a . . . . 
+    . . . . b b d d d 3 3 3 a a . . 
+    . . . b d d d 3 3 3 3 3 3 a a . 
+    . . b d d 3 3 3 3 3 3 3 3 3 a . 
+    . b 3 d 3 3 3 3 3 b 3 3 3 3 a b 
+    . b 3 3 3 3 3 a a 3 3 3 3 3 a b 
+    b 3 3 3 3 3 a a 3 3 3 3 d a 4 b 
+    b 3 3 3 3 b a 3 3 3 3 3 d a 4 b 
+    b 3 3 3 3 3 3 3 3 3 3 d a 4 4 e 
+    a 3 3 3 3 3 3 3 3 3 d a 4 4 4 e 
+    a 3 3 3 3 3 3 3 d d a 4 4 4 e . 
+    a a 3 3 3 d d d a a 4 4 4 e e . 
+    . e a a a a a a 4 4 4 4 e e . . 
+    . . e e b b 4 4 4 4 b e e . . . 
+    . . . e e e e e e e e . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.x = mySprite.x - mySprite.width
+game.onUpdateInterval(1000, function () {
+    if (rotation == 0) {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Right)
+    } else if (rotation == 1) {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Bottom)
+    } else if (rotation == 2) {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Left)
+    } else {
+        nextSpot = mySprite.tilemapLocation().getNeighboringLocation(CollisionDirection.Top)
+    }
+    mySprite.setPosition(nextSpot.x, nextSpot.y)
+    rotation += 1
+    if (rotation > 3) {
+        rotation = 0
+    }
+})
+```
+
+## See also #seealso
+
+[get tile location](/reference/tiles/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile3": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile4": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMzAyMDMwMjAzMDIwMzAyMDEwMTAyMDMwMjAzMDIwMzAyMDMwMTAxMDMwMjAzMDIwMzAyMDMwMjAxMDEwMjAzMDIwMzAyMDMwMjAzMDEwMTAzMDIwMzAyMDMwMjAzMDIwMTAxMDIwMzAyMDMwMjAzMDIwMzAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/get-tiles-by-type.md
+++ b/libs/game/docs/reference/tiles/get-tiles-by-type.md
@@ -1,52 +1,86 @@
 # get Tiles By Type
 
-Get a list of locations in the tilemap that have the same tile image.
+Return an array of tile locations from the tilemap that contain the specified tile.
 
 ```sig
-tiles.getTilesByType(0)
+tiles.getTilesByType(null)
 ```
-
-All the locations in the tilemap with the chosen **image** are returned in an array of [tiles](/types/tile). You can use this array to change or replace the tiles as one group.
 
 ## Parameters
 
-* **image**: the chosen tile image. This function returns all locations with this image
+* **tile**: a tile [image](/types/image) to search the tilemap for.
 
 ## Returns
 
-* an [array](/types/array) of [tiles](/types/tile) from the tilemap that have the same  **image**.
+* an [array](/types/array) of tile locations from the tilemap that have the tile specified in **tile**.
 
 ## Example #example
 
-Get a list of all the tiles in the center of the tilemap. Replace all of them with the tile type used for the border.
+Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, find the column tiles in the tilemap and set them as either wall tiles or regular tiles.
 
 ```blocks
-let image = img`
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-`;
-// TODO tiles.setTilemap(tiles.createTilemap(null, 0, 8 ** 8, 9)); 
-for (let tile of tiles.getTilesByType(image)) {
-    tiles.setTileAt(tile, image)
-    pause(500)
-}
+let isWall = false
+tiles.setTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setBounceOnWall(true)
+mySprite.vx = 80
+mySprite.vy = 70
+game.onUpdateInterval(5000, function () {
+    isWall = !(isWall)
+    for (let wallTile of tiles.getTilesByType(assets.tile`myTile`)) {
+        tiles.setWallAt(wallTile, isWall)
+    }
+})
 ```
 
 ## See also #seealso
 
-[get tile location](/reference/tiles/get-tile-location),
-[set tile at](/reference/tiles/set-tile-at)
+[get tile location](/reference/tiles/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/location.md
+++ b/libs/game/docs/reference/tiles/location.md
@@ -1,0 +1,246 @@
+# Location
+
+The Location object contains the postition information of a game element on the tilemap.
+
+## column (property)
+
+Get a tile column position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let col = location.column
+```
+
+```typescript-ignore
+let col = location.column
+```
+
+### Returns
+
+* a [number](/types/number) that is the tile column position of object on the tilemap.
+
+## row (property)
+
+Get a tile row position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let row = location.row
+```
+
+```typescript-ignore
+let row = location.row
+```
+
+### Returns
+
+* a [number](/types/number) that is the tile row position of object on the tilemap.
+
+## x (property)
+
+Get the horizontal center position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let horz = location.x
+```
+
+```typescript-ignore
+let horz = location.x
+```
+
+### Returns
+
+* a [number](/types/number) that is the current horizontal center position, in pixels, of the object on the tilemap.
+
+## y (property)
+
+Get the vertical center position of an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let vert = location.y
+```
+
+```typescript-ignore
+let vert = location.y
+```
+
+### Returns
+
+* a [number](/types/number) that is the vertical center position, in pixels, of object on the tilemap.
+
+## left (property)
+
+Get the of position of left side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let left = location.left
+```
+
+```typescript-ignore
+let left = location.left
+```
+
+### Returns
+
+* a [number](/types/number) that is the left side, in pixels, of object on the tilemap.
+
+## right (property)
+
+Get the of position of right side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let right = location.right
+```
+
+```typescript-ignore
+let right = location.right
+```
+
+### Returns
+
+* a [number](/types/number) that is the right side, in pixels, of object on the tilemap.
+
+## top (property)
+
+Get the of position of top side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let top = location.top
+```
+
+```typescript-ignore
+let top = location.top
+```
+
+### Returns
+
+* a [number](/types/number) that is the right side, in pixels, of object on the tilemap.
+
+## bottom (property)
+
+Get the of position of bottom side an object on the tilemap.
+
+```block
+let location: tiles.Location = null
+
+let bottom = location.bottom
+```
+
+```typescript-ignore
+let bottom = location.bottom
+```
+
+### Returns
+
+* a [number](/types/number) that is the right side, in pixels, of object on the tilemap.
+
+## Example #example
+
+Make checkered table cloth with tiles on a tilemap. Create a hamburger sprite and randomly locate it on the table cloth. Find out where the hamburger is and display its location.
+
+```blocks
+tiles.setCurrentTilemap(tilemap`level1`)
+let mySprite = sprites.create(img`
+    ...........ccccc66666...........
+    ........ccc4444444444666........
+    ......cc444444444bb4444466......
+    .....cb4444bb4444b5b444444b.....
+    ....eb4444b5b44444b44444444b....
+    ...ebb44444b4444444444b444446...
+    ..eb6bb444444444bb444b5b444446..
+    ..e6bb5b44444444b5b444b44bb44e..
+    .e66b4b4444444444b4444444b5b44e.
+    .e6bb444444444444444444444bb44e.
+    eb66b44444bb444444444444444444be
+    eb66bb444b5b44444444bb44444444be
+    fb666b444bb444444444b5b4444444bf
+    fcb666b44444444444444bb444444bcf
+    .fbb6666b44444444444444444444bf.
+    .efbb66666bb4444444444444444bfe.
+    .86fcbb66666bbb44444444444bcc688
+    8772effcbbbbbbbbbbbbbbbbcfc22778
+    87722222cccccccccccccccc22226678
+    f866622222222222222222222276686f
+    fef866677766667777776667777fffef
+    fbff877768f86777777666776fffffbf
+    fbeffeefffeff7766688effeeeefeb6f
+    f6bfffeffeeeeeeeeeeeeefeeeeebb6e
+    f66ddfffffeeeffeffeeeeeffeedb46e
+    .c66ddd4effffffeeeeeffff4ddb46e.
+    .fc6b4dddddddddddddddddddb444ee.
+    ..ff6bb444444444444444444444ee..
+    ....ffbbbb4444444444444444ee....
+    ......ffebbbbbb44444444eee......
+    .........fffffffcccccee.........
+    ................................
+    `, SpriteKind.Player)
+mySprite.setPosition(randint(16, 144), randint(16, 104))
+let location = mySprite.tilemapLocation()
+let displayString = "My hamburger is at "
+displayString = "" + displayString + "x = "
+displayString = "" + displayString + location.x + ", y = " + location.y
+displayString = "" + displayString + " and over the tile at column = "
+displayString = "" + displayString + location.column + ", row = " + location.row
+game.showLongText(displayString, DialogLayout.Bottom)
+```
+
+## See also #seealso
+
+[get neighboring location](/reference/tiles/get-neighboring-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile3": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "tile4": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAzMDEwMzAxMDMwMTAzMDEwMzAxMDEwMzAyMDMwMjAzMDIwMzAyMDMwMzAyMDMwMjAzMDIwMzAyMDMwMTAxMDMwMjAzMDIwMzAyMDMwMjAzMDMwMjAzMDIwMzAyMDMwMjAzMDEwMTAzMDIwMzAyMDMwMjAzMDIwMzAzMDIwMzAyMDMwMjAzMDIwMzAxMDEwMzAxMDMwMTAzMDEwMzAxMDMwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/place-on-random-tile.md
+++ b/libs/game/docs/reference/tiles/place-on-random-tile.md
@@ -3,22 +3,22 @@
 Move a sprite's position to the center of a random tile in the scene.
 
 ```sig
-tiles.placeOnRandomTile(null, 0)
+tiles.placeOnRandomTile(null, null)
 ```
 
-You a can place a sprite on top of a random tile in the tile map. Use the tile image to select which group of tiles the sprite can be placed on.
+You can make a sprite locate itself right on top of a random tile in the tilemap. Choose a tile in the tilemap to indicate which type of tile to have the sprite randomly placed on. If there is only one tile of that type, the sprite will always go to that tile. If multiple tiles of the same type are in the tilemap, then the sprite will randomly locate on any one of them.
 
 ## Parameters
 
 * **sprite**: the sprite to move onto the tile.
-* **image**: the tile [image](/types/image). The sprite will be randomly placed on a tile that matches this image
+* **tile**: the tile type to randomly select in the tilemap.
 
 ## Example #example
 
-Make a tilemap with two solid color tiles. Create a circle sprite and randomly place the sprite on only the brown tiles.
+Make a tilemap with several different tiles. Create a round shaped sprite. Ramdomly place the sprite on a blue tile.
 
 ```blocks
-tiles.setTilemap(tilemap`level`)
+tiles.setTilemap(tilemap`level1`)
 let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     . . . . . . . . . . . . . . . . 
@@ -37,15 +37,13 @@ let mySprite = sprites.create(img`
     . . . . . . . . . . . . . . . . 
     . . . . . . . . . . . . . . . . 
     `, SpriteKind.Player)
-forever(function () {
-    tiles.placeOnRandomTile(mySprite, assets.tile`brownTile`)
-    pause(1000)
-})
+pause(1000)
+tiles.placeOnRandomTile(mySprite, assets.tile`myTile`)
 ```
 
 ## See also #seealso
 
-[get tile location](/reference/tiles/get-tile-location)
+[place on tile](/reference/tiles/place-on-tile)
 
 ```jres
 {
@@ -54,28 +52,63 @@ forever(function () {
         "mimeType": "image/x-mkcd-f4",
         "tilemapTile": true
     },
-    "redTile": {
+    "tile7": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile5"
+    },
+    "tile1": {
+        "data": "hwQQABAAAACIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "tile2": {
         "data": "hwQQABAAAAAiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIg==",
         "mimeType": "image/x-mkcd-f4",
         "tilemapTile": true,
-        "displayName": "redTile"
+        "displayName": "myTile0"
     },
-    "brownTile": {
-        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+    "tile3": {
+        "data": "hwQQABAAAABVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==",
         "mimeType": "image/x-mkcd-f4",
         "tilemapTile": true,
-        "displayName": "brownTile"
+        "displayName": "myTile1"
     },
-    "level": {
-        "id": "level",
+    "tile4": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile2"
+    },
+    "tile5": {
+        "data": "hwQQABAAAACqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile3"
+    },
+    "tile6": {
+        "data": "hwQQABAAAACZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmQ==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile4"
+    },
+    "level1": {
+        "id": "level1",
         "mimeType": "application/mkcd-tilemap",
-        "data": "MTAwNjAwMDUwMDAyMDAwMTAwMDIwMDAwMDIwMDAxMDAwMjAxMDAwMjAwMDEwMDAwMDEwMDAyMDAwMTAyMDAwMTAwMDIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDAwMDAzMDAwMDAwMDAwMDA2MDAwMDAwMDAwMDAyMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDMwMDAwMDAwMDAwMDAwMDA1MDAwMDAwMDAwMTAwMDAwMDAwMDAwMDA0MDAwMDAwMDAwMDAwMDYwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
         "tileset": [
             "myTiles.transparency16",
-            "myTiles.redTile",
-            "myTiles.brownTile"
+            "myTiles.tile1",
+            "myTiles.tile2",
+            "myTiles.tile3",
+            "myTiles.tile4",
+            "myTiles.tile5",
+            "myTiles.tile6",
+            "myTiles.tile7"
         ],
-        "displayName": "level"
+        "displayName": "level1"
     },
     "*": {
         "mimeType": "image/x-mkcd-f4",

--- a/libs/game/docs/reference/tiles/place-on-tile.md
+++ b/libs/game/docs/reference/tiles/place-on-tile.md
@@ -1,25 +1,21 @@
-# get Tile Location
+# place On Tile
 
-Get the tile location object for a particular column and row position in the tilemap.
+Move a sprite's position to the center of a tile location in the tilemap.
 
 ```sig
-tiles.getTileLocation(0, 0)
+tiles.placeOnTile(null, tiles.getTileLocation(0, 0))
 ```
 
-A tile location object represents a column and a row position in the tilemap. Location objects are used to get and set tiles or tile information for specific places in the tilemap.
+A sprite will locate itself on top of a tile in the tilemap using a tilemap location object. A location object contains a tile row value and a tile column value.
 
 ## Parameters
 
-* **col**: a [number](/types/number) that is the tilemap column of the tile location.
-* **row**: a [number](/types/number) that is the tilemap row of the tile location.
-
-## Returns
-
-* a tile [location](/reference/tiles/location) object for a given column and row in the tilemap.
+* **sprite**: the sprite to move onto the tile.
+* **loc**: a tile [location](/reference/tiles/location) in the tilemap.
 
 ## Example #example
 
-Make a grid tilemap with two tile colors. Create a round shaped sprite. Ramdomly choose a tile location to place the sprite at in the grid.
+Make a grid tilemap with two tile colors. Create a round shaped sprite. Ramdomly place the sprite on a tile in the grid.
 
 ```blocks
 tiles.setTilemap(tilemap`level1`)
@@ -50,8 +46,8 @@ forever(function () {
 
 ## See also #seealso
 
-[set tile at](/reference/tiles/set-tile-at),
-[place on tile](/reference/tiles/place-on-tile)
+[get tile location](/reference/tiles/get-tile-location),
+[place on random tile](/reference/tiles/place-on-random-tile)
 
 ```jres
 {

--- a/libs/game/docs/reference/tiles/set-tile-at.md
+++ b/libs/game/docs/reference/tiles/set-tile-at.md
@@ -1,48 +1,65 @@
 # set Tile At
 
-Set a location in the tilemap to a specific tile.
+Set a tile at a location in the tilemap.
 
 ```sig
-tiles.setTileAt(null, 0)
+tiles.setTileAt(tiles.getTileLocation(0, 0), null)
 ```
 
-This block allows you to place a tile [image](/types/image) at a specific [tile](/types/tile) location in the map. The tile map will be updated with the new image.
+You can set a tile at a specific column and row in the tilemap using a tile location object. Specify a tile to set in the tilemap and a location for it.
 
 ## Parameters
 
-* **tile**: the [tile](/types/tile) location.
-* **image**: the tile [image](/types/image) to place in this location.
+* **loc**: a tile [location](/reference/tiles/location) in the tilemap.
+* **tile**: the to set in the tilemap.
 
 ## Example #example
 
-Make a scene using a tilemap with border tiles and two tiles in the center. Replace the tiles in the center with the ones used for the border.
+Create an empty tilemap and a solid color tile. Set the solid color tile at different places in the tilemap and replace its previous location with a transparent tile.
 
 ```blocks
-let image = img`
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-a a a a a a a a a a a a a a a a 
-`;
-// TODO tiles.setTilemap(tiles.createTilemap(null, 0, 8 ** 8, 9));
-pause(1000)
-tiles.setTileAt(tiles.getTileLocation(4, 3), image)
-pause(1000)
-tiles.setTileAt(tiles.getTileLocation(5, 3), image)
+tiles.setTilemap(tilemap`level1`)
+let spot = tiles.getTileLocation(0, 0)
+forever(function () {
+    tiles.setTileAt(spot, assets.tile`transparency16`)
+    spot = tiles.getTileLocation(randint(0, 9), randint(0, 6))
+    tiles.setTileAt(spot, assets.tile`myTile`)
+    pause(1000)
+})
 ```
 
 ## See also #seealso
 
-[set tile](/reference/tiles/set-tile), [get tile location](/reference/tiles/get-tile-location)
+[get tile location](/reference/tiles/get-tile-location),
+[place on tile](/reference/tiles/place-on-tile)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/set-wall-at.md
+++ b/libs/game/docs/reference/tiles/set-wall-at.md
@@ -1,87 +1,86 @@
 # set Wall At
 
-Set a wall at a tile location in the tilemap.
+Set a tile as a wall tile in the tilemap.
 
 ```sig
-tiles.setWallAt(null, false)
+tiles.setWallAt(tiles.getTileLocation(0, 0), false)
 ```
 
-Tiles in a tilemap can serve as "wall" tiles to cause an action on a sprite that
-comes in contact with the tile. Sprites have flags ([boolean](/types/boolean)
-settings) that can set certain behavior when the contact a wall tile.
+Wall tiles create a barrier for sprites so that they can't pass through tilemap at the tile location. You can set a tile location in the tilemap as a wall or turn it back to a regular tile.
 
 ## Parameters
 
-* **tile**: the [tile](/types/tile) location.
-* **on**: a [boolean](/types/boolean) value that sets the wall **ON** if `true` or **OFF** if `false` at the tile location.
+* **loc**: a tile [location](/reference/tiles/location) in the tilemap.
+* **on**: a [boolean](/types/boolean) value to set the tile location be a wall tile if `true` or a regular tile if `false`.
 
 ## Example #example
 
-Create a scene with two horizontal walls. Bounce a sprite between the walls.
+Make a column of tiles from top to bottom of the screen. Set a sprite in motion and set it to bounce on walls. Every `5` seconds, set the tiles  in the column to be wall tiles or regular tiles.
 
 ```blocks
-namespace myTiles {
-    //% blockIdentity=images._tile
-    export const tile0 = img`
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-. . . . . . . . . . . . . . . . 
-`
-}
-tiles.setTilemap(tiles.createTilemap(
-            hex`0a0008000000000000000000000009090909090909090909000000000000000000000000000000000000000000000000000000000000000000000000000000000909090909090909090900000000000000000000`,
-            img`
-. . . . . . . . . . 
-. . . . . . . . . . 
-. . . . . . . . . . 
-. . . . . . . . . . 
-. . . . . . . . . . 
-. . . . . . . . . . 
-. . . . . . . . . . 
-. . . . . . . . . . 
-`,
-            [myTiles.tile0,sprites.castle.tilePath4,sprites.castle.tilePath3,sprites.castle.tilePath1,sprites.castle.tilePath9,sprites.castle.tilePath6,sprites.castle.tilePath8,sprites.castle.tilePath7,sprites.castle.tilePath2,sprites.castle.tilePath5],
-            TileScale.Sixteen
-        ))
-for (let index = 0; index <= 9; index++) {
-    tiles.setWallAt(tiles.getTileLocation(index, 1), true)
-    tiles.setWallAt(tiles.getTileLocation(index, 6), true)
-}
+let isWall = false
+tiles.setTilemap(tilemap`level1`)
 let mySprite = sprites.create(img`
-2 5 5 5 5 5 5 5 5 5 5 5 5 5 2 2 
-2 2 2 5 5 5 5 5 5 5 5 5 5 2 2 3 
-7 7 2 2 5 5 5 5 5 5 5 5 2 2 3 3 
-7 7 7 2 2 5 5 5 5 5 5 2 2 3 3 3 
-7 7 7 7 2 5 5 5 5 5 2 2 3 3 3 3 
-7 7 7 7 7 2 5 5 5 5 2 3 3 3 3 3 
-7 7 7 7 7 2 2 5 5 2 2 3 3 3 3 3 
-7 7 7 7 7 7 2 2 2 2 3 3 3 3 3 3 
-7 7 7 7 7 7 7 2 2 3 3 3 3 3 3 3 
-7 7 7 7 7 7 7 2 2 2 2 3 3 3 3 3 
-7 7 7 7 7 7 2 2 4 4 4 2 2 3 3 3 
-7 7 7 7 7 2 4 4 4 4 4 4 2 2 3 3 
-7 7 7 2 2 4 4 4 4 4 4 4 4 2 3 3 
-7 7 2 2 4 4 4 4 4 4 4 4 4 2 2 3 
-7 2 2 4 4 4 4 4 4 4 4 4 4 4 2 3 
-2 2 4 4 4 4 4 4 4 4 4 4 4 4 2 2 
-`, SpriteKind.Player)
-mySprite.setVelocity(50, 50)
-mySprite.setFlag(SpriteFlag.BounceOnWall, true)
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setBounceOnWall(true)
+mySprite.vx = 80
+mySprite.vy = 70
+game.onUpdateInterval(5000, function () {
+    isWall = !(isWall)
+    for (let wallTile of tiles.getTilesByType(assets.tile`myTile`)) {
+        tiles.setWallAt(wallTile, isWall)
+    }
+})
 ```
 
 ## See also #seealso
 
-[set tile](/reference/tiles/set-tile), [get tile location](/reference/tiles/get-tile-location)
+[get tile location](/reference/tiles/get-tile-location),
+[on hit wall](/reference/scene/on-hit-wall)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7g==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMTAwMDAwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDEwMDAwMDAwMDAwMDAwMDAwMDAwMDAxMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/tile-at-location-equals.md
+++ b/libs/game/docs/reference/tiles/tile-at-location-equals.md
@@ -1,0 +1,97 @@
+# tile At Location Equals
+
+Check if a location in the tilemap contains the tile you're looking for.
+
+```sig
+tiles.tileAtLocationEquals(tiles.getTileLocation(0, 0), null)
+```
+
+## Parameters
+
+* **location**: a [location](/reference/scene/location) in the tilemap.
+* **tile**: an [image](/types/image) that matches the tile you're looking for.
+
+## Returns
+
+* a [boolean](/types/boolean) value that is `true` if the tile at **location** matches the **tile** you want to check for. If not, `false` is returned.
+
+## Example #example
+
+Make a tilemap with two columns of wall tiles with a different color for each.  Set a sprite in motion and cause it to bounce on walls. When the sprite contacts a tile, check to see what color the tile is.
+
+```blocks
+scene.onHitWall(SpriteKind.Player, function (sprite, location) {
+    if (tiles.tileAtLocationEquals(location, assets.tile`myTile0`)) {
+        mySprite.sayText("Blue", 500, false)
+    } else if (tiles.tileAtLocationEquals(location, assets.tile`myTile1`)) {
+        mySprite.sayText("Green", 500, false)
+    } else {
+        mySprite.startEffect(effects.fire, 200)
+    }
+})
+let mySprite: Sprite = null
+tiles.setTilemap(tilemap`level1`)
+mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . 1 2 2 2 2 2 2 2 2 2 2 1 . . 
+    . . . 1 2 2 2 2 2 2 2 2 1 . . . 
+    . . . 1 1 2 2 2 2 2 2 1 1 . . . 
+    . . . . . 1 1 1 1 1 1 . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+mySprite.setBounceOnWall(true)
+mySprite.vx = 40
+mySprite.vy = 35
+```
+
+## See also #seealso
+
+[get tile location](/reference/tiles/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAACIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "tile2": {
+        "data": "hwQQABAAAAB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3dw==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile1"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAyMDAwMDAwMDAwMDAwMDAwMDAxMDIwMDAwMDAwMDAwMDAwMDAwMDEwMjAwMDAwMDAwMDAwMDAwMDAwMTAyMDAwMDAwMDAwMDAwMDAwMDAxMDIwMDAwMDAwMDAwMDAwMDAwMDEwMjAwMDAwMDAwMDAwMDAwMDAwMTAyMDAwMDAwMDAwMDAwMDAwMDAxMDIwMDAwMDAwMDAwMDAwMDAwMDEwMjAwMDAwMDIwMDIwMDAwMDAyMDAyMDAwMDAwMjAwMjAwMDAwMDIwMDIwMDAwMDAyMDAyMDAwMDAwMjAwMjAwMDAwMDIwMDIwMDAwMDAyMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1",
+            "myTiles.tile2"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/docs/reference/tiles/tile-at-location-is-wall.md
+++ b/libs/game/docs/reference/tiles/tile-at-location-is-wall.md
@@ -1,0 +1,98 @@
+# tile At Location Is Wall
+
+Check if a tile at a location in the tilemap is also a wall tile.
+
+```sig
+tiles.tileAtLocationIsWall(null)
+```
+
+The tile in the tilemap at the location selected is checked to see if it is set as a wall. After they are placed in the tilemap with the Tilemap Editor, tiles can be set as _wall_ tiles.
+
+## Parameters
+
+* **location**: the [location](/reference/tiles/location) object for the tile to check if it's a wall.
+
+## Returns
+
+* a [boolean](/types/boolean) value that is `true` if the tile at **location** is a wall. The value is `false` if the tile is not a wall.
+
+## Example #example
+
+Set a tilemap with two columns of the same tile. Make one of the columns be all wall tiles. Send a ghost sprite across both colunms so it can detect which one is the wall.
+
+```blocks
+scene.onOverlapTile(SpriteKind.Player, assets.tile`myTile0`, function (sprite, location) {
+    if (tiles.tileAtLocationIsWall(location)) {
+        mySprite.sayText("That's a wall!")
+    } else {
+        mySprite.sayText("Not a wall.")
+    }
+})
+let mySprite: Sprite = null
+scene.setBackgroundColor(11)
+tiles.setCurrentTilemap(tilemap`level1`)
+mySprite = sprites.create(img`
+    ........................
+    ........................
+    ........................
+    ........................
+    ..........ffff..........
+    ........ff1111ff........
+    .......fb111111bf.......
+    .......f11111111f.......
+    ......fd11111111df......
+    ......fd11111111df......
+    ......fddd1111dddf......
+    ......fbdbfddfbdbf......
+    ......fcdcf11fcdcf......
+    .......fb111111bf.......
+    ......fffcdb1bdffff.....
+    ....fc111cbfbfc111cf....
+    ....f1b1b1ffff1b1b1f....
+    ....fbfbffffffbfbfbf....
+    .........ffffff.........
+    ...........fff..........
+    ........................
+    ........................
+    ........................
+    ........................
+    `, SpriteKind.Player)
+mySprite.left = 0
+mySprite.setFlag(SpriteFlag.GhostThroughWalls, true)
+mySprite.vx = 30
+```
+
+## See also #seealso
+
+[get tile location](/reference/tiles/get-tile-location)
+
+```jres
+{
+    "transparency16": {
+        "data": "hwQQABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true
+    },
+    "tile1": {
+        "data": "hwQQABAAAABmZmZmZmZmZmZvZmZmb2ZmZmZm9mZm9mZmZm9mb2ZmZvZmZmZmZm9mZmZmZmZmZmZmZmZmZmZmZmb2ZvZmb2Zm9mZmZmZm9mZmZmZmZmZmZmb2b2b2ZmZmZmZmZmZmZm9mZmb2ZmZmZmb2ZmZm9mZvZmZmZvZmZvZmZmZmZmZmZg==",
+        "mimeType": "image/x-mkcd-f4",
+        "tilemapTile": true,
+        "displayName": "myTile0"
+    },
+    "level1": {
+        "id": "level1",
+        "mimeType": "application/mkcd-tilemap",
+        "data": "MTAwYTAwMDgwMDAwMDAwMDAxMDAwMDAxMDAwMDAwMDAwMDAwMDEwMDAwMDEwMDAwMDAwMDAwMDAwMTAwMDAwMTAwMDAwMDAwMDAwMDAxMDAwMDAxMDAwMDAwMDAwMDAwMDEwMDAwMDEwMDAwMDAwMDAwMDAwMTAwMDAwMTAwMDAwMDAwMDAwMDAxMDAwMDAxMDAwMDAwMDAwMDAwMDEwMDAwMDEwMDAwMDAwMDAwMDAwMjAwMDAwMDAwMDIwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMDAwMDAwMDIwMDAwMDAwMDAyMDAwMDAwMDAwMjAwMDAwMDAwMDIwMA==",
+        "tileset": [
+            "myTiles.transparency16",
+            "myTiles.tile1"
+        ],
+        "displayName": "level1"
+    },
+    "*": {
+        "mimeType": "image/x-mkcd-f4",
+        "dataEncoding": "base64",
+        "namespace": "myTiles"
+    }
+}
+```

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -625,7 +625,7 @@ namespace tiles {
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
-    //% help=scene/set-tile-at
+    //% help=tiles/set-tile-at
     //% weight=70
     export function setTileAt(loc: Location, tile: Image): void {
         const scene = game.currentScene();
@@ -643,7 +643,7 @@ namespace tiles {
     //% blockId=mapsetwallat block="set wall $on at $loc"
     //% on.shadow=toggleOnOff loc.shadow=mapgettile
     //% blockNamespace="scene" group="Tilemap Operations"
-    //% help=scene/set-wall-at
+    //% help=tiles/set-wall-at
     //% weight=60
     export function setWallAt(loc: Location, on: boolean): void {
         const scene = game.currentScene();
@@ -660,7 +660,7 @@ namespace tiles {
     //% blockId=mapgettile block="tilemap col $col row $row"
     //% blockNamespace="scene" group="Locations"
     //% weight=100 blockGap=8
-    //% help=scene/get-tile-location
+    //% help=tiles/get-tile-location
     export function getTileLocation(col: number, row: number): Location {
         const scene = game.currentScene();
         if (col == undefined || row == undefined || !scene.tileMap) return null;
@@ -697,7 +697,7 @@ namespace tiles {
     //% location.shadow=mapgettile
     //% tile.shadow=tileset_tile_picker tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% weight=40 help=scene/tile-at-location-equals
+    //% weight=40 help=tiles/tile-at-location-equals
     export function tileAtLocationEquals(location: Location, tile: Image): boolean {
         const scene = game.currentScene();
         if (!location || !tile || !scene.tileMap) return false;
@@ -713,7 +713,7 @@ namespace tiles {
     //% block="tile at $location is wall"
     //% location.shadow=mapgettile
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% weight=30 help=scene/tile-at-location-is-wall
+    //% weight=30 help=tiles/tile-at-location-is-wall
     export function tileAtLocationIsWall(location: Location): boolean {
         if (!location || !location.tileMap) return false;
         return location.isWall();
@@ -727,7 +727,7 @@ namespace tiles {
     //% blockId=tiles_image_at_location
     //% block="tile image at $location"
     //% location.shadow=mapgettile
-    //% weight=0 help=scene/tile-image-at-location
+    //% weight=0 help=tiles/tile-image-at-location
     //% blockNamespace="scene" group="Locations"
     export function tileImageAtLocation(location: Location): Image {
         const scene = game.currentScene();
@@ -743,7 +743,7 @@ namespace tiles {
     //% blockId=mapplaceontile block="place $sprite=variables_get(mySprite) on top of $loc"
     //% loc.shadow=mapgettile
     //% blockNamespace="scene" group="Tilemap Operations" blockGap=8
-    //% help=scene/place-on-tile
+    //% help=tiles/place-on-tile
     //% weight=100
     export function placeOnTile(sprite: Sprite, loc: Location): void {
         if (!sprite || !loc || !loc.tileMap) return;
@@ -759,7 +759,7 @@ namespace tiles {
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Tilemap Operations"
-    //% help=scene/place-on-random-tile
+    //% help=tiles/place-on-random-tile
     //% weight=90
     export function placeOnRandomTile(sprite: Sprite, tile: Image): void {
         if (!sprite || !game.currentScene().tileMap) return;
@@ -776,7 +776,7 @@ namespace tiles {
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
     //% blockNamespace="scene" group="Locations" blockGap=8
-    //% help=scene/get-tiles-by-type
+    //% help=tiles/get-tiles-by-type
     //% weight=10
     export function getTilesByType(tile: Image): Location[] {
         const scene = game.currentScene();


### PR DESCRIPTION
Migrate the reference pages for the `tiles` namespace into the `./tiles` folder. Update the API help paths.

This is additive such that the similar pages remain in `./scene` until there's a release that contains the `tilemap.ts` with the new help paths. A later PR should then remove the similar pages from `./scene`.

RE: #1332