### PR TITLE
Support playable as game over sound

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -161,7 +161,7 @@ namespace info {
                                 // Clear effect and sound, unless set by user
                                 const goc = game.gameOverConfig();
                                 goc.setEffect(false, null, false);
-                                goc.setSound(false, null, false);
+                                goc.setSound(false, null, false, false);
                                 game.gameOver(false);
                             }
                         }
@@ -779,7 +779,7 @@ namespace info {
                     // Clear effect and sound, unless set by user
                     const goc = game.gameOverConfig();
                     goc.setEffect(false, null, false);
-                    goc.setSound(false, null, false);
+                    goc.setSound(false, null, false, false);
                     game.gameOver(false);
                 }
             }

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -590,13 +590,13 @@ namespace music {
         }
     }
 
-    //% shim=TD_ID
     //% blockId=music_song_field_editor
     //% block="song $song"
     //% song.fieldEditor=musiceditor
     //% toolboxParent=music_playable_play
     //% toolboxParentArgument=toPlay
     //% group="Songs"
+    //% duplicateShadowOnDrag
     export function createSong(song: Buffer): Playable {
         return new sequencer.Song(song);
     }

--- a/libs/mixer/soundEffect.ts
+++ b/libs/mixer/soundEffect.ts
@@ -158,6 +158,7 @@ namespace music {
     //% toolboxParentArgument=toPlay
     //% weight=20
     //% group="Sounds"
+    //% duplicateShadowOnDrag
     export function createSoundEffect(waveShape: WaveShape, startFrequency: number, endFrequency: number, startVolume: number, endVolume: number, duration: number, effect: SoundExpressionEffect, interpolation: InterpolationCurve): SoundEffect {
         const result = new SoundEffect();
 


### PR DESCRIPTION
The game over "use sound" block now takes any playable type.

![image](https://user-images.githubusercontent.com/12176807/214663619-daa50a2a-3dfc-41f6-bdff-d71e53d797e9.png)

Also sorted the Game Over blocks as they appear in the toolbox.
