### PR TITLE
Fix stable table regression

### DIFF
--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -74,7 +74,6 @@ namespace game {
 
             // If it's just a small change to the hitbox on one axis,
             // don't change the dimensions to avoid random clipping
-            // this._hitbox = newHitBox;
             if (xDiff > Fx.twoFx8) {
                 this.ox = nMinX;
                 this.width = newHitBox.width;

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -47,14 +47,43 @@ namespace game {
         }
 
         updateIfInvalid() {
-            if (!this.isValid()) {
-                const newHB = calculateHitBox(this.parent)
-                this.hash = newHB.hash;
-                this.ox = newHB.ox;
-                this.oy = newHB.oy;
-                this.width = newHB.width;
-                this.height = newHB.height;
+            if (this.isValid())
+                return;
+
+            const newHitBox = game.calculateHitBox(this.parent);
+
+            const oMinX = this.ox;
+            const oMinY = this.oy;
+            const oMaxX = Fx.add(oMinX, this.width);
+            const oMaxY = Fx.add(oMinY, this.height);
+
+            const nMinX = newHitBox.ox;
+            const nMinY = newHitBox.oy;
+            const nMaxX = Fx.add(nMinX, newHitBox.width);
+            const nMaxY = Fx.add(nMinY, newHitBox.height);
+
+            // total diff in x / y corners between the two hitboxes
+            const xDiff = Fx.add(
+                Fx.abs(Fx.sub(oMinX, nMinX)),
+                Fx.abs(Fx.sub(oMaxX, nMaxX))
+            );
+            const yDiff = Fx.add(
+                Fx.abs(Fx.sub(oMinY, nMinY)),
+                Fx.abs(Fx.sub(oMaxY, nMaxY))
+            );
+
+            // If it's just a small change to the hitbox on one axis,
+            // don't change the dimensions to avoid random clipping
+            // this._hitbox = newHitBox;
+            if (xDiff > Fx.twoFx8) {
+                this.ox = oMinX;
+                this.width = Fx.sub(oMaxX, oMinX);
             }
+            if (yDiff > Fx.twoFx8) {
+                this.oy = oMinY;
+                this.height = Fx.sub(oMaxY, oMinY);
+            }
+            this.hash = newHitBox.hash;
         }
 
         overlapsWith(other: Hitbox): boolean {

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -76,12 +76,12 @@ namespace game {
             // don't change the dimensions to avoid random clipping
             // this._hitbox = newHitBox;
             if (xDiff > Fx.twoFx8) {
-                this.ox = oMinX;
-                this.width = Fx.sub(oMaxX, oMinX);
+                this.ox = nMinX;
+                this.width = newHitBox.width;
             }
             if (yDiff > Fx.twoFx8) {
-                this.oy = oMinY;
-                this.height = Fx.sub(oMaxY, oMinY);
+                this.oy = nMinY;
+                this.height = newHitBox.height;
             }
             this.hash = newHitBox.hash;
         }

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -1,6 +1,6 @@
 namespace game {
     export class Hitbox {
-        hash: Fx8;
+        hash: number;
         parent: Sprite;
         ox: Fx8;
         oy: Fx8;
@@ -46,7 +46,20 @@ namespace game {
             return (x >= this.left) && (x <= this.right) && (y >= this.top) && (y <= this.bottom);
         }
 
+        updateIfInvalid() {
+            if (!this.isValid()) {
+                const newHB = calculateHitBox(this.parent)
+                this.hash = newHB.hash;
+                this.ox = newHB.ox;
+                this.oy = newHB.oy;
+                this.width = newHB.width;
+                this.height = newHB.height;
+            }
+        }
+
         overlapsWith(other: Hitbox): boolean {
+            this.updateIfInvalid();
+            other.updateIfInvalid();
             if (this.contains(other.left, other.top)) return true;
             if (this.contains(other.left, other.bottom)) return true;
             if (this.contains(other.right, other.top)) return true;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -346,11 +346,11 @@ class Sprite extends sprites.BaseSprite {
     }
 
     setHitbox() {
-        if (!this._hitbox) {
+        if (this._hitbox) {
+            this._hitbox.updateIfInvalid();
+        } else {
             this._hitbox = game.calculateHitBox(this);
-            return;
         }
-        this._hitbox.updateIfInvalid();
     }
 
     isStatic() {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -346,44 +346,11 @@ class Sprite extends sprites.BaseSprite {
     }
 
     setHitbox() {
-        const newHitBox = game.calculateHitBox(this);
-
-        if (!this._hitbox || this._hitbox.isValid()) {
-            this._hitbox = newHitBox;
+        if (!this._hitbox) {
+            this._hitbox = game.calculateHitBox(this);
             return;
         }
-
-        const oMinX = this._hitbox.ox;
-        const oMinY = this._hitbox.oy;
-        const oMaxX = Fx.add(oMinX, this._hitbox.width);
-        const oMaxY = Fx.add(oMinY, this._hitbox.height);
-
-        const nMinX = newHitBox.ox;
-        const nMinY = newHitBox.oy;
-        const nMaxX = Fx.add(nMinX, newHitBox.width);
-        const nMaxY = Fx.add(nMinY, newHitBox.height);
-
-        // total diff in x / y corners between the two hitboxes
-        const xDiff = Fx.add(
-            Fx.abs(Fx.sub(oMinX, nMinX)),
-            Fx.abs(Fx.sub(oMaxX, nMaxX))
-        );
-        const yDiff = Fx.add(
-            Fx.abs(Fx.sub(oMinY, nMinY)),
-            Fx.abs(Fx.sub(oMaxY, nMaxY))
-        );
-
-        // If it's just a small change to the hitbox on one axis,
-        // don't change the dimensions to avoid random clipping
-        this._hitbox = newHitBox;
-        if (xDiff <= Fx.twoFx8) {
-            this._hitbox.ox = oMinX;
-            this._hitbox.width = Fx.sub(oMaxX, oMinX);
-        }
-        if (yDiff <= Fx.twoFx8) {
-            this._hitbox.oy = oMinY;
-            this._hitbox.height = Fx.sub(oMaxY, oMinY);
-        }
+        this._hitbox.updateIfInvalid();
     }
 
     isStatic() {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -337,7 +337,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     calcDimensionalHash() {
-        return Fx.mul(Fx.mul(this._width, this._height), Fx8(this._image.revision()));
+        return this._image.revision() + Fx.toIntShifted(this._width, 8) + Fx.toIntShifted(this._height, 16);
     }
 
     resetHitbox() {


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/4864

We were missing updating the hitbox here when it becomes invalid. 

Also update hash generation for sprite hitbox / img, I think this should be fine as written? issue before is that this._image.revision() starts off at 0, so multiplying it would be.. not ideal as it would just ignore the different scaling of _x _y for static images

build w/ stable table: https://arcade.makecode.com/app/e8fdc2c613b1610dd6c807e09d6305d9af5bdcc0-c92540148b#pub:_V2KJKPadDRJu


https://arcade.makecode.com/app/e8fdc2c613b1610dd6c807e09d6305d9af5bdcc0-c92540148b#pub:_Tfaaewgmkig2 is another one you can check / the minimal repro I listed in that pr