### PR TITLE
Cherry-pick keymap fix to stable9.4

### DIFF
--- a/libs/game/sim/keymap.ts
+++ b/libs/game/sim/keymap.ts
@@ -67,9 +67,9 @@ namespace pxsim {
             this.setPlayerKeys(
                 1, // Player 1
                 87, // W - Up
-                83, // D - Down
+                83, // S - Down
                 65, // A - Left
-                83, // S - Right
+                68, // D - Right
                 32, // Space - A
                 13 // Enter - B
             );
@@ -79,7 +79,7 @@ namespace pxsim {
                 73, // I - Up
                 75, // K - Down
                 74, // J - Left
-                75, // K - Right
+                76, // L - Right
                 85, // U - A
                 79 // O - B
             );


### PR DESCRIPTION
Cherry-pick keymap fix: https://github.com/microsoft/pxt-common-packages/pull/1349/commits/b99df4587660566cdb94aab68b9663ac3ae6ec5d