### PR TITLE
Patch in pages for built-in extension "Learn More" links

### DIFF
--- a/libs/radio-broadcast/docs/reference/radio-broadcast.md
+++ b/libs/radio-broadcast/docs/reference/radio-broadcast.md
@@ -11,11 +11,11 @@ radio.sendMessage(0)
 radio.onReceivedMessage(0, function() {})
 ```
 
-```package
-radio-broadcast
-```
-
 ## See Also
 
 [send message](/reference/radio/send-message),
 [send value](/reference/radio/on-received-message)
+
+```package
+radio-broadcast
+```

--- a/libs/radio-broadcast/docs/reference/radio-broadcast.md
+++ b/libs/radio-broadcast/docs/reference/radio-broadcast.md
@@ -1,0 +1,21 @@
+# Radio Broadcast
+
+The Radio Broadcast extension has blocks for sending to and receiving messages from all the @boardname@ boards nearby. Just two blocks are used, one to send a broadcast message and another to run code when a broadcast message is received.
+
+A message, which is a [number](/types/number), is sent to, or received by all nearby @boardname@ boards regardless of which [Group](/reference/radio/set-group) number they are transmitting or receiving on.
+
+## Blocks in this extension
+
+```cards
+radio.sendMessage(0)
+radio.onReceivedMessage(0, function() {})
+```
+
+```package
+radio-broadcast
+```
+
+## See Also
+
+[send message](/reference/radio/send-message),
+[send value](/reference/radio/on-received-message)

--- a/libs/servo/docs/reference/servo.md
+++ b/libs/servo/docs/reference/servo.md
@@ -8,7 +8,6 @@ This extension has blocks to rotate and run servos connected to the pins.
 
 To better understand how servos work and how they are controlled, take a few minutes to read this [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf).
 
-
 Also, watch this video for a further look into how motors and servos work.
 
 https://www.youtube.com/watch?v=okxooamdAP4

--- a/libs/servo/docs/reference/servo.md
+++ b/libs/servo/docs/reference/servo.md
@@ -1,0 +1,42 @@
+# Servo
+
+This extension has blocks to rotate and run servos connected to the pins.
+
+### ~ hint
+
+#### How servos work
+
+To better understand how servos work and how they are controlled, take a few minutes to read this [Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf).
+
+
+Also, watch this video for a further look into how motors and servos work.
+
+https://www.youtube.com/watch?v=okxooamdAP4
+
+### ~
+
+## Blocks in this extension
+
+```cards
+servos.P0.setPulse(1500)
+servos.P0.setAngle(90)
+servos.P0.run(50)
+servos.P0.stop()
+servos.P0.setRange(0, 180)
+servos.P0.setStopOnNeutral(false)
+```
+
+## See also
+
+[set pulse](/reference/servos/set-pulse),
+[set angle](/reference/servos/set-angle),
+[run](/reference/servos/run),
+[stop](/reference/servos/stop),
+[set range](/reference/servos/set-range),
+[set stop on neutral](/reference/servos/set-stop-on-neutral)
+
+[Brief Guide to Servos](https://www.kitronik.co.uk/pdf/a-brief-guide-to-servos.pdf)
+
+```package
+servo
+```


### PR DESCRIPTION
A couple of top level API pages as destinations for the `radio-broadcast` and `servo` extensions that are 'built-in'.

RE: https://github.com/microsoft/pxt/pull/8914 and https://github.com/microsoft/pxt-microbit/issues/4752#issuecomment-1157010721