### PR TITLE
Added: getCountdown, changeCountDownBy blocks

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -365,8 +365,9 @@ namespace info {
     //% blockId=gamegetcountdown
     //% weight=79
     //% group="Countdown"
-    export function getCountdown() {
-        return (infoState.gameEnd - game.currentScene().millis()) / 1000;
+    export function countdown(): number {
+        initHUD();
+        return infoState.gameEnd ? ((infoState.gameEnd - game.currentScene().millis()) / 1000) : 0;
     }
 
     /**
@@ -383,18 +384,15 @@ namespace info {
     }
 
     /**
-     * Get the value of the current count down
+     * Change the running countdown by the given number of seconds
+     * @param seconds the number of seconds the countdown should be changed by
      */
     //% block="change countdown by $seconds (s)"
     //% blockId=gamechangecountdown
     //% weight=77
     //% group="Countdown"
     export function changeCountdownBy(seconds: number) {
-        if (!infoState) {
-            startCountdown(seconds);
-            return;
-        }
-        infoState.gameEnd += (seconds * 1000);
+        startCountdown((countdown() + seconds));
     }
 
     /**

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -384,6 +384,26 @@ namespace info {
     }
 
     /**
+     * Get the value of the current count down
+     */
+    //% block
+    //% blockId=gamegetcountdown
+    //% group="Countdown"
+    export function getCountdown() {
+        return (infoState.gameEnd - game.currentScene().millis()) / 1000;
+    }
+
+    /**
+     * Get the value of the current count down
+     */
+    //% block="change countdown by $seconds (s)"
+    //% blockId=gamechangecountdown
+    //% group="Countdown"
+    export function changeCountdownBy(seconds: number) {
+        infoState.gameEnd += (seconds * 1000);
+    }
+
+    /**
      * Run code when the countdown reaches 0. If this function
      * is not called then game.over() is called instead
      */

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -359,11 +359,22 @@ namespace info {
     }
 
     /**
+     * Get the value of the current count down
+     */
+    //% block="countdown"
+    //% blockId=gamegetcountdown
+    //% weight=79
+    //% group="Countdown"
+    export function getCountdown() {
+        return (infoState.gameEnd - game.currentScene().millis()) / 1000;
+    }
+
+    /**
      * Start a countdown of the given duration in seconds
      * @param duration the duration of the countdown, eg: 10
      */
     //% blockId=gamecountdown block="start countdown %duration (s)"
-    //% help=info/start-countdown weight=79 blockGap=8
+    //% help=info/start-countdown weight=78 blockGap=8
     //% group="Countdown"
     export function startCountdown(duration: number) {
         updateFlag(Visibility.Countdown, true);
@@ -372,9 +383,24 @@ namespace info {
     }
 
     /**
+     * Get the value of the current count down
+     */
+    //% block="change countdown by $seconds (s)"
+    //% blockId=gamechangecountdown
+    //% weight=77
+    //% group="Countdown"
+    export function changeCountdownBy(seconds: number) {
+        if (!infoState) {
+            startCountdown(seconds);
+            return;
+        }
+        infoState.gameEnd += (seconds * 1000);
+    }
+
+    /**
      * Stop the current countdown and hides the timer display
      */
-    //% blockId=gamestopcountdown block="stop countdown" weight=78
+    //% blockId=gamestopcountdown block="stop countdown" weight=76
     //% help=info/stop-countdown
     //% group="Countdown"
     export function stopCountdown() {
@@ -384,30 +410,10 @@ namespace info {
     }
 
     /**
-     * Get the value of the current count down
-     */
-    //% block="countdown"
-    //% blockId=gamegetcountdown
-    //% group="Countdown"
-    export function getCountdown() {
-        return (infoState.gameEnd - game.currentScene().millis()) / 1000;
-    }
-
-    /**
-     * Get the value of the current count down
-     */
-    //% block="change countdown by $seconds (s)"
-    //% blockId=gamechangecountdown
-    //% group="Countdown"
-    export function changeCountdownBy(seconds: number) {
-        infoState.gameEnd += (seconds * 1000);
-    }
-
-    /**
      * Run code when the countdown reaches 0. If this function
      * is not called then game.over() is called instead
      */
-    //% blockId=gamecountdownevent block="on countdown end" weight=77
+    //% blockId=gamecountdownevent block="on countdown end" weight=75
     //% help=info/on-countdown-end
     //% group="Countdown"
     export function onCountdownEnd(handler: () => void) {

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -386,7 +386,7 @@ namespace info {
     /**
      * Get the value of the current count down
      */
-    //% block
+    //% block="countdown"
     //% blockId=gamegetcountdown
     //% group="Countdown"
     export function getCountdown() {


### PR DESCRIPTION
Added two blocks so that users can get the current countdown of their game and also change the countdown by negative or positive seconds. Negative makes it so there is less time left on the countdown, positive makes it so there is more time on the countdown. 

**Quick Demo:** 


https://user-images.githubusercontent.com/49178322/194131975-ac438c6c-afd5-4234-a06f-e951f82faf48.mp4


**The Blocks** (the two new are at the bottom of the screenshot)

![countdown-group](https://user-images.githubusercontent.com/49178322/194129603-beac675b-1d9e-429f-a94f-179235645341.png)


Closes https://github.com/microsoft/pxt-arcade/issues/2248

**The target:** https://arcade.makecode.com/app/bf585e360f8e57bd8312ad0b0ea40b6f706ddba7-421bc06f42#editor
