### PR TITLE
Surfacing more image blocks

### DIFF
--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -156,6 +156,7 @@ interface Image {
      */
     //% shim=ImageMethods::drawTransparentImage
     //% blockNamespace="images"
+    //% blockId=image_draw_transparent_image
     //% group="Drawing"
     //% block="$this draw $from at x $x y $y"
     //% this.shadow=variables_get

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -31,6 +31,46 @@ interface Image {
     drawRect(x: number, y: number, w: number, h: number, c: color): void;
 
     /**
+     * Draw an empty circle.
+     *
+     * @param cx The center x coordinate of the circle
+     * @param cy The center y coordinate of the circle
+     * @param r The radius of the circle
+     * @param c The color to draw the circle
+     */
+    //% helper=imageDrawCircle
+    //% blockId=image_draw_circle
+    //% block="draw circle in $this at cx $cx cy $cy radius $r $c"
+    //% this.shadow=variables_get
+    //% this.defl=picture
+    //% c.shadow=colorindexpicker
+    //% inlineInputMode="inline"
+    //% weight=10
+    //% blockNamespace="images"
+    //% group="Drawing"
+    drawCircle(cx: number, cy: number, r: number, c: color): void;
+
+    /**
+     * Fills a circle
+     *
+     * @param cx The center x coordinate of the circle
+     * @param cy The center y coordinate of the circle
+     * @param r The radius of the circle
+     * @param c The color to draw the circle
+     */
+    //% helper=imageFillCircle
+    //% blockId=image_fill_circle
+    //% block="fill circle in $this at cx $cx cy $cy radius $r $c"
+    //% this.shadow=variables_get
+    //% this.defl=picture
+    //% c.shadow=colorindexpicker
+    //% inlineInputMode="inline"
+    //% weight=9
+    //% blockNamespace="images"
+    //% group="Drawing"
+    fillCircle(cx: number, cy: number, r: number, c: color): void;
+
+    /**
      * Set pixel color
      */
     //% shim=ImageMethods::setPixel blockNamespace="images" group="Drawing"
@@ -110,6 +150,19 @@ interface Image {
 
     //% shim=ImageMethods::revision
     revision(): number;
+
+    /**
+     * Draw given image with transparent background on the current image
+     */
+    //% shim=ImageMethods::drawTransparentImage
+    //% blockNamespace="images"
+    //% group="Drawing"
+    //% block="$this draw $from at x $x y $y"
+    //% this.shadow=variables_get
+    //% this.defl="picture"
+    //% from.shadow=screen_image_picker
+    //% weight=0
+    drawTransparentImage(from: Image, x: int32, y: int32): void;
 }
 
 declare namespace image {

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -1,6 +1,13 @@
 type color = number
 
 namespace image {
+    export enum Dimension {
+        //% block="width"
+        Width,
+        //% block="height"
+        Height
+    }
+
     export function repeatY(count: number, image: Image) {
         let arr = [image]
         while (--count > 0)
@@ -23,6 +30,24 @@ namespace image {
             y += img.height
         }
         return r
+    }
+
+    /**
+     * Returns the width or height of a picture.
+     *
+     * @param picture The picture to get the width or height of
+     * @param dimension The dimension to get
+     * @returns
+     */
+    //% blockId=image_get_dimension
+    //% group="Create"
+    //% blockNamespace="images"
+    //% block="$picture $dimension"
+    //% picture.shadow=variables_get
+    //% picture.defl=picture
+    export function getDimension(picture: Image, dimension: Dimension) {
+        if (dimension === Dimension.Width) return picture.width;
+        else return picture.height;
     }
 }
 

--- a/libs/screen/text.ts
+++ b/libs/screen/text.ts
@@ -121,7 +121,7 @@ f405100800100800 021e7c5455542800 031e007e48493000 0a1e007c45443800 0b1e00304948
 611e0050586a2800 6a1e04047d040400 6b1e00083d482000 801e7c2112207c00 811e384132403800 821e7c2012217c00
 831e384032413800 841e7c2110217c00 851e384230423800 f21e040972080400 f31e00b84142f800 a3207e0a7a120a00
 a420a8fcaa828400 a720087e2a1c0800 ab200098a4a6bf02 ac20183c5a5a4200 af20627f22443800 9021103854101000
-912108047e040800 9221101054381000 932110207e201000 9421103810103810 95212844fe442800 
+912108047e040800 9221101054381000 932110207e201000 9421103810103810 95212844fe442800
 `,
 
     }
@@ -196,7 +196,27 @@ namespace texteffects {
 }
 
 interface Image {
+    /**
+     * Prints some text to an image at a given location
+     *
+     * @param text The text to print
+     * @param x The pixel coordinate of the left side of the text
+     * @param y The pixel coordinate of the top side of the text
+     * @param color The color to print the text
+     * @param font The font to use when printing the text
+     * @param offsets Character offsets for text effects
+     */
     //% helper=imagePrint
+    //% blockId=image_print_text
+    //% blockNamespace="images"
+    //% inlineInputMode="inline"
+    //% group="Drawing"
+    //% block="$this print $text at x $x y $y $color"
+    //% this.shadow=variables_get
+    //% this.defl=picture
+    //% text.defl=abc
+    //% color.shadow=colorindexpicker
+    //% weight=5
     print(text: string, x: number, y: number, color?: number, font?: image.Font, offsets?: texteffects.TextEffectState[]): void;
 
     //% helper=imagePrintCenter


### PR DESCRIPTION
As has become tradition, I'd like to sneak a few missing blocks into this release.

This PR surfaces some already existent TS image apis into blocks:

![image](https://user-images.githubusercontent.com/13754588/190519249-0db38792-3293-41b0-9a20-cd7d308c108b.png)
![image](https://user-images.githubusercontent.com/13754588/190519288-c3cd5ef0-41a2-4553-9577-31dce13f3402.png)

In particular, the width/height block is extremely useful because the only way to get those values right now is to create a sprite (which you then have to immediately destroy).