### PR TITLE
pass up player icons & reaction icons to multiplayer page

### DIFF
--- a/libs/game/multiplayer.cpp
+++ b/libs/game/multiplayer.cpp
@@ -4,6 +4,9 @@ namespace multiplayer {
     //%
     void postImage(Image_ im) {
     }
+    //%
+    void postIcon(int type, int icon, Image_ im) {
+    }
 
     //%
     void setOrigin(String origin) {

--- a/libs/game/multiplayer.ts
+++ b/libs/game/multiplayer.ts
@@ -1,9 +1,17 @@
 namespace multiplayer {
+    enum IconType {
+        Player = 0,
+        Reaction = 1,
+    }
+
     //% shim=multiplayer::getCurrentImage
     declare function getCurrentImage(): Image;
 
     //% shim=multiplayer::postImage
     declare function postImage(im: Image): void;
+
+    //% shim=multiplayer::postIcon
+    declare function postIcon(type: IconType, slot: number, im: Image): void;
 
     //% shim=multiplayer::setOrigin
     declare function setOrigin(origin: string): void;
@@ -33,5 +41,42 @@ namespace multiplayer {
                 }
             })
         }
+    }
+
+    export function postPresenceIcon(slot: number, im: Image, implicit?: boolean) {
+        initIconState();
+        if (slot < 1 || slot > 4)
+            return;
+
+        const presenceSetExplicitly = explicitlySetIcons[IconType.Player];
+        if (implicit && presenceSetExplicitly[slot])
+            return;
+        if (!implicit)
+            presenceSetExplicitly[slot] = true;
+
+        postIcon(IconType.Player, slot, im);
+    }
+
+    export function postReactionIcon(slot: number, im: Image, implicit?: boolean) {
+        initIconState();
+        if (slot < 1 || slot > 6)
+            return;
+
+        const reactionsSetExplicitly = explicitlySetIcons[IconType.Reaction];
+        if (implicit && reactionsSetExplicitly[slot])
+            return;
+        if (!implicit)
+            reactionsSetExplicitly[slot] = true;
+
+        postIcon(IconType.Reaction, slot, im);
+    }
+
+    let explicitlySetIcons: boolean[][];
+    function initIconState() {
+        if (explicitlySetIcons)
+            return;
+        explicitlySetIcons = [];
+        explicitlySetIcons[IconType.Player] = [];
+        explicitlySetIcons[IconType.Reaction] = [];
     }
 }

--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -16,6 +16,25 @@ namespace pxsim.multiplayer {
         } as pxsim.MultiplayerImageMessage);
     }
 
