### PR TITLE
Respect Transparency for Screen Edge Collisions

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -195,6 +195,13 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 if (tileMap && tileMap.enabled) {
                     this.tilemapCollisions(ms, tileMap);
                 }
+                
+                // check for screen edge collisions
+                const bounce = s.flags & sprites.Flag.BounceOnWall;
+                if (s.flags & sprites.Flag.StayInScreen || (bounce && !tileMap)) {
+                    this.screenEdgeCollisions(ms, bounce, scene.camera);
+                }
+
                 // if sprite still needs to move, add it to the next step of movements
                 if (Fx.abs(ms.dx) > MIN_MOVE_GAP || Fx.abs(ms.dy) > MIN_MOVE_GAP) {
                     remainingMovers.push(ms);
@@ -343,6 +350,29 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                         });
                 }
             }
+        }
+    }
+
+    protected screenEdgeCollisions(movingSprite: MovingSprite, bounce: number, camera: scene.Camera) {
+        let s = movingSprite.sprite;
+        if (!s.isStatic()) s.setHitbox();
+
+        let offset = Fx.toFloat(s._hitbox.left) - camera.offsetX;
+        if (offset < 0) {
+            s.left -= offset;
+            if (bounce) s.vx = -s.vx;
+        }
+        else if ((offset = Fx.toFloat(s._hitbox.right) - camera.offsetX - screen.width) > 0) {
+            s.right -= offset;
+            if (bounce) s.vx = -s.vx;
+        }
+        if ((offset = Fx.toFloat(s._hitbox.top) - camera.offsetY) < 0) {
+            s.top -= offset;
+            if (bounce) s.vy = -s.vy;
+        }
+        else if ((offset = Fx.toFloat(s._hitbox.bottom) - camera.offsetY - screen.height) > 0) {
+            s.bottom -= offset;
+            if (bounce) s.vy = -s.vy;
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -639,28 +639,6 @@ class Sprite extends sprites.BaseSprite {
             this.destroy()
         }
 
-        const bounce = this.flags & sprites.Flag.BounceOnWall;
-        const tm = game.currentScene().tileMap;
-        if (this.flags & sprites.Flag.StayInScreen || (bounce && !tm)) {
-            if (this.left < camera.offsetX) {
-                this.left = camera.offsetX;
-                if (bounce) this.vx = -this.vx;
-            }
-            else if (this.right > camera.offsetX + screen.width) {
-                this.right = camera.offsetX + screen.width;
-                if (bounce) this.vx = -this.vx;
-            }
-
-            if (this.top < camera.offsetY) {
-                this.top = camera.offsetY;
-                if (bounce) this.vy = -this.vy;
-            }
-            else if (this.bottom > camera.offsetY + screen.height) {
-                this.bottom = camera.offsetY + screen.height;
-                if (bounce) this.vy = -this.vy;
-            }
-        }
-
         if (this.sayRenderer) this.sayRenderer.update(dt, camera, this);
     }
 


### PR DESCRIPTION
This change switches "Stay in Screen" and "Bounce on Wall" checks to use the sprite's Hitbox instead of the left, right, top, and bottom fields. Left, right, top, and bottom do not account for transparency around the sprite, so a sprite with a transparent border would look like it could never actually reach the edge (see https://github.com/microsoft/pxt-arcade/issues/4846 for an example). By using HitBox, we ensure the sprite will not stop/bounce until a non-transparent section of the sprite intersects with the edge.

I've also moved this check into the PhysicsEngine, which seems like a more natural place for it.

Fixes https://github.com/microsoft/pxt-arcade/issues/4846