### PR TITLE
Fix top collision bug by not flooring hitbox

### DIFF
--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -17,11 +17,11 @@ namespace game {
         }
 
         get left() {
-            return Fx.add(this.ox, Fx.floor(this.parent._x));
+            return Fx.add(this.ox, this.parent._x);
         }
 
         get top() {
-            return Fx.add(this.oy, Fx.floor(this.parent._y));
+            return Fx.add(this.oy, this.parent._y);
         }
 
         get right() {


### PR DESCRIPTION
This fixes a bug in the physics engine where sprites would get "caught" on the tilemap when moving up and left/right at the same time. Here's a program that repros it:

https://makecode.com/_CgaY9V0TPhva

Note how the box glitches out when moving across the top row of tiles.

The bug was introduced as part of the scaling fixes: https://github.com/microsoft/pxt-common-packages/pull/1316

But it looks like this particular change was not needed to fix [the bug linked in that pr](https://github.com/microsoft/pxt-arcade/issues/4546); the bug still seems fixed after reverting these two lines.