+    export function postIcon(iconType: IconType, slot: number, im: pxsim.RefImage) {
+        if (getMultiplayerState().origin !== "server")
+            return;
+        if (im._width * im._height > 64 * 64) {
+            // setting 64x64 as max size for icon for now
+            return;
+        }
+        const asBuf = pxsim.image.toBuffer(im);
+        const sb = board() as ScreenBoard;
+        const screenState = sb && sb.screenState;
+        getMultiplayerState().send({
+            content: "Icon",
+            slot: slot,
+            icon: asBuf,
+            iconType: iconType,
+            palette: screenState.paletteToUint8Array(),
+        } as pxsim.MultiplayerIconMessage);
+    }
+
 
     export function getCurrentImage(): pxsim.RefImage {
         return getMultiplayerState().backgroundImage;
@@ -52,6 +71,19 @@ namespace pxsim {
     export interface MultiplayerImageMessage extends SimulatorMultiplayerMessage {
         content: "Image";
         image: RefBuffer;
+        // 48bytes, [r0,g0,b0,r1,g1,b1,...]
+        palette: Uint8Array;
+    }
+
+    export enum IconType {
+        Player = 0,
+        Reaction = 1,
+    }
+    export interface MultiplayerIconMessage extends SimulatorMultiplayerMessage {
+        content: "Icon";
+        icon: RefBuffer;
+        slot: number;
+        iconType: IconType;
         // 48bytes, [r0,g0,b0,r1,g1,b1,...]
         palette: Uint8Array;
     }

--- a/libs/multiplayer/fieldEditors.ts
+++ b/libs/multiplayer/fieldEditors.ts
@@ -1,4 +1,4 @@
-namespace mp {
+namespace multiplayer {
     /**
      * A type of state to get for a player
      */

--- a/libs/multiplayer/mp.ts
+++ b/libs/multiplayer/mp.ts
@@ -1,5 +1,4 @@
-const postPresence = multiplayer.postPresenceIcon;
-namespace sprites.multiplayer {
+namespace sprites.mp {
     //% blockId=mp_setPlayerSprite
     //% block="set $player sprite to $sprite=variables_get(mySprite)"
     //% player.shadow=mp_playernumber
@@ -11,7 +10,7 @@ namespace sprites.multiplayer {
         if (sprite && sprite.image) {
             // Passing 'implicit' flag so we don't override icons that
             // user has explicitly defined.
-            postPresence(
+            multiplayer.postPresenceIcon(
                 player,
                 sprite.image,
                 /** implicit **/ true
@@ -19,14 +18,14 @@ namespace sprites.multiplayer {
         } else {
             // Passing 'implicit' flag so we don't override icons that
             // user has explicitly defined.
-            postPresence(
+            multiplayer.postPresenceIcon(
                 player,
                 undefined,
                 /** implicit **/ true
             );
 
         }
-        mp._state().setPlayerSprite(player, sprite);
+        multiplayer._state().setPlayerSprite(player, sprite);
     }
 
     //% blockId=mp_getPlayerSprite
@@ -37,7 +36,7 @@ namespace sprites.multiplayer {
     //% group="Multiplayer"
     //% parts="multiplayer"
     export function getPlayerSprite(player: number): Sprite {
-        return mp._state().getPlayerSprite(player);
+        return multiplayer._state().getPlayerSprite(player);
     }
 
     //% blockId=mp_isPlayerSprite
@@ -53,7 +52,7 @@ namespace sprites.multiplayer {
     }
 }
 
-namespace controller.multiplayer {
+namespace controller.mp {
     //% blockId=mp_moveWithButtons
     //% block="$player move $sprite with buttons||vx $vx vy $vy"
     //% player.shadow=mp_playernumber
@@ -74,7 +73,7 @@ namespace controller.multiplayer {
         vx?: number,
         vy?: number
     ) {
-        mp.getController(player).moveSprite(sprite, vx, vy);
+        multiplayer.getController(player).moveSprite(sprite, vx, vy);
     }
 
     //% blockId=mp_onButtonEvent
@@ -84,11 +83,11 @@ namespace controller.multiplayer {
     //% parts="multiplayer"
     //% weight=90
     export function onButtonEvent(
-        button: mp.MultiplayerButton,
+        button: multiplayer.MultiplayerButton,
         event: ControllerButtonEvent,
         handler: (player: number) => void
     ) {
-        mp._state().onButtonEvent(button, event, handler);
+        multiplayer._state().onButtonEvent(button, event, handler);
     }
 
     //% blockId=mp_isButtonPressed
@@ -100,13 +99,13 @@ namespace controller.multiplayer {
     //% blockGap=8
     export function isButtonPressed(
         player: number,
-        button: mp.MultiplayerButton
+        button: multiplayer.MultiplayerButton
     ): boolean {
-        return mp.getButton(mp.getController(player), button).isPressed();
+        return multiplayer.getButton(multiplayer.getController(player), button).isPressed();
     }
 }
 
-namespace info.multiplayer {
+namespace info.mp {
     //% blockId=mp_getPlayerState
     //% block="$player $state"
     //% player.shadow=mp_playernumber
@@ -117,12 +116,12 @@ namespace info.multiplayer {
     //% blockGap=8
     export function getPlayerState(player: number, state: number): number {
         if (state === MultiplayerState.Score) {
-            return mp.getInfo(player).score();
+            return multiplayer.getInfo(player).score();
         } else if (state === MultiplayerState.Lives) {
-            return mp.getInfo(player).life();
+            return multiplayer.getInfo(player).life();
         }
 
-        return mp._state().getPlayerState(player, state);
+        return multiplayer._state().getPlayerState(player, state);
     }
 
     //% blockId=mp_setPlayerState
@@ -139,12 +138,12 @@ namespace info.multiplayer {
         value: number
     ) {
         if (state === MultiplayerState.Score) {
-            return mp.getInfo(player).setScore(value);
+            return multiplayer.getInfo(player).setScore(value);
         } else if (state === MultiplayerState.Lives) {
-            return mp.getInfo(player).setLife(value);
+            return multiplayer.getInfo(player).setLife(value);
         }
 
-        mp._state().setPlayerState(player, state, value);
+        multiplayer._state().setPlayerState(player, state, value);
     }
 
     //% blockId=mp_changePlayerStateBy
@@ -176,7 +175,7 @@ namespace info.multiplayer {
     //% weight=70
     //% blockGap=8
     export function onScore(score: number, handler: (player: number) => void) {
-        mp._state().onReachedScore(score, handler);
+        multiplayer._state().onReachedScore(score, handler);
     }
 
     //% blockId=mp_onLifeZero
@@ -186,14 +185,14 @@ namespace info.multiplayer {
     //% parts="multiplayer"
     //% weight=60
     export function onLifeZero(handler: (player: number) => void) {
-        mp._state().onLifeZero(handler);
+        multiplayer._state().onLifeZero(handler);
     }
 }
 
 //% icon="\uf0c0"
 //% block="Multiplayer"
 //% color="#207a77"
-namespace mp {
+namespace multiplayer {
     export enum PlayerNumber {
         //% block="1"
         One = 1,
@@ -228,7 +227,7 @@ namespace mp {
     //% parts="multiplayer"
     //% weight=100
     export function setPlayerIndicatorsVisible(visible: boolean) {
-        mp._state().setPlayerIndicatorsVisible(visible);
+        multiplayer._state().setPlayerIndicatorsVisible(visible);
     }
 
     //% blockId=mp_isPlayer
@@ -328,7 +327,7 @@ namespace mp {
 
     class ButtonHandler {
         constructor(
-            public button: mp.MultiplayerButton,
+            public button: multiplayer.MultiplayerButton,
             public event: ControllerButtonEvent,
             public handler: (player: number) => void
         ) {}
@@ -404,7 +403,7 @@ namespace mp {
         }
 
         onButtonEvent(
-            button: mp.MultiplayerButton,
+            button: multiplayer.MultiplayerButton,
             event: ControllerButtonEvent,
             handler: (playerNumber: number) => void
         ) {
@@ -418,7 +417,7 @@ namespace mp {
             this.buttonHandlers.push(new ButtonHandler(button, event, handler));
 
             const registerHandler = (p: number) => {
-                mp.getButton(mp.getController(p), button).onEvent(event, () => {
+                multiplayer.getButton(multiplayer.getController(p), button).onEvent(event, () => {
                     this.getButtonHandler(button, event).handler(p);
                 });
             };
@@ -439,7 +438,7 @@ namespace mp {
             this.scoreHandlers.push(new ScoreHandler(score, handler));
 
             const registerHandler = (p: number) => {
-                mp.getInfo(p).onScore(score, () => {
+                multiplayer.getInfo(p).onScore(score, () => {
                     this.getScoreHandler(score).handler(p);
                 });
             };
@@ -452,7 +451,7 @@ namespace mp {
         onLifeZero(handler: (playerNumber: number) => void) {
             if (!this.lifeZeroHandler) {
                 const registerHandler = (p: number) => {
-                    mp.getInfo(p).onLifeZero(() => {
+                    multiplayer.getInfo(p).onLifeZero(() => {
                         this.lifeZeroHandler(p);
                     });
                 };
@@ -515,7 +514,7 @@ namespace mp {
         }
 
         protected getButtonHandler(
-            button: mp.MultiplayerButton,
+            button: multiplayer.MultiplayerButton,
             event: ControllerButtonEvent
         ) {
             for (const bHandler of this.buttonHandlers) {

--- a/libs/multiplayer/mp.ts
+++ b/libs/multiplayer/mp.ts
@@ -1,3 +1,4 @@
+const postPresence = multiplayer.postPresenceIcon;
 namespace sprites.multiplayer {
     //% blockId=mp_setPlayerSprite
     //% block="set $player sprite to $sprite=variables_get(mySprite)"
@@ -7,6 +8,24 @@ namespace sprites.multiplayer {
     //% group="Multiplayer"
     //% parts="multiplayer"
     export function setPlayerSprite(player: number, sprite: Sprite) {
+        if (sprite && sprite.image) {
+            // Passing 'implicit' flag so we don't override icons that
+            // user has explicitly defined.
+            postPresence(
+                player,
+                sprite.image,
+                /** implicit **/ true
+            );
+        } else {
+            // Passing 'implicit' flag so we don't override icons that
+            // user has explicitly defined.
+            postPresence(
+                player,
+                undefined,
+                /** implicit **/ true
+            );
+
+        }
         mp._state().setPlayerSprite(player, sprite);
     }
 


### PR DESCRIPTION
final portion of the support, depends on https://github.com/microsoft/pxt/pull/9287 and https://github.com/microsoft/pxt-backend/pull/748 . @eanders-ms if you're not in the middle of a pr I'll just go ahead and swap the `*.multiplayer` namespaces to `*.mp` so that I can remove the hack in `/mp.ts`. Here's a test game that sets the two user sprites + a pizza for slot one: 
https://makecode.com/_XrmfzuFdyLHt

(no blocks for setting icons directly, just the javascript api -- I'll add it to sprite util extension or something unless we decide to include one)

for the javascript apis, there's a possibly slightly tricky 'implicitly set vs explicitly set' state for whether the icon gets sent or not -- this is so we can add the default behavior of 'set / update player icon whenever they setPlayerSprite' without overriding images that the player has explicitly set (e.g. with the extension blocks I mentioned above)