### PR TITLE
fix bug where moving out of screen on followed sprite can break with stay in screen

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -195,7 +195,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
                 if (tileMap && tileMap.enabled) {
                     this.tilemapCollisions(ms, tileMap);
                 }
-                
+
                 // check for screen edge collisions
                 const bounce = s.flags & sprites.Flag.BounceOnWall;
                 if (s.flags & sprites.Flag.StayInScreen || (bounce && !tileMap)) {
@@ -356,6 +356,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
     protected screenEdgeCollisions(movingSprite: MovingSprite, bounce: number, camera: scene.Camera) {
         let s = movingSprite.sprite;
         if (!s.isStatic()) s.setHitbox();
+        if (!camera.isUpdated()) camera.update();
 
         let offset = Fx.toFloat(s._hitbox.left) - camera.offsetX;
         if (offset < 0) {


### PR DESCRIPTION
Scenario is pretty simple; sprite has stay in screen set & is the sprite the camera is following, and moves off screen within the physics (e.g. as part of a wall hit event). This then causes it to snap to the edge of the screen, as the camera won't be updated at that point. (can occur without following the same sprite as stay in screen is set to, as that's a bit of a arbitrary circumstance, but describing those circumstances is much harder :) )

I'm very happy I did https://github.com/microsoft/pxt-common-packages/pull/1385 earlier this week or I would have been scratching my head a ton trying to figure out what could possibly have gone wrong here.