### PR TITLE
only post screen when at end of render, incl palette in sim<->host messages

### DIFF
--- a/libs/game/multiplayer.cpp
+++ b/libs/game/multiplayer.cpp
@@ -2,18 +2,15 @@
 
 namespace multiplayer {
     //%
-    void postImage(Image_ im, String goal) {
-        // no support >:(
+    void postImage(Image_ im) {
     }
 
     //%
     void setOrigin(String origin) {
-        // no
     }
 
     //%
     Image_ getCurrentImage() {
-        // nah
         return NULL;
     }
 

--- a/libs/game/multiplayer.ts
+++ b/libs/game/multiplayer.ts
@@ -2,11 +2,14 @@ namespace multiplayer {
     //% shim=multiplayer::getCurrentImage
     declare function getCurrentImage(): Image;
 
+    //% shim=multiplayer::postImage
+    export declare function postImage(im: Image): void;
+
     //% shim=multiplayer::setOrigin
     declare function setOrigin(origin: string): void;
 
     //% shim=multiplayer::getOrigin
-    declare function getOrigin(): string;
+    export declare function getOrigin(): string;
 
     export function init() {
         game.addScenePushHandler(() => {
@@ -20,5 +23,15 @@ namespace multiplayer {
             });
         });
         game.pushScene();
+    }
+
+    export function initServer() {
+        if (getOrigin() === "server") {
+            game.eventContext().registerFrameHandler(scene.MULTIPLAYER_POST_SCREEN_PRIORITY, () => {
+                if (getOrigin() === "server") {
+                    postImage(screen);
+                }
+            })
+        }
     }
 }

--- a/libs/game/multiplayer.ts
+++ b/libs/game/multiplayer.ts
@@ -3,13 +3,13 @@ namespace multiplayer {
     declare function getCurrentImage(): Image;
 
     //% shim=multiplayer::postImage
-    export declare function postImage(im: Image): void;
+    declare function postImage(im: Image): void;
 
     //% shim=multiplayer::setOrigin
     declare function setOrigin(origin: string): void;
 
     //% shim=multiplayer::getOrigin
-    export declare function getOrigin(): string;
+    declare function getOrigin(): string;
 
     export function init() {
         game.addScenePushHandler(() => {

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -65,6 +65,7 @@ namespace scene {
     export const RENDER_DIAGNOSTICS_PRIORITY = 150;
     export const MULTIPLAYER_SCREEN_PRIORITY = 190;
     export const UPDATE_SCREEN_PRIORITY = 200;
+    export const MULTIPLAYER_POST_SCREEN_PRIORITY = 210;
 
     // default rendering z indices
     export const ON_PAINT_Z = -20;
@@ -179,6 +180,7 @@ namespace scene {
             });
             // update screen
             this.eventContext.registerFrameHandler(UPDATE_SCREEN_PRIORITY, control.__screen.update);
+            multiplayer.initServer();
             // register additional components
             Scene.initializers.forEach(f => f(this));
         }

--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -4,6 +4,8 @@ namespace pxsim.multiplayer {
     }, 50, true);
 
     export function postImage(im: pxsim.RefImage) {
+        if (getMultiplayerState().origin !== "server")
+            return;
         const asBuf = pxsim.image.toBuffer(im);
         const sb = board() as ScreenBoard;
         throttledImgPost(<MultiplayerImageMessage>{

--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -6,7 +6,7 @@ namespace pxsim.multiplayer {
     export function postImage(im: pxsim.RefImage) {
         const asBuf = pxsim.image.toBuffer(im);
         const sb = board() as ScreenBoard;
-        getMultiplayerState().send(<MultiplayerImageMessage>{
+        throttledImgPost(<MultiplayerImageMessage>{
             content: "Image",
             image: asBuf,
             palette: sb?.screenState?.currPaletteString(),

--- a/libs/screen/sim/state.ts
+++ b/libs/screen/sim/state.ts
@@ -1,7 +1,6 @@
 namespace pxsim {
     function htmlColorToUint32(hexColor: string) {
         const ca = new Uint8ClampedArray(4)
-        const ui = new Uint32Array(ca.buffer)
         const v = parseInt(hexColor.replace(/#/, ""), 16)
         ca[0] = (v >> 16) & 0xff;
         ca[1] = (v >> 8) & 0xff;
@@ -11,11 +10,11 @@ namespace pxsim {
         return new Uint32Array(ca.buffer)[0]
     }
 
-    function UInt32ToHexColorCode(col: number) {
+    function UInt32ToRGB(col: number): number[] {
         const ui = new Uint32Array(1);
         ui[0] = col;
         const ca = new Uint8ClampedArray(ui.buffer);
-        return [ca[0], ca[1], ca[2]].reduce((acc, val) => acc + val.toString(16).padStart(2, "0"), "");
+        return [ca[0], ca[1], ca[2]];
     }
 
     export class ScreenState {
@@ -46,8 +45,16 @@ namespace pxsim {
             this.brightness = b | 0;
         }
 
-        currPaletteString() {
-            return this.palette.reduce((acc, curr) => acc + UInt32ToHexColorCode(curr), "");
+        paletteToUint8Array() {
+            const out = new Uint8Array(this.palette.length * 3);
+            for (let i = 0; i < this.palette.length; ++i) {
+                const [r, g, b] = UInt32ToRGB(this.palette[i]);
+                const s = 3 * i;
+                out[s] = r;
+                out[s + 1] = g;
+                out[s + 2] = b;
+            }
+            return out;
         }
 
         setPaletteFromHtmlColors(src: string[]) {

--- a/libs/screen/sim/state.ts
+++ b/libs/screen/sim/state.ts
@@ -11,6 +11,13 @@ namespace pxsim {
         return new Uint32Array(ca.buffer)[0]
     }
 
+    function UInt32ToHexColorCode(col: number) {
+        const ui = new Uint32Array(1);
+        ui[0] = col;
+        const ca = new Uint8ClampedArray(ui.buffer);
+        return [ca[0], ca[1], ca[2]].reduce((acc, val) => acc + val.toString(16).padStart(2, "0"), "");
+    }
+
     export class ScreenState {
         width = 0
         height = 0
@@ -25,10 +32,8 @@ namespace pxsim {
 
         constructor(paletteSrc: string[], w = 0, h = 0) {
             if (!paletteSrc) paletteSrc = ["#000000", "#ffffff"]
-            this.palette = new Uint32Array(paletteSrc.length)
-            for (let i = 0; i < this.palette.length; ++i) {
-                this.palette[i] = htmlColorToUint32(paletteSrc[i])
-            }
+            this.palette = new Uint32Array(paletteSrc.length);
+            this.setPaletteFromHtmlColors(paletteSrc);
             if (w) {
                 this.width = w
                 this.height = h
@@ -39,6 +44,16 @@ namespace pxsim {
 
         setScreenBrightness(b: number) {
             this.brightness = b | 0;
+        }
+
+        currPaletteString() {
+            return this.palette.reduce((acc, curr) => acc + UInt32ToHexColorCode(curr), "");
+        }
+
+        setPaletteFromHtmlColors(src: string[]) {
+            for (let i = 0; i < this.palette.length; ++i) {
+                this.palette[i] = htmlColorToUint32(src[i])
+            }
         }
 
         setPalette(buf: RefBuffer) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "libs/**/*"
   ],
   "dependencies": {
-    "pxt-core": "8.2.4"
+    "pxt-core": "8.4.8"
   },
   "devDependencies": {
     "typescript": "^4.2.3"


### PR DESCRIPTION
two main things:

* Send the screen from within the game engine, after the screen update step. Currently, we just send it at a random time in the loop, causing things to occasionally be misrendered / missing if they are done part way through the render (that is, it's not uncommon to see screens that are supposed to have a dialog flash the scene behind it without the dialog)
* Patch on palette to the messages that go between sim <-> host frame -- tested on the sending side, not on the consuming side yet. Have to check with Eric on how we want to format this in the --multiplayer <-> backend communication where it's binpacked -- it's currently a 48b uint8array, we can safely chop off the first 3 bytes if we want as those are always 0x00000 (transparency) -- even if someone tries to set it we just ignore that value.

~dependent on adding throttle to pxtsim/runtime.ts: https://github.com/microsoft/pxt/pull/9130, will need to bump pxt version in package.json after that's in~ pxt version bumped so ready to go~