### PR TITLE
Add sound effect blocks to pxt-common-packages

### DIFF
--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -112,7 +112,7 @@ namespace music {
 
     /**
      * Play a melody from the melody editor.
-     * @param melody - string of up to eight notes [C D E F G A B C5] or rests [-] separated by spaces, 
+     * @param melody - string of up to eight notes [C D E F G A B C5] or rests [-] separated by spaces,
      * which will be played one at a time, ex: "E D G F B A C5 B "
      * @param tempo - number in beats per minute (bpm), dictating how long each note will play for
      */
@@ -176,7 +176,7 @@ namespace music {
      */
     //% help=music/stop-all-sounds
     //% blockId=music_stop_all_sounds block="stop all sounds"
-    //% weight=10
+    //% weight=45
     //% group="Sounds"
     export function stopAllSounds() {
         Melody.stopAll();

--- a/libs/mixer/pxt.json
+++ b/libs/mixer/pxt.json
@@ -13,6 +13,7 @@
         "ns.ts",
         "targetoverrides.ts",
         "music.ts",
+        "soundEffect.ts",
         "pxtparts.json",
         "headphone.svg"
     ],

--- a/libs/mixer/sim/music.ts
+++ b/libs/mixer/sim/music.ts
@@ -1,6 +1,6 @@
 namespace pxsim.music {
     export function playInstructions(b: RefBuffer) {
-        return AudioContextManager.playInstructionsAsync(b)
+        return AudioContextManager.playInstructionsAsync(b.data)
     }
 
     export function queuePlayInstructions(when: number, b: RefBuffer) {

--- a/libs/mixer/soundEffect.ts
+++ b/libs/mixer/soundEffect.ts
@@ -1,0 +1,210 @@
+enum WaveShape {
+    //% block="sine"
+    Sine = 0,
+    //% block="sawtooth"
+    Sawtooth = 1,
+    //% block="triangle"
+    Triangle = 2,
+    //% block="square"
+    Square = 3,
+    //% block="noise"
+    Noise = 4
+}
+
+enum InterpolationCurve {
+    //% block="linear"
+    Linear,
+    //% block="curve"
+    Curve,
+    //% block="logarithmic"
+    Logarithmic
+}
+
+enum SoundExpressionEffect {
+    //% block="none"
+    None = 0,
+    //% block="vibrato"
+    Vibrato = 1,
+    //% block="tremolo"
+    Tremolo = 2,
+    //% block="warble"
+    Warble = 3
+}
+
+enum SoundExpressionPlayMode {
+    //% block="until done"
+    UntilDone,
+    //% block="in background"
+    InBackground
+}
+
+namespace music {
+    /**
+     * Play a sound effect from a sound expression string.
+     * @param sound the sound expression string
+     * @param mode the play mode, play until done or in the background
+     */
+    //% blockId=soundExpression_playSoundEffect
+    //% block="play sound $sound $mode"
+    //% sound.shadow=soundExpression_createSoundEffect
+    //% weight=100 help=music/play-sound-effect
+    //% blockGap=8
+    export function playSoundEffect(sound: Buffer, mode: SoundExpressionPlayMode) {
+        queuePlayInstructions(0, sound);
+        if (mode === SoundExpressionPlayMode.UntilDone) {
+            let totalDuration = 0;
+
+            for (let i = 0; i < sound.length; i += 12) {
+                totalDuration += sound.getNumber(NumberFormat.UInt16LE, i + 4);
+            }
+
+            pause(totalDuration);
+        }
+    }
+
+    /**
+     * Create a sound expression from a set of sound effect parameters.
+     * @param waveShape waveform of the sound effect
+     * @param startFrequency starting frequency for the sound effect waveform
+     * @param endFrequency ending frequency for the sound effect waveform
+     * @param startVolume starting volume of the sound, or starting amplitude
+     * @param endVolume ending volume of the sound, or ending amplitude
+     * @param duration the amount of time in milliseconds (ms) that sound will play for
+     * @param effect the effect to apply to the waveform or volume
+     * @param interpolation interpolation method for frequency scaling
+     */
+    //% blockId=soundExpression_createSoundEffect
+    //% help=music/create-sound-effect
+    //% block="$waveShape|| start frequency $startFrequency end frequency $endFrequency duration $duration start volume $startVolume end volume $endVolume effect $effect interpolation $interpolation"
+    //% waveShape.defl=WaveShape.Sine
+    //% waveShape.fieldEditor=soundeffect
+    //% waveShape.fieldOptions.useMixerSynthesizer=true
+    //% startFrequency.defl=5000
+    //% startFrequency.min=0
+    //% startFrequency.max=5000
+    //% endFrequency.defl=0
+    //% endFrequency.min=0
+    //% endFrequency.max=5000
+    //% startVolume.defl=255
+    //% startVolume.min=0
+    //% startVolume.max=255
+    //% endVolume.defl=0
+    //% endVolume.min=0
+    //% endVolume.max=255
+    //% duration.defl=500
+    //% duration.min=1
+    //% duration.max=9999
+    //% effect.defl=SoundExpressionEffect.None
+    //% interpolation.defl=InterpolationCurve.Linear
+    //% compileHiddenArguments=true
+    //% inlineInputMode="variable"
+    //% inlineInputModeLimit=3
+    //% expandableArgumentBreaks="3,5"
+    export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): Buffer {
+        return soundToInstructionBuffer(waveShape, startFrequency, endFrequency, startVolume, endVolume, duration, effect, interpolation, 20, 1);
+    }
+
+    interface Step {
+        frequency: number;
+        volume: number;
+    }
+
+     export function soundToInstructionBuffer(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve, fxSteps: number, fxRange: number) {
+        const steps: Step[] = [];
+
+        // Optimize the simple case
+        if (interpolation === InterpolationCurve.Linear && effect === SoundExpressionEffect.None) {
+            steps.push({
+                frequency: startFrequency,
+                volume: (startVolume / 255) * 1024,
+            })
+            steps.push({
+                frequency: endFrequency,
+                volume: (endVolume / 255) * 1024,
+            })
+        }
+        else {
+
+            fxSteps = Math.min(fxSteps, Math.floor(duration / 5))
+
+            const getVolumeAt = (t: number) => ((startVolume + t * (endVolume - startVolume) / duration) / 255) * 1024;
+            let getFrequencyAt: (t: number) => number;
+
+            switch (interpolation) {
+                case InterpolationCurve.Linear:
+                    getFrequencyAt = t => startFrequency + t * (endFrequency - startFrequency) / duration;
+                    break;
+                case InterpolationCurve.Curve:
+                    getFrequencyAt = t => startFrequency + (endFrequency - startFrequency) * Math.sin(t / duration * (Math.PI / 2));
+                    break;
+                case InterpolationCurve.Logarithmic:
+                    getFrequencyAt = t => startFrequency + (Math.log(1 + 9 * (t / duration)) / Math.log(10)) * (endFrequency - startFrequency)
+                    break;
+            }
+
+            const timeSlice = duration / fxSteps;
+
+            for (let i = 0; i < fxSteps; i++) {
+                const newStep = {
+                    frequency: getFrequencyAt(i * timeSlice),
+                    volume: getVolumeAt(i * timeSlice)
+                };
+
+                if (effect === SoundExpressionEffect.Tremolo) {
+                    if (i % 2 === 0) {
+                        newStep.volume = Math.max(newStep.volume - fxRange * 500, 0)
+                    }
+                    else {
+                        newStep.volume = Math.min(newStep.volume + fxRange * 500, 1023)
+                    }
+                }
+                else if (effect === SoundExpressionEffect.Vibrato) {
+                    if (i % 2 === 0) {
+                        newStep.frequency = Math.max(newStep.frequency - fxRange * 100, 0)
+                    }
+                    else {
+                        newStep.frequency = newStep.frequency + fxRange * 100
+                    }
+                }
+                else if (effect === SoundExpressionEffect.Warble) {
+                    if (i % 2 === 0) {
+                        newStep.frequency = Math.max(newStep.frequency - fxRange * 1000, 0)
+                    }
+                    else {
+                        newStep.frequency = newStep.frequency + fxRange * 1000
+                    }
+                }
+
+                steps.push(newStep)
+            }
+        }
+
+        const out = control.createBuffer(12 * (steps.length - 1));
+        const stepDuration = Math.floor(duration / (steps.length - 1))
+
+        for (let i = 0; i < steps.length - 1; i++) {
+            const offset = i * 12;
+            out.setNumber(NumberFormat.UInt8LE, offset, waveToValue(waveShape));
+            out.setNumber(NumberFormat.UInt16LE, offset + 2, steps[i].frequency);
+            out.setNumber(NumberFormat.UInt16LE, offset + 4, stepDuration);
+            out.setNumber(NumberFormat.UInt16LE, offset + 6, steps[i].volume);
+            out.setNumber(NumberFormat.UInt16LE, offset + 8, steps[i + 1].volume);
+            out.setNumber(NumberFormat.UInt16LE, offset + 10, steps[i + 1].frequency);
+        }
+
+        return out;
+    }
+
+    function waveToValue(wave: WaveShape) {
+        switch (wave) {
+            case WaveShape.Square: return 15;
+            case WaveShape.Sine: return 3;
+            case WaveShape.Triangle: return 1;
+            case WaveShape.Noise: return 18;
+            case WaveShape.Sawtooth: return 2;
+        }
+    }
+
+    //% shim=music::queuePlayInstructions
+    function queuePlayInstructions(timeDelta: number, buf: Buffer) { }
+}

--- a/libs/mixer/soundEffect.ts
+++ b/libs/mixer/soundEffect.ts
@@ -81,15 +81,17 @@ namespace music {
 
 
     /**
-     * Play a sound effect from a sound expression string.
-     * @param sound the sound expression string
+     * Play a SoundEffect.
+     * @param sound the SoundEffect to play
      * @param mode the play mode, play until done or in the background
      */
     //% blockId=soundExpression_playSoundEffect
     //% block="play sound $sound $mode"
     //% sound.shadow=soundExpression_createSoundEffect
-    //% weight=100 help=music/play-sound-effect
+    //% weight=30
+    //% help=music/play-sound-effect
     //% blockGap=8
+    //% group="Sounds"
     export function playSoundEffect(sound: SoundEffect, mode: SoundExpressionPlayMode) {
         const toPlay = sound.toBuffer(music.volume());
 
@@ -137,6 +139,8 @@ namespace music {
     //% inlineInputMode="variable"
     //% inlineInputModeLimit=3
     //% expandableArgumentBreaks="3,5"
+    //% weight=20
+    //% group="Sounds"
     export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): SoundEffect {
         const result = new SoundEffect();
 
@@ -253,6 +257,18 @@ namespace music {
         }
     }
 
+
+    /**
+     * Generate a random similar sound effect to the given one.
+     *
+     * @param sound the sound effect
+     */
+    //% blockId=soundExpression_generateSimilarSound
+    //% block="randomize $sound"
+    //% sound.shadow=soundExpression_createSoundEffect
+    //% weight=0 help=music/generate-similar-sound
+    //% blockGap=8
+    //% group="Sounds"
     export function generateSimilarSound(sound: SoundEffect) {
         const res = new SoundEffect();
         res.waveShape = sound.waveShape;
@@ -265,11 +281,10 @@ namespace music {
         res.interpolation = randomInterpolation();
 
         res.duration = Math.clamp(
-            res.duration + (Math.random() - 0.5) * res.duration,
             Math.min(100, res.duration),
-            Math.max(2000, res.duration)
+            Math.max(2000, res.duration),
+            res.duration + (Math.random() - 0.5) * res.duration,
         );
-
 
         if (res.waveShape === WaveShape.Noise) {
             // The primary waveforms don't produce sounds that are similar to noise,
@@ -298,33 +313,33 @@ namespace music {
             newFrequencyDifference *= -1;
         }
 
-        newFrequencyDifference = Math.clamp(newFrequencyDifference, -5000, 5000);
+        newFrequencyDifference = Math.clamp(-5000, 5000, newFrequencyDifference);
 
         res.startFrequency = Math.clamp(
-            Math.random() * 5000,
             Math.max(-newFrequencyDifference, 1),
-            Math.clamp(5000 - newFrequencyDifference, 1, 5000)
+            Math.clamp(1, 5000, 5000 - newFrequencyDifference),
+            Math.random() * 5000,
         );
 
-        res.endFrequency = Math.clamp(res.startFrequency + newFrequencyDifference, 1, 5000);
+        res.endFrequency = Math.clamp(1, 5000, res.startFrequency + newFrequencyDifference);
 
         // Same strategy for volume
         const oldVolumeDifference = res.endVolume - res.startVolume;
         let newVolumeDifference = oldVolumeDifference + oldVolumeDifference * (Math.random() - 0.5);
 
-        newVolumeDifference = Math.clamp(newVolumeDifference, -255, 255);
+        newVolumeDifference = Math.clamp(-255, 255, newVolumeDifference);
 
         if (Math.sign(oldVolumeDifference) !== Math.sign(newVolumeDifference)) {
             newVolumeDifference *= -1;
         }
 
         res.startVolume = Math.clamp(
-            Math.random() * 255,
             Math.max(-newVolumeDifference, 0),
-            Math.clamp(255 - newVolumeDifference, 0, 255)
+            Math.clamp(0, 255, 255 - newVolumeDifference),
+            Math.random() * 255,
         );
 
-        res.endVolume = Math.clamp(res.startVolume + newVolumeDifference, 0, 255);
+        res.endVolume = Math.clamp(0, 255, res.startVolume + newVolumeDifference);
 
         return res;
     }

--- a/libs/mixer/soundEffect.ts
+++ b/libs/mixer/soundEffect.ts
@@ -269,7 +269,7 @@ namespace music {
     //% weight=0 help=music/generate-similar-sound
     //% blockGap=8
     //% group="Sounds"
-    export function generateSimilarSound(sound: SoundEffect) {
+    export function randomizeSound(sound: SoundEffect) {
         const res = new SoundEffect();
         res.waveShape = sound.waveShape;
         res.startFrequency = sound.startFrequency;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "libs/**/*"
   ],
   "dependencies": {
-    "pxt-core": "7.5.23"
+    "pxt-core": "8.2.4"
   },
   "devDependencies": {
     "typescript": "^4.2.3"


### PR DESCRIPTION
Adds the sound effect field editor to pxt-common-packages using the mixer sound engine instead of the codal one.

![image](https://user-images.githubusercontent.com/13754588/181596057-de43f755-8b54-4b9a-ac81-f970baad5e13.png)

The "randomize" block is the same as pressing "generate similar sound" in the field editor