### PR TITLE
add 'none' option for particle effects dropdown

### DIFF
--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -360,7 +360,7 @@ namespace effects {
                 if (sources && sources.length)
                     sources.removeElement(this);
             }
-            destroy() { this._prune();}
+            destroy() { this._prune(); }
             clear() { this.head = undefined; }
         }
         const source = new NullParticleSource();

--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -353,9 +353,10 @@ namespace effects {
             // remove self at next opportunity
             _prune() {
                 const scene = game.currentScene();
-                if (scene)
-                    scene.allSprites.removeElement(this);
-                const sources = game.currentScene().particleSources;
+                if (!scene)
+                    return;
+                scene.allSprites.removeElement(this);
+                const sources = scene.particleSources;
                 if (sources && sources.length)
                     sources.removeElement(this);
             }

--- a/libs/game/particleeffects.ts
+++ b/libs/game/particleeffects.ts
@@ -337,4 +337,33 @@ namespace effects {
         source.z = -2;
         return source;
     });
+
+    //% fixedInstance whenUsed block="none"
+    export const none = new ScreenEffect(0, 0, 0, function (anchor: particles.ParticleAnchor, particlesPerSecond: number) {
+        class NullParticleSource extends particles.ParticleSource {
+            constructor() {
+                super(null, 0);
+                this._prune();
+            }
+
+            __draw(camera: scene.Camera) {}
+
+            _update(dt: number) {}
+
+            // remove self at next opportunity
+            _prune() {
+                const scene = game.currentScene();
+                if (scene)
+                    scene.allSprites.removeElement(this);
+                const sources = game.currentScene().particleSources;
+                if (sources && sources.length)
+                    sources.removeElement(this);
+            }
+            destroy() { this._prune();}
+            clear() { this.head = undefined; }
+        }
+        const source = new NullParticleSource();
+
+        return source;
+    });
 }


### PR DESCRIPTION
I believe this is what you were looking for? This will add it to all effects dropdowns but 🤷, maybe we can make it so this clears all sources to treat it as a proper 'clear all effects' effect (if you wanna try that just making prune call destroy on every other element in the array)