### PR TITLE
Add class to make it easier to extend sprite

### DIFF
--- a/libs/game/extendableSprite.ts
+++ b/libs/game/extendableSprite.ts
@@ -1,0 +1,51 @@
+namespace sprites {
+    /**
+     * A version of the Sprite class that is easier to extend.
+     * 
+     * Unlike the normal Sprite class, this class will automatically add
+     * itself to the physics engine and run all sprite created handlers
+     * in the constructor
+     */
+    export class ExtendableSprite extends Sprite {
+        constructor(spriteImage: Image, kind?: number) {
+            super(spriteImage);
+
+            const scene = game.currentScene();
+            this.setKind(kind);
+            scene.physicsEngine.addSprite(this);
+    
+            // run on created handlers
+            scene.createdHandlers
+                .filter(h => h.kind == kind)
+                .forEach(h => h.handler(this));
+        }
+
+        /**
+         * Override to change how the sprite is drawn to the screen
+         * 
+         * @param drawLeft The left position to draw the sprite at (already adjusted for camera)
+         * @param drawTop The top position to draw the sprite at (already adjusted for camera)
+         */
+        draw(drawLeft: number, drawTop: number) {
+            super.drawSprite(drawLeft, drawTop);
+        }
+
+        /**
+         * Override to add update logic for a sprite. This method runs once per frame
+         * 
+         * @param deltaTimeMillis The time that has elapsed since the last frame in milliseconds
+         */
+        update(deltaTimeMillis: number) {
+        }
+        
+        __update(camera: scene.Camera, dt: number) {
+            super.__update(camera, dt);
+            this.update(game.currentScene().eventContext.deltaTimeMillis)
+        }
+
+        protected drawSprite(drawLeft: number, drawTop: number): void {
+            this.draw(drawLeft, drawTop);
+        }
+    }
+
+}

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -13,6 +13,7 @@
         "spritesay.ts",
         "sprites.ts",
         "sprite.ts",
+        "extendableSprite.ts",
         "sprite.d.ts",
         "spritemap.ts",
         "spriteevents.ts",

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -645,21 +645,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     __drawCore(camera: scene.Camera) {
-        if (this.sayRenderer) {
-            if (this.sayEndTime !== undefined) {
-                if (control.millis() < this.sayEndTime) {
-                    this.sayRenderer.draw(screen, camera, this);
-                }
-                else {
-                    this.sayRenderer.destroy();
-                    this.sayRenderer = undefined;
-                    this.sayEndTime = undefined;
-                }
-            }
-            else {
-                this.sayRenderer.draw(screen, camera, this)
-            }
-        }
+        this.drawSay(camera);
 
         if (this.isOutOfScreen(camera)) return;
 
@@ -669,47 +655,8 @@ class Sprite extends sprites.BaseSprite {
         const l = Math.floor(this.left - ox);
         const t = Math.floor(this.top - oy);
 
-        if (!this.isScaled())
-            screen.drawTransparentImage(this._image, l, t);
-        else
-            screen.blit(
-                // dst rect in screen
-                l, t,
-                this.width,
-                this.height,
-                // src rect in sprite image
-                this._image,
-                0, 0,
-                this._image.width, this._image.height,
-                true, false);
-
-        if (this.flags & SpriteFlag.ShowPhysics) {
-            const font = image.font5;
-            const margin = 2;
-            let tx = l;
-            let ty = t + this.height + margin;
-            screen.print(`${this.x >> 0},${this.y >> 0}`, tx, ty, 1, font);
-            tx -= font.charWidth;
-            if (this.vx || this.vy) {
-                ty += font.charHeight + margin;
-                screen.print(`v${this.vx >> 0},${this.vy >> 0}`, tx, ty, 1, font);
-            }
-            if (this.ax || this.ay) {
-                ty += font.charHeight + margin;
-                screen.print(`a${this.ax >> 0},${this.ay >> 0}`, tx, ty, 1, font);
-            }
-        }
-
-        // debug info
-        if (game.debug) {
-            screen.drawRect(
-                Fx.toInt(this._hitbox.left) - ox,
-                Fx.toInt(this._hitbox.top) - oy,
-                Fx.toInt(this._hitbox.width),
-                Fx.toInt(this._hitbox.height),
-                1
-            );
-        }
+        this.drawSprite(l, t);
+        this.drawDebug(l, t, ox, oy);
     }
 
     __update(camera: scene.Camera, dt: number) {
@@ -1170,5 +1117,69 @@ class Sprite extends sprites.BaseSprite {
 
     toString() {
         return `${this.id}(${this.x},${this.y})->(${this.vx},${this.vy})`;
+    }
+
+    protected drawSay(camera: scene.Camera) {
+        if (this.sayRenderer) {
+            if (this.sayEndTime !== undefined) {
+                if (control.millis() < this.sayEndTime) {
+                    this.sayRenderer.draw(screen, camera, this);
+                }
+                else {
+                    this.sayRenderer.destroy();
+                    this.sayRenderer = undefined;
+                    this.sayEndTime = undefined;
+                }
+            }
+            else {
+                this.sayRenderer.draw(screen, camera, this)
+            }
+        }
+    }
+
+    protected drawDebug(left: number, top: number, offsetX: number, offsetY: number) {
+        if (this.flags & SpriteFlag.ShowPhysics) {
+            const font = image.font5;
+            const margin = 2;
+            let tx = left;
+            let ty = top + this.height + margin;
+            screen.print(`${this.x >> 0},${this.y >> 0}`, tx, ty, 1, font);
+            tx -= font.charWidth;
+            if (this.vx || this.vy) {
+                ty += font.charHeight + margin;
+                screen.print(`v${this.vx >> 0},${this.vy >> 0}`, tx, ty, 1, font);
+            }
+            if (this.ax || this.ay) {
+                ty += font.charHeight + margin;
+                screen.print(`a${this.ax >> 0},${this.ay >> 0}`, tx, ty, 1, font);
+            }
+        }
+
+        // debug info
+        if (game.debug) {
+            screen.drawRect(
+                Fx.toInt(this._hitbox.left) - offsetX,
+                Fx.toInt(this._hitbox.top) - offsetY,
+                Fx.toInt(this._hitbox.width),
+                Fx.toInt(this._hitbox.height),
+                1
+            );
+        }
+    }
+
+    protected drawSprite(drawLeft: number, drawTop: number) {
+        if (!this.isScaled())
+            screen.drawTransparentImage(this._image, drawLeft, drawTop);
+        else
+            screen.blit(
+                // dst rect in screen
+                drawLeft, drawTop,
+                this.width,
+                this.height,
+                // src rect in sprite image
+                this._image,
+                0, 0,
+                this._image.width, this._image.height,
+                true, false);
     }
 }


### PR DESCRIPTION
Adds a new class "ExtendableSprite" with a number of features to make extending a sprite easier:

1. The constructor now automatically adds the sprite to the physics engine and runs the "on created" handlers
2. Adds a "draw" method that can be overridden without having to reimplement the sprite say or debug info drawing. It also passes in a left and top instead of the camera that already takes into account the RelativeToCamera flag
3. Adds an "update" method that takes in the delta time in milliseconds instead of seconds and can be overridden without messing up the other sprite update logic.

As an added bonus, the new draw and update methods have signatures that are much easier to remember than the ones from BaseSprite which I always have to look up whenever I'm doing this.


@jwunderl any other ideas on what would be nice to add to this?