### PR TITLE
Unify all music playback blocks

### DIFF
--- a/libs/mixer/instrument.ts
+++ b/libs/mixer/instrument.ts
@@ -1,6 +1,8 @@
 namespace music.sequencer {
     const BUFFER_SIZE = 12;
 
+    let currentSequencer: sequencer.Sequencer;
+
     /**
      * Byte encoding format for songs
      * FIXME: should this all be word aligned?
@@ -66,10 +68,11 @@ namespace music.sequencer {
      *          2 = sharp
      */
 
-    export class Song {
+    export class Song extends Playable {
         tracks: Track[];
 
         constructor(public buf: Buffer) {
+            super();
             this.tracks = [];
 
             let currentOffset = 7;
@@ -127,6 +130,22 @@ namespace music.sequencer {
 
         get numberOfTracks(): number {
             return this.buf[6];
+        }
+
+        play(playbackMode: PlaybackMode) {
+            if (currentSequencer) currentSequencer.stop();
+            currentSequencer = new sequencer.Sequencer(this);
+
+            if (playbackMode === PlaybackMode.UntilDone) {
+                currentSequencer.start(false);
+                pause(this.measures * this.beatsPerMeasure * this.beatsPerMinute * 60 * 1000)
+            }
+            else if (playbackMode === PlaybackMode.InBackground) {
+                currentSequencer.start(false);
+            }
+            else {
+                currentSequencer.start(true);
+            }
         }
     }
 

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -597,7 +597,7 @@ namespace music {
     //% toolboxParent=music_playable_play
     //% toolboxParentArgument=toPlay
     //% group="Songs"
-    export function createSong(song: Buffer) {
+    export function createSong(song: Buffer): Playable {
         return new sequencer.Song(song);
     }
 

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -81,6 +81,7 @@ namespace music {
     //% blockNamespace=music
     //% weight=76 blockGap=8
     //% group="Tone"
+    //% deprecated=1
     export function playTone(frequency: number, ms: number): void {
         if (ms == 0)
             ms = 86400000 // 1 day
@@ -123,6 +124,7 @@ namespace music {
     //% melody.shadow="melody_editor"
     //% tempo.min=40 tempo.max=500
     //% tempo.defl=120
+    //% deprecated=1
     export function playMelody(melody: string, tempo: number) {
         let notes: string[] = melody.split(" ").filter(n => !!n);
         let formattedMelody = "";
@@ -181,6 +183,7 @@ namespace music {
     export function stopAllSounds() {
         Melody.stopAll();
         stopPlaying();
+        _stopPlayables();
     }
 
     //% fixedInstances
@@ -213,6 +216,7 @@ namespace music {
         //% parts="headphone"
         //% weight=92 blockGap=8
         //% group="Sounds"
+        //% deprecated=1
         stop() {
             if (this._player) {
                 this._player.stop()
@@ -270,6 +274,7 @@ namespace music {
         //% parts="headphone"
         //% weight=93 blockGap=8
         //% group="Sounds"
+        //% deprecated=1
         loop(volume = 255) {
             this.playCore(volume, true)
         }
@@ -283,6 +288,7 @@ namespace music {
         //% parts="headphone"
         //% weight=95 blockGap=8
         //% group="Sounds"
+        //% deprecated=1
         play(volume = 255) {
             this.playCore(volume, false)
         }
@@ -297,6 +303,7 @@ namespace music {
         //% parts="headphone"
         //% weight=94 blockGap=8
         //% group="Sounds"
+        //% deprecated=1
         playUntilDone(volume = 255) {
             this.stop()
             const p = this._player = new MelodyPlayer(this)
@@ -583,26 +590,15 @@ namespace music {
         }
     }
 
-    let currentSequencer: sequencer.Sequencer;
-
     //% shim=TD_ID
     //% blockId=music_song_field_editor
-    //% block="$song"
+    //% block="song $song"
     //% song.fieldEditor=musiceditor
-    export function _songFieldEditor(song: Buffer) {
-        return song;
-    }
-
-    //% blockId=music_start_song
-    //% block="start song $song looping $loop"
-    //% song.snippet="hex``"
-    //% song.pySnippet='hex(""" """)'
-    //% song.shadow=music_song_field_editor
-    export function startSong(song: Buffer, loop: boolean) {
-        if (currentSequencer) currentSequencer.stop();
-
-        currentSequencer = new sequencer.Sequencer(new sequencer.Song(song));
-        currentSequencer.start(loop);
+    //% toolboxParent=music_playable_play
+    //% toolboxParentArgument=toPlay
+    //% group="Songs"
+    export function createSong(song: Buffer) {
+        return new sequencer.Song(song);
     }
 
     export function playInstructions(when: number, instructions: Buffer) {

--- a/libs/mixer/playable.ts
+++ b/libs/mixer/playable.ts
@@ -1,0 +1,181 @@
+namespace music {
+    export enum PlaybackMode {
+        //% block="until done"
+        UntilDone,
+        //% block="in background"
+        InBackground,
+        //% block="looping in background"
+        LoopingInBackground
+    }
+
+    let stateStack: PlayableState[];
+
+    class PlayableState {
+        looping: Playable[];
+        constructor() {
+            this.looping = [];
+        }
+
+        stopLooping() {
+            for (const p of this.looping) {
+                p.stopped = true;
+            }
+            this.looping = [];
+        }
+    }
+
+    function state() {
+        _init();
+        return stateStack[stateStack.length - 1];
+    }
+
+    function _init() {
+        if (stateStack) return;
+        stateStack = [new PlayableState()];
+
+        game.addScenePushHandler(() => {
+            stateStack.push(new PlayableState());
+        });
+
+        game.addScenePopHandler(() => {
+            stateStack.pop();
+            if (stateStack.length === 0) stateStack.push(new PlayableState());
+        });
+    }
+
+    export class Playable {
+        stopped: boolean;
+        constructor() {
+
+        }
+
+        play(playbackMode: PlaybackMode) {
+            // subclass
+        }
+
+        loop() {
+            state().looping.push(this);
+            this.stopped = false;
+
+            control.runInParallel(() => {
+                while (!this.stopped) {
+                    this.play(PlaybackMode.UntilDone);
+                }
+            });
+        }
+    }
+
+    export class MelodyPlayable extends Playable {
+        constructor(public melody: Melody) {
+            super();
+        }
+
+        play(playbackMode: PlaybackMode) {
+            if (playbackMode === PlaybackMode.InBackground) {
+                this.melody.play(music.volume());
+            }
+            else if (playbackMode === PlaybackMode.UntilDone) {
+                this.melody.playUntilDone(music.volume());
+            }
+            else {
+                this.melody.loop(music.volume());
+            }
+        }
+    }
+
+    export class TonePlayable extends Playable {
+        constructor(public pitch: number, public duration: number) {
+            super();
+        }
+
+        play(playbackMode: PlaybackMode) {
+            if (playbackMode === PlaybackMode.InBackground) {
+                control.runInParallel(() => music.playTone(this.pitch, this.duration));
+            }
+            else if (playbackMode === PlaybackMode.UntilDone) {
+                music.playTone(this.pitch, this.duration);
+                if (this.duration > 2000) {
+                    pause(this.duration);
+                }
+            }
+            else {
+                this.loop();
+            }
+        }
+    }
+
+    //% blockId="music_playable_play"
+    //% block="play $toPlay $playbackMode"
+    //% toPlay.shadow=music_melody_playable
+    //% group="Sounds"
+    export function play(toPlay: Playable, playbackMode: PlaybackMode) {
+        toPlay.play(playbackMode);
+    }
+
+    //% blockId="music_melody_playable"
+    //% block="sound $melody"
+    //% toolboxParent=music_playable_play
+    //% toolboxParentArgument=toPlay
+    //% group="Sounds"
+    //% duplicateShadowOnDrag
+    //% blockHidden
+    export function melodyPlayable(melody: Melody) {
+        return new MelodyPlayable(melody);
+    }
+
+
+    //% blockId="music_string_playable"
+    //% block="melody $melody at tempo $tempo|(bpm)"
+    //% toolboxParent=music_playable_play
+    //% toolboxParentArgument=toPlay
+    //% weight=85 blockGap=8
+    //% help=music/melody-editor
+    //% group="Songs"
+    //% duplicateShadowOnDrag
+    //% melody.shadow=melody_editor
+    //% tempo.min=40 tempo.max=500
+    //% tempo.defl=120
+    export function stringPlayable(melody: string, tempo: number) {
+        let notes: string[] = melody.split(" ").filter(n => !!n);
+        let formattedMelody = "";
+        let newOctave = false;
+
+        // build melody string, replace '-' with 'R' and add tempo
+        // creates format like "C5-174 B4 A G F E D C "
+        for (let i = 0; i < notes.length; i++) {
+            if (notes[i] === "-") {
+                notes[i] = "R";
+            } else if (notes[i] === "C5") {
+                newOctave = true;
+            } else if (newOctave) { // change the octave if necesary
+                notes[i] += "4";
+                newOctave = false;
+            }
+            // add tempo after first note
+            if (i == 0) {
+                formattedMelody += notes[i] + "-" + tempo + " ";
+            } else {
+                formattedMelody += notes[i] + " ";
+            }
+        }
+
+        return new MelodyPlayable(new Melody(formattedMelody));
+    }
+
+    //% blockId="music_tone_playable"
+    //% block="tone $note for $duration"
+    //% toolboxParent=music_playable_play
+    //% toolboxParentArgument=toPlay
+    //% group="Tone"
+    //% duplicateShadowOnDrag
+    //% note.shadow=device_note
+    //% duration.shadow=device_beat
+    //% parts="headphone"
+    export function tonePlayable(note: number, duration: number) {
+        return new TonePlayable(note, duration);
+    }
+
+    export function _stopPlayables() {
+        state().stopLooping();
+    }
+}

--- a/libs/mixer/playable.ts
+++ b/libs/mixer/playable.ts
@@ -119,7 +119,7 @@ namespace music {
     //% group="Sounds"
     //% duplicateShadowOnDrag
     //% blockHidden
-    export function melodyPlayable(melody: Melody) {
+    export function melodyPlayable(melody: Melody): Playable {
         return new MelodyPlayable(melody);
     }
 
@@ -135,7 +135,7 @@ namespace music {
     //% melody.shadow=melody_editor
     //% tempo.min=40 tempo.max=500
     //% tempo.defl=120
-    export function stringPlayable(melody: string, tempo: number) {
+    export function stringPlayable(melody: string, tempo: number): Playable {
         let notes: string[] = melody.split(" ").filter(n => !!n);
         let formattedMelody = "";
         let newOctave = false;
@@ -171,7 +171,7 @@ namespace music {
     //% note.shadow=device_note
     //% duration.shadow=device_beat
     //% parts="headphone"
-    export function tonePlayable(note: number, duration: number) {
+    export function tonePlayable(note: number, duration: number): Playable {
         return new TonePlayable(note, duration);
     }
 

--- a/libs/mixer/pxt.json
+++ b/libs/mixer/pxt.json
@@ -16,6 +16,7 @@
         "soundEffect.ts",
         "instrument.ts",
         "sequencer.ts",
+        "playable.ts",
         "pxtparts.json",
         "headphone.svg"
     ],

--- a/libs/mixer/soundEffect.ts
+++ b/libs/mixer/soundEffect.ts
@@ -39,7 +39,7 @@ enum SoundExpressionPlayMode {
 }
 
 namespace music {
-    export class SoundEffect {
+    export class SoundEffect extends Playable {
         waveShape: WaveShape;
         startFrequency: number;
         endFrequency: number;
@@ -50,6 +50,7 @@ namespace music {
         interpolation: InterpolationCurve;
 
         constructor() {
+            super();
             this.waveShape = WaveShape.Sine;
             this.startFrequency = 5000;
             this.endFrequency = 1;
@@ -77,6 +78,20 @@ namespace music {
                 volume
             );
         }
+
+        play(playbackMode: PlaybackMode) {
+            const toPlay = this.toBuffer(music.volume());
+            if (playbackMode === PlaybackMode.InBackground) {
+                queuePlayInstructions(0, toPlay);
+            }
+            else if (playbackMode === PlaybackMode.UntilDone) {
+                queuePlayInstructions(0, toPlay);
+                pause(this.duration)
+            }
+            else {
+                this.loop();
+            }
+        }
     }
 
 
@@ -87,11 +102,11 @@ namespace music {
      */
     //% blockId=soundExpression_playSoundEffect
     //% block="play sound $sound $mode"
-    //% sound.shadow=soundExpression_createSoundEffect
     //% weight=30
     //% help=music/play-sound-effect
     //% blockGap=8
     //% group="Sounds"
+    //% deprecated=1
     export function playSoundEffect(sound: SoundEffect, mode: SoundExpressionPlayMode) {
         const toPlay = sound.toBuffer(music.volume());
 
@@ -139,6 +154,8 @@ namespace music {
     //% inlineInputMode="variable"
     //% inlineInputModeLimit=3
     //% expandableArgumentBreaks="3,5"
+    //% toolboxParent=music_playable_play
+    //% toolboxParentArgument=toPlay
     //% weight=20
     //% group="Sounds"
     export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): SoundEffect {

--- a/libs/music/ns.ts
+++ b/libs/music/ns.ts
@@ -4,6 +4,6 @@
  */
 //% color=#E30FC0 weight=90 icon="\uf025"
 //% blockGap=8
-//% groups='["Sounds", "Songs", "Tone",  "Volume", "Tempo"]'
+//% groups='["Songs", "Sounds", "Tone",  "Volume", "Tempo"]'
 namespace music {
 }

--- a/libs/music/ns.ts
+++ b/libs/music/ns.ts
@@ -4,6 +4,6 @@
  */
 //% color=#E30FC0 weight=90 icon="\uf025"
 //% blockGap=8
-//% groups='["Sounds", "Melody", "Tone",  "Volume", "Tempo"]'
+//% groups='["Sounds", "Songs", "Tone",  "Volume", "Tempo"]'
 namespace music {
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5552

This PR unifies all of the various melody/song/tone/effect blocks into a single playback block with different shadows for each type. The playback block has three options for playback: "until done", "in background", or "looping in background". Here's what the toolbox looks with this change:

<img width="437" alt="image" src="https://user-images.githubusercontent.com/13754588/214426046-55d9ea5f-1048-498d-8933-687cc40de5d7.png">
<img width="428" alt="image" src="https://user-images.githubusercontent.com/13754588/214426121-5442f328-f602-46c3-b60e-0c12e6206e11.png">
<img width="432" alt="image" src="https://user-images.githubusercontent.com/13754588/214426175-38976e61-3b44-42f5-9f95-75a6f69c872d.png">
<img width="438" alt="image" src="https://user-images.githubusercontent.com/13754588/214426227-5338f5ac-c113-4242-a488-9043ba8b9da7.png">

All of the shadow blocks here have the "duplicate on drag" behavior so you can drag them out of the block to assign to variables or whatever. Not only does this change unify all of the blocks, it also reduces the overall number of blocks in the toolbox.

No upgrade rules are needed. Here's a build link: 

https://arcade.makecode.com/app/9896b4c680b9f43609dfc35cf51de2d68d18f0ba-e997f1cd4e