### PR TITLE
Add `game over [player]` block to multiplayer extension

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -82,10 +82,10 @@ namespace game {
             else this.loseMessage = message;
             if (explicit) this.messageSetByUser = true;
         }
-        getMessage(win: boolean) {
+        getMessage(win: boolean, preferMultiplayer?: boolean) {
             if (this.messageSetByUser)
                 return win ? this.winMessage : this.loseMessage;
-            else if (info.multiplayerScoring() && this.scoringType !== ScoringType.None)
+            else if (preferMultiplayer)
                 return win ? this.winMessageMultiplayer : this.loseMessage;
             else
                 return win ? this.winMessage : this.loseMessage;
@@ -322,7 +322,11 @@ namespace game {
         _gameOverImpl(win);
     }
 
-    function _gameOverImpl(win: boolean) {
+    export function gameOverPlayerWin(player: number) {
+        _gameOverImpl(true, player);
+    }
+
+    function _gameOverImpl(win: boolean, winnerOverride?: number) {
         init();
         if (__isOver) return;
         __isOver = true;
@@ -332,19 +336,20 @@ namespace game {
         } else {
             const goc = game.gameOverConfig();
 
-            const judged = goc.scoringType !== ScoringType.None;
+            const judged = !winnerOverride && goc.scoringType !== ScoringType.None;
             const playersWithScores = info.playersWithScores();
             const prevBestScore = judged && info.highScore();
             const winner = judged && win && info.winningPlayer();
             const scores = playersWithScores.map(player => new GameOverPlayerScore(player.number, player.impl.score(), player === winner));
 
-            // Save all scores as relevant to the game.
-            if (winner) {
+            // Save scores if this was a judged game and there was a winner (don't save in the LOSE case).
+                if (judged && winner) {
                 info.saveAllScores();
                 info.saveHighScore();
             }
 
-            const message = goc.getMessage(win);
+            const preferMultiplayer = !!winnerOverride || (judged && info.multiplayerScoring());
+            const message = goc.getMessage(win, preferMultiplayer);
             const effect = goc.getEffect(win);
             const sound = goc.getSound(win);
 
@@ -362,7 +367,7 @@ namespace game {
 
             pause(400);
 
-            const overDialog = new GameOverDialog(win, message, judged, scores, prevBestScore);
+            const overDialog = new GameOverDialog(win, message, judged, scores, prevBestScore, winnerOverride);
             scene.createRenderable(scene.HUD_Z, target => {
                 overDialog.update();
                 target.drawTransparentImage(

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -343,7 +343,7 @@ namespace game {
             const scores = playersWithScores.map(player => new GameOverPlayerScore(player.number, player.impl.score(), player === winner));
 
             // Save scores if this was a judged game and there was a winner (don't save in the LOSE case).
-                if (judged && winner) {
+            if (judged && winner) {
                 info.saveAllScores();
                 info.saveHighScore();
             }

--- a/libs/multiplayer/ns.ts
+++ b/libs/multiplayer/ns.ts
@@ -1,0 +1,6 @@
+//% color="#207a77" weight=96 icon="\uf0c0"
+//% blockGap=8
+//% block="Multiplayer"
+//% groups='["Sprites", "Controller", "Info", "Game", "Utility"]'
+namespace mp {
+}

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -1,6 +1,3 @@
-//% color="#207a77"
-//% icon="\uf0c0"
-//% block="Multiplayer"
 namespace mp {
     const MAX_PLAYERS = 4;
 
@@ -403,6 +400,7 @@ namespace mp {
     //% help=multiplayer/get-player-sprite
     //% parts="multiplayer"
     export function getPlayerSprite(player: Player): Sprite {
+        if (!player) return undefined;
         return player.getSprite();
     }
 
@@ -421,6 +419,7 @@ namespace mp {
     //% help=multiplayer/set-player-sprite
     //% parts="multiplayer"
     export function setPlayerSprite(player: Player, sprite: Sprite) {
+        if (!player) return;
         player.setSprite(sprite);
     }
 
@@ -445,6 +444,7 @@ namespace mp {
     //% help=controller/move-sprite
     //% parts="multiplayer"
     export function moveWithButtons(player: Player, vx?: number, vy?: number) {
+        if (!player) return;
         player.moveWithButtons(vx, vy);
     }
 
@@ -481,6 +481,7 @@ namespace mp {
     //% help=controller/button/is-pressed
     //% parts="multiplayer"
     export function isButtonPressed(player: Player, button: MultiplayerButton): boolean {
+        if (!player) return false;
         return getButton(player._getController(), button).isPressed();
     }
 
@@ -517,6 +518,7 @@ namespace mp {
     //% help=multiplayer/get-player-state
     //% parts="multiplayer"
     export function getPlayerState(player: Player, state: number): number {
+        if (!player) return 0;
         return player.getState(state);
     }
 
@@ -536,6 +538,7 @@ namespace mp {
     //% help=multiplayer/set-player-state
     //% parts="multiplayer"
     export function setPlayerState(player: Player, state: number, value: number) {
+        if (!player) return;
         player.setState(state, value);
     }
 
@@ -556,6 +559,7 @@ namespace mp {
     //% help=multiplayer/change-player-state-by
     //% parts="multiplayer"
     export function changePlayerStateBy(player: Player, state: number, delta: number) {
+        if (!player) return;
         player.setState(state, player.getState(state) + delta);
     }
 
@@ -574,6 +578,7 @@ namespace mp {
     //% help=multiplayer/get-player-property
     //% parts="multiplayer"
     export function getPlayerProperty(player: Player, prop: PlayerProperty): number {
+        if (!player) return 0;
         return player.getProperty(prop);
     }
 
@@ -609,6 +614,19 @@ namespace mp {
     //% parts="multiplayer"
     export function onLifeZero(handler: (player: Player) => void) {
         _mpstate().onLifeZero(handler);
+    }
+
+    //% blockId=mp_gameOverPlayerWin
+    //% block="game over $player wins"
+    //% player.shadow=mp_playerSelector
+    //% group=Game
+    //% weight=100
+    //% blockGap=8
+    //% help=multiplayer/game-over-player-win
+    //% parts="multiplayer"
+    export function gameOverPlayerWin(player: Player) {
+        if (!player) return;
+        game.gameOverPlayerWin(player.number);
     }
 
     /**

--- a/libs/multiplayer/pxt.json
+++ b/libs/multiplayer/pxt.json
@@ -3,6 +3,7 @@
     "description": "Additional blocks for building multiplayer games",
     "files": [
         "README.md",
+        "ns.ts",
         "fieldEditors.ts",
         "images.ts",
         "player.ts",


### PR DESCRIPTION
Adds this block to the multiplayer extension:

![image](https://user-images.githubusercontent.com/12176807/214495878-96a3f6a1-5c12-47f6-899d-11479b1f2d72.png)

It overrides the active scoring method to explicitly set who won the game.

Resolves https://github.com/microsoft/pxt-arcade/issues/5559