### PR TITLE
When reassigning player sprite, reassign button controls as well

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -169,6 +169,11 @@ namespace controller {
             this._moveSpriteInternal(sprite, vx, vy);
         }
 
+        stopControllingSprite(sprite: Sprite) {
+            if (!sprite) return;
+            this._controlledSprites = this._controlledSprites.filter(s => s.s.id !== sprite.id);
+        }
+
         // use this instead of movesprite internally to avoid adding the "multiplayer" part
         // to the compiled program
         _moveSpriteInternal(sprite: Sprite, vx: number = 100, vy: number = 100) {

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -57,6 +57,9 @@ namespace mp {
         _state: number[];
         _index: number;
         _data: any;
+        _mwb: boolean;
+        _vx: number;
+        _vy: number;
 
         constructor(index: number) {
             this._index = index;
@@ -110,10 +113,22 @@ namespace mp {
                 );
 
             }
+
+            if (this._sprite) {
+                this._sprite.destroy();
+            }
+
             this._sprite = sprite;
+
+            if (this._sprite && this._mwb) {
+                this._getController().moveSprite(this.getSprite(), this._vx, this._vy);
+            }
         }
 
         moveWithButtons(vx?: number, vy?: number) {
+            this._mwb = true;
+            this._vx = vx;
+            this._vy = vy;
             this._getController().moveSprite(this.getSprite(), vx, vy);
         }
 

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -114,8 +114,8 @@ namespace mp {
 
             }
 
-            if (this._sprite) {
-                this._sprite.destroy();
+            if (this._sprite && this._mwb) {
+                this._getController().stopControllingSprite(this._sprite);
             }
 
             this._sprite = sprite;

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -121,7 +121,7 @@ namespace mp {
             this._sprite = sprite;
 
             if (this._sprite && this._mwb) {
-                this._getController().moveSprite(this.getSprite(), this._vx, this._vy);
+                this._getController().moveSprite(this._sprite, this._vx, this._vy);
             }
         }
 


### PR DESCRIPTION
This change makes it so that if a user sets up button control on a player and then assigns a new sprite to the player, we will move controls to the new sprite and stop controlling the old one.

This change also makes it possible to setup player control before the sprite is assigned, whereas before this would silently fail.

This will always control the most recent sprite assigned to the player:
![image](https://user-images.githubusercontent.com/12176807/214897841-64943d2c-d474-4bf9-9575-9424b3e5c0a5.png)

Resolves https://github.com/microsoft/pxt-arcade/issues/5567
