### PR TITLE
mv post reaction / presence icon to mp namespace

### DIFF
--- a/libs/game/multiplayer.ts
+++ b/libs/game/multiplayer.ts
@@ -1,17 +1,9 @@
 namespace multiplayer {
-    enum IconType {
-        Player = 0,
-        Reaction = 1,
-    }
-
     //% shim=multiplayer::getCurrentImage
     declare function getCurrentImage(): Image;
 
     //% shim=multiplayer::postImage
     declare function postImage(im: Image): void;
-
-    //% shim=multiplayer::postIcon
-    declare function postIcon(type: IconType, slot: number, im: Image): void;
 
     //% shim=multiplayer::setOrigin
     declare function setOrigin(origin: string): void;
@@ -42,6 +34,15 @@ namespace multiplayer {
             })
         }
     }
+}
+
+namespace mp {
+    enum IconType {
+        Player = 0,
+        Reaction = 1,
+    }
+    //% shim=multiplayer::postIcon
+    declare function postIcon(type: IconType, slot: number, im: Image): void;
 
     export function postPresenceIcon(slot: number, im: Image, implicit?: boolean) {
         initIconState();

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -98,7 +98,7 @@ namespace mp {
             if (sprite && sprite.image) {
                 // Passing 'implicit' flag so we don't override icons that
                 // user has explicitly defined.
-                multiplayer.postPresenceIcon(
+                mp.postPresenceIcon(
                     this.number,
                     sprite.image,
                     /** implicit **/ true
@@ -106,12 +106,12 @@ namespace mp {
             } else {
                 // Passing 'implicit' flag so we don't override icons that
                 // user has explicitly defined.
-                multiplayer.postPresenceIcon(
+                mp.postPresenceIcon(
                     this.number,
                     undefined,
                     /** implicit **/ true
                 );
-    
+
             }
             this._sprite = sprite;
         }


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5532

as a sidenote we'll still have two apis in here (multiplayer.init & multiplayer.initServer) but they're internal / not things we'd particularly want users to use anyways