### PR TITLE
Fixing camera read loc

### DIFF
--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -8,6 +8,8 @@ namespace scene {
         drawOffsetX: number;
         drawOffsetY: number;
         sprite: Sprite;
+        protected _lastUpdatedSpriteX: number;
+        protected _lastUpdatedSpriteY: number;
 
         protected shakeStartTime: number;
         protected shakeDuration: number;
@@ -75,9 +77,15 @@ namespace scene {
             }
         }
 
+        isUpdated() {
+            return !this.sprite || (this.sprite.x === this._lastUpdatedSpriteX && this.sprite.y === this._lastUpdatedSpriteY);
+        }
+
         update() {
             // if sprite, follow sprite
             if (this.sprite) {
+                this._lastUpdatedSpriteX = this.sprite.x;
+                this._lastUpdatedSpriteY = this.sprite.y;
                 this.offsetX = this.sprite.x - (screen.width >> 1);
                 this.offsetY = this.sprite.y - (screen.height >> 1);
             }

--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -27,9 +27,9 @@ namespace scene {
         set offsetX(v: number) {
             const scene = game.currentScene();
             if (scene.tileMap && scene.tileMap.enabled) {
-                this._offsetX = scene.tileMap.offsetX(v);
+                this._offsetX = Math.floor(scene.tileMap.offsetX(v));
             } else {
-                this._offsetX = v;
+                this._offsetX = Math.floor(v);
             }
         }
         get offsetY() {
@@ -38,29 +38,29 @@ namespace scene {
         set offsetY(v: number) {
             const scene = game.currentScene();
             if (scene.tileMap && scene.tileMap.enabled) {
-                this._offsetY = scene.tileMap.offsetY(v);
+                this._offsetY = Math.floor(scene.tileMap.offsetY(v));
             } else {
-                this._offsetY = v;
+                this._offsetY = Math.floor(v);
             }
         }
 
         get x() {
-            return this.drawOffsetX + (screen.width >> 1);
+            return this.offsetX + (screen.width >> 1);
         }
         get y() {
-            return this.drawOffsetY + (screen.height >> 1);
+            return this.offsetY + (screen.height >> 1);
         }
         get left() {
-            return this.drawOffsetX;
+            return this.offsetX;
         }
         get right() {
-            return this.drawOffsetX + screen.width;
+            return this.offsetX + screen.width;
         }
         get top() {
-            return this.drawOffsetY;
+            return this.offsetY;
         }
         get bottom() {
-            return this.drawOffsetY + screen.height;
+            return this.offsetY + screen.height;
         }
 
         shake(amplitude: number = 4, duration: number = 1000) {
@@ -81,9 +81,6 @@ namespace scene {
                 this.offsetX = this.sprite.x - (screen.width >> 1);
                 this.offsetY = this.sprite.y - (screen.height >> 1);
             }
-
-            this.offsetX = Math.floor(this.offsetX);
-            this.offsetY = Math.floor(this.offsetY);
 
             this.drawOffsetX = this.offsetX;
             this.drawOffsetY = this.offsetY;

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -195,6 +195,8 @@ namespace scene {
     //% weight=70
     export function cameraProperty(property: CameraProperty): number {
         const scene = game.currentScene();
+        if (scene.camera.sprite)
+            scene.camera.update();
         switch (property) {
             case CameraProperty.X: return scene.camera.x;
             case CameraProperty.Y: return scene.camera.y;

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -144,6 +144,7 @@ namespace scene {
     export function cameraFollowSprite(sprite: Sprite) {
         const scene = game.currentScene();
         scene.camera.sprite = sprite;
+        scene.camera.update();
     }
 
     /**

--- a/libs/game/scenes.ts
+++ b/libs/game/scenes.ts
@@ -196,7 +196,7 @@ namespace scene {
     //% weight=70
     export function cameraProperty(property: CameraProperty): number {
         const scene = game.currentScene();
-        if (scene.camera.sprite)
+        if (!scene.camera.isUpdated())
             scene.camera.update();
         switch (property) {
             case CameraProperty.X: return scene.camera.x;


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5440

here's a build for it as it's easiest to just test it https://arcade.makecode.com/app/708640d9e59404f6d619b6d9e551c9854dfa2596-d43654d8b7

This makes it so we basically pass through to the sprites position when grabbing camera state - so the pause(0) hack we did is no longer necessary, and it's fine bumping the code out of the `run code after game engine updates the camera` back into an on game update if we want. Here's a version where I did that: https://arcade.makecode.com/app/708640d9e59404f6d619b6d9e551c9854dfa2596-d43654d8b7#pub:_FFLTaRKXePxE