### PR TITLE
post icon messages to parent iframe even if not in multiplayer mode

### DIFF
--- a/libs/game/sim/multiplayer.ts
+++ b/libs/game/sim/multiplayer.ts
@@ -17,8 +17,6 @@ namespace pxsim.multiplayer {
     }
 
     export function postIcon(iconType: IconType, slot: number, im: pxsim.RefImage) {
-        if (getMultiplayerState().origin !== "server")
-            return;
         if (im._width * im._height > 64 * 64) {
             // setting 64x64 as max size for icon for now
             return;


### PR DESCRIPTION
Don't drop icon messages when not in host mode, just let parent iframe determine what to do with them