### PR TITLE
Update nrf52 platform.h to support PWM on all pins

### DIFF
--- a/libs/core---nrf52/platform.h
+++ b/libs/core---nrf52/platform.h
@@ -20,7 +20,7 @@
 #define DEV_NUM_PINS 32
 #endif
 
-#define DEV_PWM_PINS 0x0000ffffffffULL // all pins are PWM pins it seems
+#define DEV_PWM_PINS 0xffffffffffffffffULL // all pins are PWM pins it seems
 #define DEV_AIN_PINS 0x0000f000001fULL
 
 // Codal doesn't yet distinguish between PWM and AIN


### PR DESCRIPTION
Hello,

While developing a MakeCode target for a new custom nrf52840 based board I noticed that the pins on the second port (i.e. P1_0 to P1_31) weren't outputting PWM when analogWrite was called. 

To solve this issue I changed `DEV_PWM_PINS` (in lib/core---nrf52/platform.h) to`0xffffffffffffffffUL` to support all pins on nrf52840 devices.

I haven't got any other nrf52 device to test on so I'm not sure if it will have an effect on other chips but it seems to only be used in the IS_ANALOG_PIN macro so I don't foresee an issue