### PR TITLE
Truncate dimensions when creating an image

### DIFF
--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -746,6 +746,9 @@ namespace pxsim.image {
 
 
     export function create(w: number, h: number) {
+        // truncate decimal sizes
+        w |= 0
+        h |= 0
         return new RefImage(w, h, getScreenState().bpp())
     }
 


### PR DESCRIPTION
We don't support non-integer image sizes, so truncate any width and height values passed into `create()`.

Fixes https://github.com/microsoft/pxt-arcade/issues/4726