### PR TITLE
fix rate at which multiplayer images are sent to 20fps

### DIFF
--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -51,10 +51,12 @@ namespace pxsim {
         state: "Pressed" | "Released" | "Held";
     }
 
+    let postScreenInterval: any;
     export class MultiplayerState {
         lastMessageId: number;
         origin: string;
         backgroundImage: RefImage;
+
 
         constructor() {
             this.lastMessageId = 0;
@@ -74,7 +76,10 @@ namespace pxsim {
         init(origin: string) {
             this.origin = origin;
             runtime.board.addMessageListener(msg => this.messageHandler(msg));
-            setInterval(() => {
+            if (postScreenInterval) {
+                clearInterval(postScreenInterval)
+            }
+            postScreenInterval = setInterval(() => {
                 if (this.origin === "server") {
                     const b = board() as ScreenBoard;
                     const screenState = b && b.screenState;


### PR DESCRIPTION
It felt like way too many messages were going through so I poked around for a bit, due to some pretty weird lifecycle stuff in simdriver we actually end up initializing multiple times (I didn't look too closely but it appears to be a bit of a race -- e.g. when I just logged out I saw upwards of 4-5 calls to init like this but when I set breakpoints I only saw it repeat once or so), and this setInterval was getting recreated multiple times and sending upwards of 100 frames / a second.

The frame sending logic is independent of the individual sim runtime either way, so limit to a single setInterval in the scope of the frame