### PR TITLE
Fix Off-by-One Error Traversing Image Rows

### DIFF
--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -163,7 +163,7 @@ namespace pxsim.ImageMethods {
         let hh = 0
         while (len--) {
             if (hh++ >= img._height) {
-                hh = 0
+                hh = 1
                 sp = ++x
             }
             dst.data[dp++] = img.data[sp]
@@ -182,7 +182,7 @@ namespace pxsim.ImageMethods {
         let hh = 0
         while (len--) {
             if (hh++ >= img._height) {
-                hh = 0
+                hh = 1
                 dp = ++x
             }
             img.data[dp] = src.data[sp++]


### PR DESCRIPTION
When we reset the height field at the end of each "row", we should actually set it to 1 instead of 0, since the code expects it to have been incremented once already at this point.

Fixes https://github.com/microsoft/pxt-arcade/issues/4690

Using the sample from the above bug, without fix:
<img width="161" alt="image" src="https://user-images.githubusercontent.com/69657545/183777587-c50f3eac-6e93-4c16-b311-0dd934faaf93.png">

With fix:
<img width="161" alt="image" src="https://user-images.githubusercontent.com/69657545/183777492-25d534e1-dc9c-4408-9721-434a99fd7250.png">
