### PR TITLE
add keyboard shortcut for menu (1) and reset (2)

### DIFF
--- a/libs/game/sim/keymap.ts
+++ b/libs/game/sim/keymap.ts
@@ -89,8 +89,8 @@ namespace pxsim {
             this.setSystemKeys(
                 80, // P - Screenshot
                 82, // R - Gif
-                0, // Menu - not mapped
-                0 // Reset - not mapped
+                49, // Menu - '1' button
+                50 // Reset - '2' button
             );
 
             // Player 1 alternate mapping. This is cleared when the game sets any player keys explicitly

--- a/libs/game/sim/keymap.ts
+++ b/libs/game/sim/keymap.ts
@@ -89,8 +89,8 @@ namespace pxsim {
             this.setSystemKeys(
                 80, // P - Screenshot
                 82, // R - Gif
-                49, // Menu - '1' button
-                50 // Reset - '2' button
+                192, // Menu - '`' (backtick) button
+                8 // Reset - Backspace button
             );
 
             // Player 1 alternate mapping. This is cleared when the game sets any player keys explicitly


### PR DESCRIPTION
Will want to port this for the arcade cabinets we're making. This was made even quicker than I thought by Eric's last change :)

Set the 'Backtick' key on the keyboard for 'Menu' and the 'Backspace' key on the keyboard for 'Reset'

closes https://github.com/microsoft/pxt-arcade/issues/4777
closes https://github.com/microsoft/pxt-arcade/issues/3491