### PR TITLE
get rid of spurious errors in vscode for game pkg

### DIFF
--- a/libs/game/temp.d.ts
+++ b/libs/game/temp.d.ts
@@ -36,4 +36,10 @@ declare namespace Math {
     function sign(x: number): number;
 }
 
+declare interface Image {
+    revision(): number;
+    isStatic(): boolean;
+    equals(img: Image): boolean;
+}
+
 declare const img: any;

--- a/libs/game/tsconfig.json
+++ b/libs/game/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "outDir": "../built",
+        "newLine": "LF",
+        "sourceMap": false,
+        "types": []
+    },
+    "include": [
+        "*.ts",
+        "../settings/*.ts",
+        "../screen/*.ts",
+        "../mixer/*.ts",
+        "../power/*.ts",
+        "../core/*.ts",
+        "../base/*.ts",
+        "../../../pxt/libs/pxt-common/*.ts"
+    ]
+}


### PR DESCRIPTION
no user side changes, just gets rid of a lot of red squiggles when you're making changes in vscode. Many of them came from https://github.com/microsoft/pxt-common-packages/blob/fewerErrorsInVSCode/libs/game---light/pxt.json giving a few duplicate class definitions when the default tsconfig is which just grabs defs for all files in the repo