### PR TITLE
walls shouldn't stop new ghosts

### DIFF
--- a/libs/game/physics.ts
+++ b/libs/game/physics.ts
@@ -466,7 +466,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
                     if (s.flags & sprites.Flag.DestroyOnWall) {
                         s.destroy();
-                    } else if (s._vx === movingSprite.cachedVx) {
+                    } else if (s._vx === movingSprite.cachedVx && !(s.flags & SPRITE_NO_WALL_COLLISION)) {
                         // sprite collision event didn't change velocity in this direction;
                         // apply normal updates
                         if (s.flags & sprites.Flag.BounceOnWall) {
@@ -547,7 +547,7 @@ class ArcadePhysicsEngine extends PhysicsEngine {
 
                     if (s.flags & sprites.Flag.DestroyOnWall) {
                         s.destroy();
-                    } else if (s._vy === movingSprite.cachedVy) {
+                    } else if (s._vy === movingSprite.cachedVy && !(s.flags & SPRITE_NO_WALL_COLLISION)) {
                         // sprite collision event didn't change velocity in this direction;
                         // apply normal updates
                         if (s.flags & sprites.Flag.BounceOnWall) {


### PR DESCRIPTION
fix physics bug we ran into on stream last week (the one we hacked in a fix by adding 1 to vx) -- make it so when a wall collision handler causes a sprite to be unable to collide with walls (newly clipping, ghost, destroyed) we don't 0 out the velocity. If we think destroyed might actually occur and end up with some visual nonsense I can change it to just `SpriteFlag.GhostThroughWalls`~

here's a sample game where it'd apply https://arcade.makecode.com/S79255-37130-89180-31596