### PR TITLE
Fix fclose(NULL) in settings---files that might cause crashes

### DIFF
--- a/libs/settings---files/settings.cpp
+++ b/libs/settings---files/settings.cpp
@@ -136,7 +136,8 @@ int _remove(String key) {
 //%
 bool _exists(String key) {
     auto f = openKey(key, "rb");
-    fclose(f);
+    if (f != NULL)
+        fclose(f);
     return f != NULL;
 }
 


### PR DESCRIPTION
fclose(NULL) has undefined behavior and might in some case lead to segfault and crash.

This PR simply test before calling fclose inside the _exists code for files based settings.

Should fix https://github.com/microsoft/pxt-arcade/issues/3812 and allow to use settings.exists on RPi Zero.