### PR TITLE
[common] Support for remapping keyboard input

### DIFF
--- a/libs/game/keymap.cpp
+++ b/libs/game/keymap.cpp
@@ -1,0 +1,12 @@
+#include "pxt.h"
+
+namespace keymap {
+
+    void _setPlayerKeys(int player, int up, int down, int left, int right, int A, int B) {
+        // not supported
+    }
+
+    void _setSystemKeys(int screenshot, int gif) {
+        // not supported
+    }
+}

--- a/libs/game/keymap.ts
+++ b/libs/game/keymap.ts
@@ -11,7 +11,7 @@ namespace keymap {
     ): void;
 
     //% shim=keymap::_setSystemKeys
-    declare function _setSystemKeys(screenshot: number, gif: number): void;
+    declare function _setSystemKeys(screenshot: number, gif: number, menu: number, reset: number): void;
 
     /**
      * Sets the keyboard input map for the given player.
@@ -39,15 +39,19 @@ namespace keymap {
      * Sets the keyboard input map for system keys.
      * @param screenshot The key code for 'screenshot'
      * @param gif The key code for 'gif'
+     * @param menu The key code for 'menu'
+     * @param reset The key code for 'reset'
      */
-    export function setSystemKeys(screenshot: KeyCode, gif: KeyCode) {
-        _setSystemKeys(screenshot, gif);
+    export function setSystemKeys(screenshot: KeyCode, gif: KeyCode, menu: KeyCode, reset: KeyCode) {
+        _setSystemKeys(screenshot, gif, menu, reset);
     }
 
     /**
      * Key codes
      */
     export enum KeyCode {
+        None = 0,
+
         Backspace = 8,
         Tab = 9,
         Enter = 13,

--- a/libs/game/keymap.ts
+++ b/libs/game/keymap.ts
@@ -1,0 +1,165 @@
+namespace keymap {
+    //% shim=keymap::_setPlayerKeys
+    declare function _setPlayerKeys(
+        player: number, // player number is 1-based
+        up: number,
+        down: number,
+        left: number,
+        right: number,
+        A: number,
+        B: number
+    ): void;
+
+    //% shim=keymap::_setSystemKeys
+    declare function _setSystemKeys(screenshot: number, gif: number): void;
+
+    /**
+     * Sets the keyboard input map for the given player.
+     * @param player The player number. 1 = Player1, etc.
+     * @param up The key code for 'up'.
+     * @param down The key code for 'down'
+     * @param left The key code for 'left'
+     * @param right The key code for 'right'
+     * @param A The key code for 'A'
+     * @param B The key code for 'B'
+     */
+    export function setPlayerKeys(
+        player: number, // player number is 1-based
+        up: KeyCode,
+        down: KeyCode,
+        left: KeyCode,
+        right: KeyCode,
+        A: KeyCode,
+        B: KeyCode
+    ) {
+        _setPlayerKeys(player, up, down, left, right, A, B);
+    }
+
+    /**
+     * Sets the keyboard input map for system keys.
+     * @param screenshot The key code for 'screenshot'
+     * @param gif The key code for 'gif'
+     */
+    export function setSystemKeys(screenshot: KeyCode, gif: KeyCode) {
+        _setSystemKeys(screenshot, gif);
+    }
+
+    /**
+     * Key codes
+     */
+    export enum KeyCode {
+        Backspace = 8,
+        Tab = 9,
+        Enter = 13,
+        Shift = 16,
+        Ctrl = 17,
+        Alt = 18,
+        PauseBreak = 19,
+        CapsLock = 20,
+        Escape = 27,
+        Space = 32,
+        PageUp = 33,
+        PageDown = 34,
+        End = 35,
+        Home = 36,
+
+        LeftArrow = 37,
+        UpArrow = 38,
+        RightArrow = 39,
+        DownArrow = 40,
+
+        Insert = 45,
+        Delete = 46,
+
+        Zero = 48,
+        One = 49,
+        Two = 50,
+        Three = 51,
+        Four = 52,
+        Five = 53,
+        Six = 54,
+        Seven = 55,
+        Eight = 56,
+        Nine = 57,
+
+        A = 65,
+        B = 66,
+        C = 67,
+        D = 68,
+        E = 69,
+        F = 70,
+        G = 71,
+        H = 72,
+        I = 73,
+        J = 74,
+        K = 75,
+        L = 76,
+        M = 77,
+        N = 78,
+        O = 79,
+        P = 80,
+        Q = 81,
+        R = 82,
+        S = 83,
+        T = 84,
+        U = 85,
+        V = 86,
+        W = 87,
+        X = 88,
+        Y = 89,
+        Z = 90,
+
+        LeftWindowsKey = 91,
+        RightWindowsKey = 92,
+
+        Numpad0 = 96,
+        Numpad1 = 97,
+        Numpad2 = 98,
+        Numpad3 = 99,
+        Numpad4 = 100,
+        Numpad5 = 101,
+        Numpad6 = 102,
+        Numpad7 = 103,
+        Numpad8 = 104,
+        Numpad9 = 105,
+
+        Multiply = 106,
+        Add = 107,
+        Subtract = 109,
+        DecimalPoint = 110,
+        Divide = 111,
+
+        F1 = 112,
+        F2 = 113,
+        F3 = 114,
+        F4 = 115,
+        F5 = 116,
+        F6 = 117,
+        F7 = 118,
+        F8 = 119,
+        F9 = 120,
+        F10 = 121,
+        F11 = 122,
+        F12 = 123,
+
+        NumLock = 144,
+        ScrollLock = 145,
+
+        SemiColon = 186,
+        Equals = 187,
+        Comma = 188,
+        Dash = 189,
+        Period = 190,
+        ForwardSlash = 191,
+        Tilde = 192,
+
+        OpenBracket = 219,
+        ClosedBracket = 221,
+        SingleQuote = 222,
+
+        // Mouse
+        MouseLeftButton = -1,
+        MouseRightButton = -2,
+        MouseCenterButton = -3,
+    }
+}

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -50,7 +50,9 @@
         "assetTemplates.ts",
         "animation.ts",
         "multiplayer.cpp",
-        "multiplayer.ts"
+        "multiplayer.ts",
+        "keymap.cpp",
+        "keymap.ts"
     ],
     "public": true,
     "dependencies": {

--- a/libs/game/sim/keymap.ts
+++ b/libs/game/sim/keymap.ts
@@ -36,8 +36,8 @@ namespace pxsim.keymap {
         getKeymapState().setPlayerKeys(player, up, down, left, right, A, B);
     }
 
-    export function _setSystemKeys(screenshot: number, gif: number) {
-        getKeymapState().setSystemKeys(screenshot, gif);
+    export function _setSystemKeys(screenshot: number, gif: number, menu: number, reset: number) {
+        getKeymapState().setSystemKeys(screenshot, gif, menu, reset);
     }
 }
 
@@ -88,7 +88,9 @@ namespace pxsim {
             // System keymap
             this.setSystemKeys(
                 80, // P - Screenshot
-                82 // R - Gif
+                82, // R - Gif
+                0, // Menu - not mapped
+                0 // Reset - not mapped
             );
 
             // Player 1 alternate mapping. This is cleared when the game sets any player keys explicitly
@@ -136,18 +138,20 @@ namespace pxsim {
             this.saveMap(mapName, keyCodes);
         }
 
-        public setSystemKeys(screenshot: number, gif: number) {
+        public setSystemKeys(screenshot: number, gif: number, menu: number, reset: number) {
             const mapName = "system";
             // Clear existing mapped keys for system
             this.clearMap(mapName);
             this.keymap[screenshot] = Key.Screenshot;
             this.keymap[gif] = Key.Gif;
+            this.keymap[menu] = Key.Menu;
+            this.keymap[reset] = Key.Reset;
             // Remember this mapping
-            this.saveMap(mapName, [screenshot, gif]);
+            this.saveMap(mapName, [screenshot, gif, menu, reset]);
         }
 
         public getKey(keyCode: number): Key {
-            return this.keymap[keyCode] || this.altmap[keyCode] || Key.None;
+            return keyCode ? this.keymap[keyCode] || this.altmap[keyCode] || Key.None : Key.None;
         }
 
         private saveMap(name: string, keyCodes: number[]) {

--- a/libs/game/sim/keymap.ts
+++ b/libs/game/sim/keymap.ts
@@ -1,0 +1,163 @@
+namespace pxsim.keymap {
+    // Keep in sync with pxt-arcade-sim/api.ts
+    export enum Key {
+        None = 0,
+
+        // Player 1
+        Left = 1,
+        Up = 2,
+        Right = 3,
+        Down = 4,
+        A = 5,
+        B = 6,
+
+        Menu = 7,
+
+        // Player 2 = Player 1 + 7
+        // Player 3 = Player 2 + 7
+        // Player 4 = Player 3 + 7
+
+        // system keys
+        Screenshot = -1,
+        Gif = -2,
+        Reset = -3,
+        TogglePause = -4
+    }
+
+    export function _setPlayerKeys(
+        player: number, // player number is 1-based
+        up: number,
+        down: number,
+        left: number,
+        right: number,
+        A: number,
+        B: number
+    ) {
+        getKeymapState().setPlayerKeys(player, up, down, left, right, A, B);
+    }
+
+    export function _setSystemKeys(screenshot: number, gif: number) {
+        getKeymapState().setSystemKeys(screenshot, gif);
+    }
+}
+
+namespace pxsim {
+    import Key = pxsim.keymap.Key;
+
+    export interface KeymapBoard extends EventBusBoard {
+        keymapState: KeymapState;
+    }
+
+    export function getKeymapState() {
+        return (board() as EventBusBoard as KeymapBoard).keymapState;
+    }
+
+    const reservedKeyCodes = [
+        27, // Escape
+        9 // Tab
+    ];
+
+    export class KeymapState {
+        keymap: { [keyCode: number]: Key } = {};
+        altmap: { [keyCode: number]: Key } = {};
+        mappings: { [name: string]: number[] } = {};
+
+        constructor() {
+            // Player 1 keymap
+            this.setPlayerKeys(
+                1, // Player 1
+                87, // W - Up
+                83, // D - Down
+                65, // A - Left
+                83, // S - Right
+                32, // Space - A
+                13 // Enter - B
+            );
+            // Player 2 keymap
+            this.setPlayerKeys(
+                2, // Player 2
+                73, // I - Up
+                75, // K - Down
+                74, // J - Left
+                75, // K - Right
+                85, // U - A
+                79 // O - B
+            );
+            // Note: Player 3 and 4 have no default keyboard mapping
+
+            // System keymap
+            this.setSystemKeys(
+                80, // P - Screenshot
+                82 // R - Gif
+            );
+
+            // Player 1 alternate mapping. This is cleared when the game sets any player keys explicitly
+            this.altmap[38] = Key.Up; // UpArrow
+            this.altmap[37] = Key.Left; // LeftArrow
+            this.altmap[40] = Key.Down; // DownArrow
+            this.altmap[39] = Key.Right; // RightArrow
+            this.altmap[81] = Key.A; // Q
+            this.altmap[90] = Key.A; // Z
+            this.altmap[88] = Key.B; // X
+            this.altmap[69] = Key.B; // E
+        }
+
+        public setPlayerKeys(
+            player: number, // player number is 1-based
+            up: number,
+            down: number,
+            left: number,
+            right: number,
+            A: number,
+            B: number
+        ) {
+            // We only support four players
+            if (player < 1 || player > 4) return;
+            const keyCodes = [up, down, left, right, A, B];
+            // Check for reserved key codes
+            // TODO: How to surface this runtime error to the user?
+            // TODO: Send message to UI: "Keyboard mapping contains a reserved key code"
+            const filtered = keyCodes.filter(keyCode => reservedKeyCodes.includes(keyCode));
+            if (filtered.length) return;
+            // Clear existing mapped keys for player
+            const mapName = `player-${player}`;
+            this.clearMap(mapName);
+            // Clear altmap When explicitly setting the player keys
+            this.altmap = {};
+            // Map the new keys
+            const offset = (player - 1) * 7; // +7 for player 2's keys
+            this.keymap[up] = Key.Up + offset;
+            this.keymap[down] = Key.Down + offset;
+            this.keymap[left] = Key.Left + offset;
+            this.keymap[right] = Key.Right + offset;
+            this.keymap[A] = Key.A + offset;
+            this.keymap[B] = Key.B + offset;
+            // Remember this mapping
+            this.saveMap(mapName, keyCodes);
+        }
+
+        public setSystemKeys(screenshot: number, gif: number) {
+            const mapName = "system";
+            // Clear existing mapped keys for system
+            this.clearMap(mapName);
+            this.keymap[screenshot] = Key.Screenshot;
+            this.keymap[gif] = Key.Gif;
+            // Remember this mapping
+            this.saveMap(mapName, [screenshot, gif]);
+        }
+
+        public getKey(keyCode: number): Key {
+            return this.keymap[keyCode] || this.altmap[keyCode] || Key.None;
+        }
+
+        private saveMap(name: string, keyCodes: number[]) {
+            this.mappings[name] = keyCodes;
+        }
+
+        private clearMap(name: string) {
+            const keyCodes = this.mappings[name];
+            keyCodes?.forEach(keyCode => delete this.keymap[keyCode]);
+            delete this.mappings[name];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for remapping player inputs at runtime. This makes it possible for [Makey Makey](https://makeymakey.com/), for example, to create an extension that would define a block to remap the simulator for their board's input scheme. The extension might look like this:

```ts
namespace MakeyMakey {
    //% blockId=set_makeymakey_controls
    //% block="Remap simulator keys to Makey Makey defaults"
    export function setMakeyMakeyInputs() {
        // Configure input for player 1
        keymap.setPlayerKeys(
            1,
            keymap.KeyCode.UpArrow,
            keymap.KeyCode.DownArrow,
            keymap.KeyCode.LeftArrow,
            keymap.KeyCode.RightArrow,
            keymap.KeyCode.MouseLeftButton,
            keymap.KeyCode.Space);
        // Configure input for player 2
        keymap.setPlayerKeys(
            2,
            keymap.KeyCode.W,
            keymap.KeyCode.S,
            keymap.KeyCode.A,
            keymap.KeyCode.D,
            keymap.KeyCode.F,
            keymap.KeyCode.G);
    }
}
```

Projects built for Makey Makey would need to include this block in `on start`:
![image](https://user-images.githubusercontent.com/12176807/169418950-f6c8b521-3752-4d3f-b228-1fa433013612.png)


### Out of scope
* Runtime changes to keyboard inputs are not reflected in the keyboard popup:
 
![image](https://user-images.githubusercontent.com/12176807/169419323-2de16306-efd6-47d4-b56f-8a44da89dabe.png)


