### PR TITLE
Multiplayer fix host can pretend to be all players

### DIFF
--- a/libs/game/sim/keymap.ts
+++ b/libs/game/sim/keymap.ts
@@ -160,7 +160,7 @@ namespace pxsim {
 
         private clearMap(name: string) {
             const keyCodes = this.mappings[name];
-            keyCodes?.forEach(keyCode => delete this.keymap[keyCode]);
+            keyCodes && keyCodes.forEach(keyCode => delete this.keymap[keyCode]);
             delete this.mappings[name];
         }
     }

--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -42,7 +42,7 @@ namespace pxsim {
     export interface MultiplayerImageMessage extends SimulatorMultiplayerMessage {
         content: "Image";
         goal: string; // goal of message; e.g. "broadcast-screen"
-        image: RefImage;
+        image: RefBuffer;
     }
 
     export interface MultiplayerButtonEvent extends SimulatorMultiplayerMessage {
@@ -109,7 +109,7 @@ namespace pxsim {
                 }
             } else if (isButtonMessage(msg)) {
                 if (this.origin === "server") {
-                    (board() as any).setButton(
+                    board().handleKeyEvent(
                         msg.button + (7 * (msg.clientNumber || 1)), // + 7 to make it player 2 controls,
                         msg.state === "Pressed" || msg.state === "Held"
                     );

--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -109,7 +109,7 @@ namespace pxsim {
                 }
             } else if (isButtonMessage(msg)) {
                 if (this.origin === "server") {
-                    board().handleKeyEvent(
+                    (board() as any).handleKeyEvent(
                         msg.button + (7 * (msg.clientNumber || 1)), // + 7 to make it player 2 controls,
                         msg.state === "Pressed" || msg.state === "Held"
                     );


### PR DESCRIPTION
setButton basically just calls handleKeyEvent, and is the location at which I'm rejecting buttons from players 2+ in multiplayer sessions, so just bypassing that.

Also minor typings fix to get rid of red squiggle, and fix usage of safe navigation operator not supported in ts2.6

part of fix for https://github.com/microsoft/pxt-arcade/issues/5138

This should go in at same time as or just before arcade sim side change, it's safe to be on it's own.