### PR TITLE
Reference pages for 'multiplayer' blocks

### DIFF
--- a/libs/multiplayer/docs/reference/multiplayer.md
+++ b/libs/multiplayer/docs/reference/multiplayer.md
@@ -1,0 +1,57 @@
+# Multiplayer
+
+## Sprite
+
+```cards
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img``))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One))
+```
+
+## Information
+
+```cards
+mp.playerSelector(mp.PlayerNumber.One)
+mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
+mp.getPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score)
+mp.changePlayerStateBy(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
+mp.getPlayerByIndex(0)
+mp.getPlayerByNumber(0)
+```
+
+## Game control
+
+```cards
+mp.gameOverPlayerWin(mp.playerSelector(mp.PlayerNumber.One))
+mp.setPlayerIndicatorsVisible(true)
+```
+
+## Controller
+
+```cards
+mp.isButtonPressed(mp.playerSelector(mp.PlayerNumber.One), mp.MultiplayerButton.A)
+mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.One))
+mp.onButtonEvent(mp.MultiplayerButton.B, ControllerButtonEvent.Pressed, function (player) {})
+```
+
+## Events
+
+```cards
+mp.onLifeZero(function (player) {})
+mp.onScore(100, function (player) {})
+mp.onControllerEvent(ControllerEvent.Connected, function (player) {})
+```
+
+## See also
+
+[set player sprite](/reference/multiplayer/set-player-sprite), [get player sprite](/reference/multiplayer/get-player-sprite),
+[player selector](/reference/multiplayer/player-selector), [set player state](/reference/multiplayer/set-player-state), [get player state](/reference/multiplayer/get-player-state),
+[change player state by](/reference/multiplayer/change-player-state-by), [get player by index](/reference/multiplayer/get-player-by-index),
+[get player by number](/reference/multiplayer/get-player-by-number), [game over player win](/reference/multiplayer/game-over-player-win),
+[set player indicators visible](/reference/multiplayer/set-player-indicators-visible), [is button pressed](/reference/multiplayer/is-button-pressed),
+[move with buttons](/reference/multiplayer/move-with-buttons), [on button event](/reference/multiplayer/on-button-event),
+[on life zero](/reference/multiplayer/on-life-zero), [on score](/reference/multiplayer/on-score),
+[on controller event](/reference/multiplayer/on-controller-event)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/change-player-state-by.md
+++ b/libs/multiplayer/docs/reference/multiplayer/change-player-state-by.md
@@ -13,7 +13,7 @@ A [Player](/types/player) state value is changed by adding or subtracting some a
 * **state**: the [state item](/reference/multiplayer/multiplayer-state) to change, such as `score` or `life`.
 * **delta**: the amount to change the **state** value by.
 
-## Example
+## Example #example
 
 Set `player 1` score state to `0`. Send the player's shark sprite across the screen to eat a goldfish on the opposite side. When the shark overlaps the goldfish, add `1` to `player 1` score state.
 
@@ -111,7 +111,7 @@ game.onUpdateInterval(500, function () {
 })
 ```
 
-## See also
+## See also #seealso
 
 [set player state](/reference/multiplayer/set-player-state),
 [get player state](/reference/multiplayer/get-player-state)

--- a/libs/multiplayer/docs/reference/multiplayer/change-player-state-by.md
+++ b/libs/multiplayer/docs/reference/multiplayer/change-player-state-by.md
@@ -1,0 +1,21 @@
+# change Player State By
+
+Change a player state value by some amount.
+
+```sig
+mp.changePlayerStateBy(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
+```
+
+## Parameters
+
+* **player**: the player to change the a **state** value for.
+* **state**: the player state property to change.
+* **delta**: the amount to change the **state** value by.
+
+## See also
+
+[set player state](/reference/multiplayer/set-player-state)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/change-player-state-by.md
+++ b/libs/multiplayer/docs/reference/multiplayer/change-player-state-by.md
@@ -5,16 +5,116 @@ Change a player state value by some amount.
 ```sig
 mp.changePlayerStateBy(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
 ```
+A [Player](/types/player) state value is changed by adding or subtracting some amount from the current value. The change amount is in the **delta** parameter. If the player's ``||mp:score||`` value is `20` and you want to add `1` to the score, set **delta** to `1`. Similarly, if you want to reduce ``||mp:score||`` to `15`, set **delta** to `-5`.
 
 ## Parameters
 
 * **player**: the player to change the a **state** value for.
-* **state**: the player state property to change.
+* **state**: the [state item](/reference/multiplayer/multiplayer-state) to change, such as `score` or `life`.
 * **delta**: the amount to change the **state** value by.
+
+## Example
+
+Set `player 1` score state to `0`. Send the player's shark sprite across the screen to eat a goldfish on the opposite side. When the shark overlaps the goldfish, add `1` to `player 1` score state.
+
+```blocks
+namespace MultiplayerState {
+    export const gems = MultiplayerState.create()
+}
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+    goldfish.destroy(effects.warmRadial, 200)
+    mp.changePlayerStateBy(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 1)
+})
+let chomp = false
+let goldfish: Sprite = null
+mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
+goldfish = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . c c c c . . . . 
+    . . . . . . c c d d d d c . . . 
+    . . . . . c c c c c c d c . . . 
+    . . . . c c 4 4 4 4 d c c . . . 
+    . . . c 4 d 4 4 4 4 4 1 c . c c 
+    . . c 4 4 4 1 4 4 4 4 d 1 c 4 c 
+    . c 4 4 4 4 1 4 4 4 4 4 1 c 4 c 
+    f 4 4 4 4 4 1 4 4 4 4 4 1 4 4 f 
+    f 4 4 4 f 4 1 c c 4 4 4 1 f 4 f 
+    f 4 4 4 4 4 1 4 4 f 4 4 d f 4 f 
+    . f 4 4 4 4 1 c 4 f 4 d f f f f 
+    . . f f 4 d 4 4 f f 4 c f c . . 
+    . . . . f f 4 4 4 4 c d b c . . 
+    . . . . . . f f f f d d d c . . 
+    . . . . . . . . . . c c c . . . 
+    `, SpriteKind.Food)
+goldfish.left = 0
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    .................ccfff..............
+    ................cddbbf..............
+    ...............cddbbf...............
+    ..............fccbbcf............ccc
+    ........ffffffccccccff.........ccbbc
+    ......ffbbbbbbbbbbbbbcfff.....cdbbc.
+    ....ffbbbbbbbbbcbcbbbbcccff..cddbbf.
+    ....fbcbbbbbffbbcbcbbbcccccfffdbbf..
+    ....fbbb1111ff1bcbcbbbcccccccbbbcf..
+    .....fb11111111bbbbbbcccccccccbccf..
+    ......fccc33cc11bbbbccccccccfffbbcf.
+    .......fc131c111bbbcccccbdbc...fbbf.
+    ........f33c111cbbbfdddddcc.....fbbf
+    .........ff1111fbdbbfddcc........fff
+    ...........cccccfbdbbfc.............
+    .................fffff..............
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).right = scene.screenWidth()
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).vx = -30
+game.onUpdateInterval(500, function () {
+    if (chomp == true) {
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setImage(img`
+            ....................ccfff...........
+            ..........fffffffffcbbbbf...........
+            .........fbbbbbbbbbfffbf............
+            .........fbb111bffbbbbff............
+            .........fb11111ffbbbbbcff..........
+            .........f1cccc11bbcbcbcccf.........
+            ..........fc1c1c1bbbcbcbcccf...ccccc
+            ............c3331bbbcbcbccccfccddbbc
+            ...........c333c1bbbbbbbcccccbddbcc.
+            ...........c331c11bbbbbcccccccbbcc..
+            ..........cc13c111bbbbccccccffbccf..
+            ..........c111111cbbbcccccbbc.fccf..
+            ...........cc1111cbbbfdddddc..fbbcf.
+            .............cccffbdbbfdddc....fbbf.
+            ..................fbdbbfcc......fbbf
+            ...................fffff.........fff
+            `)
+    } else {
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setImage(img`
+            .................ccfff..............
+            ................cddbbf..............
+            ...............cddbbf...............
+            ..............fccbbcf............ccc
+            ........ffffffccccccff.........ccbbc
+            ......ffbbbbbbbbbbbbbcfff.....cdbbc.
+            ....ffbbbbbbbbbcbcbbbbcccff..cddbbf.
+            ....fbcbbbbbffbbcbcbbbcccccfffdbbf..
+            ....fbbb1111ff1bcbcbbbcccccccbbbcf..
+            .....fb11111111bbbbbbcccccccccbccf..
+            ......fccc33cc11bbbbccccccccfffbbcf.
+            .......fc131c111bbbcccccbdbc...fbbf.
+            ........f33c111cbbbfdddddcc.....fbbf
+            .........ff1111fbdbbfddcc........fff
+            ...........cccccfbdbbfc.............
+            .................fffff..............
+            `)
+    }
+    chomp = !(chomp)
+})
+```
 
 ## See also
 
-[set player state](/reference/multiplayer/set-player-state)
+[set player state](/reference/multiplayer/set-player-state),
+[get player state](/reference/multiplayer/get-player-state)
 
 ```package
 multiplayer

--- a/libs/multiplayer/docs/reference/multiplayer/game-over-player-win.md
+++ b/libs/multiplayer/docs/reference/multiplayer/game-over-player-win.md
@@ -10,7 +10,7 @@ mp.gameOverPlayerWin(mp.playerSelector(mp.PlayerNumber.One))
 
 * **player**: the [player](/types/player) set to win the game.
 
-## Example
+## Example #example
 
 Send two player sprites moving around the screen. Place a food (donut) sprite at the left side of the screen. When a player sprite reaches the donut, that player wins the game.
 
@@ -79,7 +79,7 @@ mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setBounceOnWall(true)
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setVelocity(50, 40)
 ```
 
-## See also
+## See also #seealso
 
 [get player by sprite](/reference/multiplayer/get-player-by-sprite)
 

--- a/libs/multiplayer/docs/reference/multiplayer/game-over-player-win.md
+++ b/libs/multiplayer/docs/reference/multiplayer/game-over-player-win.md
@@ -1,0 +1,15 @@
+# game Over Player Win
+
+End the game and set a player to win.
+
+```sig
+mp.gameOverPlayerWin(mp.playerSelector(mp.PlayerNumber.One))
+```
+
+## Parameters
+
+* **player**: the player to set the win for.
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/game-over-player-win.md
+++ b/libs/multiplayer/docs/reference/multiplayer/game-over-player-win.md
@@ -8,7 +8,80 @@ mp.gameOverPlayerWin(mp.playerSelector(mp.PlayerNumber.One))
 
 ## Parameters
 
-* **player**: the player to set the win for.
+* **player**: the [player](/types/player) set to win the game.
+
+## Example
+
+Send two player sprites moving around the screen. Place a food (donut) sprite at the left side of the screen. When a player sprite reaches the donut, that player wins the game.
+
+```blocks
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+    mp.gameOverPlayerWin(mp.getPlayerBySprite(sprite))
+})
+let mySprite = sprites.create(img`
+    . . . . . . b b b b a a . . . . 
+    . . . . b b d d d 3 3 3 a a . . 
+    . . . b d d d 3 3 3 3 3 3 a a . 
+    . . b d d 3 3 3 3 3 3 3 3 3 a . 
+    . b 3 d 3 3 3 3 3 b 3 3 3 3 a b 
+    . b 3 3 3 3 3 a a 3 3 3 3 3 a b 
+    b 3 3 3 3 3 a a 3 3 3 3 d a 4 b 
+    b 3 3 3 3 b a 3 3 3 3 3 d a 4 b 
+    b 3 3 3 3 3 3 3 3 3 3 d a 4 4 e 
+    a 3 3 3 3 3 3 3 3 3 d a 4 4 4 e 
+    a 3 3 3 3 3 3 3 d d a 4 4 4 e . 
+    a a 3 3 3 d d d a a 4 4 4 e e . 
+    . e a a a a a a 4 4 4 4 e e . . 
+    . . e e b b 4 4 4 4 b e e . . . 
+    . . . e e e e e e e e . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Food)
+mySprite.left = 0
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setVelocity(40, -30)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . c c c c . . . . . . . . 
+    . . c c 5 5 5 5 c c . . . . . . 
+    . c 5 5 5 5 5 5 5 5 c . . . . . 
+    c 5 5 5 5 5 1 f 5 5 5 c . . . . 
+    c 5 5 5 5 5 f f 5 5 5 5 c . . . 
+    c 5 5 5 5 5 5 5 5 5 5 5 c . . . 
+    c c b b 1 b 5 5 5 5 5 5 d c . . 
+    c 5 3 3 3 5 5 5 5 5 d d d c . . 
+    . b 5 5 5 5 5 5 5 5 d d d c . . 
+    . . c b b c 5 5 b d d d d c . . 
+    . c b b c 5 5 b b d d d d c c c 
+    . c c c c c c d d d d d d d d c 
+    . . . c c c c d 5 5 b d d c c . 
+    . . c b b c c c 5 5 b c c . . . 
+    . . c c c c c d 5 5 c . . . . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setVelocity(50, 40)
+```
+
+## See also
+
+[get player by sprite](/reference/multiplayer/get-player-by-sprite)
 
 ```package
 multiplayer

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-index.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-index.md
@@ -1,0 +1,40 @@
+# get Player By Index
+
+Get a Player from the multiplayer game list using an index value.
+
+```sig
+mp.getPlayerByIndex(0)
+```
+
+You can get a [Player](/types/player) object from the multiplayer using an index value for a location in the list. Index values start at `0` for the first list location and range to the maximum number of players minus `1` (currently `4` players maximum so, the maximum list index is `4 - 1` = `3`).
+
+## Parameters
+
+* **index**: a [number](/types/number) that is the index of the Player in the multiplayer list.
+
+## Returns
+
+* the [Player](/types/player) in the multiplayer list at location **index**.
+
+## Example
+
+Find all the players that have a score greater than `20` and give them a bonus of `5` points.
+
+```blocks
+let player: mp.Player = null
+for (let index = 0; index <= 3; index++) {
+    player = mp.getPlayerByIndex(index)
+    if (mp.getPlayerState(player, MultiplayerState.score) > 20) {
+        mp.changePlayerStateBy(player, MultiplayerState.score, 5)
+    }
+}
+```
+
+## See also
+
+[player selector](/reference/multiplayer/player-selector),
+[get player by number](/reference/multiplayer/get-player-by-number)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-index.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-index.md
@@ -16,7 +16,7 @@ You can get a [Player](/types/player) object from the multiplayer using an index
 
 * the [Player](/types/player) in the multiplayer list at location **index**.
 
-## Example
+## Example #example
 
 Find all the players that have a score greater than `20` and give them a bonus of `5` points.
 
@@ -30,7 +30,7 @@ for (let index = 0; index <= 3; index++) {
 }
 ```
 
-## See also
+## See also #seealso
 
 [player selector](/reference/multiplayer/player-selector),
 [get player by number](/reference/multiplayer/get-player-by-number)

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-number.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-number.md
@@ -1,0 +1,34 @@
+# get Player By Number
+
+Get a game Player using a player number value.
+
+```sig
+mp.getPlayerByNumber(0)
+```
+
+Rather than using a [player selector](/reference/multiplayer/player-selector), a [Player](/types/player) is returned for a player **number**. Player numbers start from `1` and range to the maximum number of players (currently `4`).
+
+## Parameters
+
+* **number**: a player [number](/types/number).
+
+## Returns
+
+* the [Player](/types/player) which matches **number**.
+
+## Example
+
+Give `player 4` an extra `5` life points.
+
+```blocks
+mp.changePlayerStateBy(mp.getPlayerByNumber(4), MultiplayerState.life, 5)
+```
+
+## See also
+
+[player selector](/reference/multiplayer/player-selector),
+[get player by index](/reference/multiplayer/get-player-by-index)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-number.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-number.md
@@ -16,7 +16,7 @@ Rather than using a [player selector](/reference/multiplayer/player-selector), a
 
 * the [Player](/types/player) which matches **number**.
 
-## Example
+## Example #example
 
 Give `player 4` an extra `5` life points.
 
@@ -24,7 +24,7 @@ Give `player 4` an extra `5` life points.
 mp.changePlayerStateBy(mp.getPlayerByNumber(4), MultiplayerState.life, 5)
 ```
 
-## See also
+## See also #seealso
 
 [player selector](/reference/multiplayer/player-selector),
 [get player by index](/reference/multiplayer/get-player-by-index)

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-sprite.md
@@ -1,0 +1,63 @@
+# get Player By Sprite
+
+Return the player assigned to a sprite.
+
+```sig
+mp.getPlayerBySprite(null)
+```
+## Parameters
+
+* **sprite**: the player whose player will be returned.
+
+## Returns
+
+* the player that is assigned to the **sprite**.
+
+## Example
+
+```blocks
+let mySprite = sprites.create(img`
+    ...........ccccc66666...........
+    ........ccc4444444444666........
+    ......cc444444444bb4444466......
+    .....cb4444bb4444b5b444444b.....
+    ....eb4444b5b44444b44444444b....
+    ...ebb44444b4444444444b444446...
+    ..eb6bb444444444bb444b5b444446..
+    ..e6bb5b44444444b5b444b44bb44e..
+    .e66b4b4444444444b4444444b5b44e.
+    .e6bb444444444444444444444bb44e.
+    eb66b44444bb444444444444444444be
+    eb66bb444b5b44444444bb44444444be
+    fb666b444bb444444444b5b4444444bf
+    fcb666b44444444444444bb444444bcf
+    .fbb6666b44444444444444444444bf.
+    .efbb66666bb4444444444444444bfe.
+    .86fcbb66666bbb44444444444bcc688
+    8772effcbbbbbbbbbbbbbbbbcfc22778
+    87722222cccccccccccccccc22226678
+    f866622222222222222222222276686f
+    fef866677766667777776667777fffef
+    fbff877768f86777777666776fffffbf
+    fbeffeefffeff7766688effeeeefeb6f
+    f6bfffeffeeeeeeeeeeeeefeeeeebb6e
+    f66ddfffffeeeffeffeeeeeffeedb46e
+    .c66ddd4effffffeeeeeffff4ddb46e.
+    .fc6b4dddddddddddddddddddb444ee.
+    ..ff6bb444444444444444444444ee..
+    ....ffbbbb4444444444444444ee....
+    ......ffebbbbbb44444444eee......
+    .........fffffffcccccee.........
+    ................................
+    `, SpriteKind.Player)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), mySprite)
+let playerID = mp.getPlayerBySprite(mySprite)
+```
+
+## See also
+
+[get player sprite](/reference/multiplayer/get-player-sprite)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-sprite.md
@@ -14,7 +14,7 @@ mp.getPlayerBySprite(null)
 
 * the [Player](/types/player) that is assigned this **sprite**.
 
-## Example
+## Example #example
 
 Send 2 player sprites moving around the screen. When they overlap the hamburger sprite, make one player say that they like the hamburger and they other say that they don't.
 
@@ -100,7 +100,7 @@ mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setVelocity(50, -50)
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setBounceOnWall(true)
 ```
 
-## See also
+## See also #seealso
 
 [get player sprite](/reference/multiplayer/get-player-sprite)
 

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-by-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-by-sprite.md
@@ -1,22 +1,32 @@
 # get Player By Sprite
 
-Return the player assigned to a sprite.
+Get the Player that has this character sprite.
 
 ```sig
 mp.getPlayerBySprite(null)
 ```
+
 ## Parameters
 
-* **sprite**: the player whose player will be returned.
+* **sprite**: the character sprite whose [Player](/types/player) is returned.
 
 ## Returns
 
-* the player that is assigned to the **sprite**.
+* the [Player](/types/player) that is assigned this **sprite**.
 
 ## Example
 
+Send 2 player sprites moving around the screen. When they overlap the hamburger sprite, make one player say that they like the hamburger and they other say that they don't.
+
 ```blocks
-let mySprite = sprites.create(img`
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+    if (mp.getPlayerProperty(mp.getPlayerBySprite(sprite), mp.PlayerProperty.Number) == 1) {
+        sprite.sayText("Yum, burger!", 100, false)
+    } else {
+        sprite.sayText("Hate, burgers!", 100, false)
+    }
+})
+let burger = sprites.create(img`
     ...........ccccc66666...........
     ........ccc4444444444666........
     ......cc444444444bb4444466......
@@ -49,9 +59,45 @@ let mySprite = sprites.create(img`
     ......ffebbbbbb44444444eee......
     .........fffffffcccccee.........
     ................................
-    `, SpriteKind.Player)
-mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), mySprite)
-let playerID = mp.getPlayerBySprite(mySprite)
+    `, SpriteKind.Food)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . 4 4 4 . . . . 4 4 4 . . . . 
+    . 4 5 5 5 e . . e 5 5 5 4 . . . 
+    4 5 5 5 5 5 e e 5 5 5 5 5 4 . . 
+    4 5 5 4 4 5 5 5 5 4 4 5 5 4 . . 
+    e 5 4 4 5 5 5 5 5 5 4 4 5 e . . 
+    . e e 5 5 5 5 5 5 5 5 e e . . . 
+    . . e 5 f 5 5 5 5 f 5 e . . . . 
+    . . f 5 5 5 4 4 5 5 5 f . . f f 
+    . . f 4 5 5 f f 5 5 6 f . f 5 f 
+    . . . f 6 6 6 6 6 6 4 4 f 5 5 f 
+    . . . f 4 5 5 5 5 5 5 4 4 5 f . 
+    . . . f 5 5 5 5 5 4 5 5 f f . . 
+    . . . f 5 f f f 5 f f 5 f . . . 
+    . . . f f . . f f . . f f . . . 
+    `, SpriteKind.Player))
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . f f f f f . . . . . . . 
+    . . . f e e e e e f f f . . . . 
+    . . f d d d e e e e d d f . . . 
+    . c d d d d d e e e b d c . . . 
+    . c d d d d d d e e b d c . . . 
+    c d d f d d f d e e f c . f f . 
+    c d d f d d f d e e f . . f e f 
+    c d e e d d d d e e f . . f e f 
+    . f d d d c d e e f f . . f e f 
+    . . f f f d e e e e e f . f e f 
+    . . . . f e e e e e e e f f f . 
+    . . . . f f e e e e e b f f . . 
+    . . . f e f f e e c d d f f . . 
+    . . f d d b d d c f f f . . . . 
+    . . f d d c d d d f f . . . . . 
+    . . . f f f f f f f . . . . . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setVelocity(60, 50)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setVelocity(50, -50)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setBounceOnWall(true)
 ```
 
 ## See also

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-property.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-property.md
@@ -19,7 +19,7 @@ Player properties contain identity information. These are set for a [Player](/ty
 
 * a [number](/types/number) which is the value for the property.
 
-## Example
+## Example #example
 
 Get the player number property for `player 1` and display it with its character sprite. 
 
@@ -46,7 +46,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).sayText("I'm player " + mp.getPlayerProperty(mp.playerSelector(mp.PlayerNumber.One), mp.PlayerProperty.Number))
 ```
 
-## See also
+## See also #example
 
 [get player state](/reference/multiplayer/get-player-state)
 

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-property.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-property.md
@@ -1,0 +1,55 @@
+# get Player Property
+
+Get the value of a Player property.
+
+```sig
+mp.getPlayerProperty(mp.playerSelector(mp.PlayerNumber.One), PlayerProperty.Index)
+```
+
+Player properties contain identity information. These are set for a [Player](/types/player) object when it's created to uniquely identfy it. Currently, there are two properties: ``||mp:index||`` and ``||mp:number||``.
+
+## Parameters
+
+* **player**: the [Player](/types/player) to get a property for. item value for.
+* **prop**: the property to get a **value** for:
+>* `index`: the zero-based index of the Player in the multiplayer object list.
+>* `number`: the player identity number of the Player object.
+
+## Returns
+
+* a [number](/types/number) which is the value for the property.
+
+## Example
+
+Get the player number property for `player 1` and display it with its character sprite. 
+
+```blocks
+scene.setBackgroundColor(10)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).sayText("I'm player " + mp.getPlayerProperty(mp.playerSelector(mp.PlayerNumber.One), mp.PlayerProperty.Number))
+```
+
+## See also
+
+[get player state](/reference/multiplayer/get-player-state)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-property.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-property.md
@@ -46,7 +46,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).sayText("I'm player " + mp.getPlayerProperty(mp.playerSelector(mp.PlayerNumber.One), mp.PlayerProperty.Number))
 ```
 
-## See also #example
+## See also #seealso
 
 [get player state](/reference/multiplayer/get-player-state)
 

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-sprite.md
@@ -1,0 +1,23 @@
+# get Player Sprite
+
+Get the sprite assign to a player.
+
+```sig
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One))
+```
+
+## Parameters
+
+* **player**: the player whose sprite will be returned.
+
+## Returns
+
+* a [sprite](/reference/types/sprite) that is assigned to the **player**.
+
+## See also
+
+[get player by sprite](/reference/multiplayer/get-player-by-sprite)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-sprite.md
@@ -1,6 +1,6 @@
 # get Player Sprite
 
-Get the sprite assign to a player.
+Get the character sprite assigned to a Player.
 
 ```sig
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One))
@@ -8,14 +8,50 @@ mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One))
 
 ## Parameters
 
-* **player**: the player whose sprite will be returned.
+* **player**: the [Player](/types/player) whose sprite will be returned.
 
 ## Returns
 
-* a [sprite](/reference/types/sprite) that is assigned to the **player**.
+* the [sprite](/reference/types/sprite) that is assigned to the **player**.
+
+## Example
+
+Make a player sprite move across the screen. When the sprite reaches the edge of the screen, send the sprite back in the opposite direction and flip the image of the sprite.
+
+```blocks
+scene.setBackgroundColor(8)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    .............ccfff..............
+    ...........ccddbcf..............
+    ..........ccddbbf...............
+    ..........fccbbcf...............
+    .....fffffccccccff.........ccc..
+    ...ffbbbbbbbcbbbbcfff....ccbbc..
+    ..fbbbbbbbbcbcbbbbcccff.cdbbc...
+    ffbbbbbbffbbcbcbbbcccccfcdbbf...
+    fbcbbb11ff1bcbbbbbcccccffbbf....
+    fbbb11111111bbbbbcccccccbbcf....
+    .fb11133cc11bbbbcccccccccccf....
+    ..fccc31c111bbbcccccbdbffbbcf...
+    ...fc13c111cbbbfcddddcc..fbbf...
+    ....fccc111fbdbbccdcc.....fbbf..
+    ........ccccfcdbbcc........fff..
+    .............fffff..............
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).vx = -20
+game.onUpdateInterval(500, function () {
+    if (mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).x < 0 || mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).x > scene.screenWidth()) {
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).image.flipX()
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).vx = mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).vx * -1
+    } else {
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).startEffect(effects.bubbles, 100)
+    }
+})
+```
 
 ## See also
 
+[set player sprite](/reference/multiplayer/set-player-sprite),
 [get player by sprite](/reference/multiplayer/get-player-by-sprite)
 
 ```package

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-sprite.md
@@ -14,7 +14,7 @@ mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One))
 
 * the [sprite](/reference/types/sprite) that is assigned to the **player**.
 
-## Example
+## Example #example
 
 Make a player sprite move across the screen. When the sprite reaches the edge of the screen, send the sprite back in the opposite direction and flip the image of the sprite.
 
@@ -49,7 +49,7 @@ game.onUpdateInterval(500, function () {
 })
 ```
 
-## See also
+## See also #seealso
 
 [set player sprite](/reference/multiplayer/set-player-sprite),
 [get player by sprite](/reference/multiplayer/get-player-by-sprite)

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-state.md
@@ -17,7 +17,7 @@ Information like the player's score and life count is contained with the [Player
 
 * **value**: a [number](/types/number) which is the value for **state**.
 
-## Example
+## Example #example
 
 Get the ``||mp:number||`` property  for `player 3`.
 
@@ -44,7 +44,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).sayText("I'm player " + mp.getPlayerProperty(mp.playerSelector(mp.PlayerNumber.One), mp.PlayerProperty.Number))
 ```
 
-## See also
+## See also #seealso
 
 [set player state](/refernece/multiplayer/set-player-state),
 [change player state by](/reference/multiplayer/change-player-state-by),

--- a/libs/multiplayer/docs/reference/multiplayer/get-player-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/get-player-state.md
@@ -1,0 +1,55 @@
+# get Player State
+
+Get the value of a Player state item.
+
+```sig
+mp.getPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score)
+```
+
+Information like the player's score and life count is contained with the [Player](/types/player) game object. The Player object has the ``||mp:score||`` and ``||mp:life||`` state items already added.
+
+## Parameters
+
+* **player**: the [Player](/types/player) to get a state item value for.
+* **state**: the [state item](/reference/multiplayer/multiplayer-state) to get a **value** for, such as `score` or `life`.
+
+## Returns
+
+* **value**: a [number](/types/number) which is the value for **state**.
+
+## Example
+
+Get the ``||mp:number||`` property  for `player 3`.
+
+```blocks
+scene.setBackgroundColor(10)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).sayText("I'm player " + mp.getPlayerProperty(mp.playerSelector(mp.PlayerNumber.One), mp.PlayerProperty.Number))
+```
+
+## See also
+
+[set player state](/refernece/multiplayer/set-player-state),
+[change player state by](/reference/multiplayer/change-player-state-by),
+[get player property](/reference/multiplayer/get-player-property)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/is-button-pressed.md
+++ b/libs/multiplayer/docs/reference/multiplayer/is-button-pressed.md
@@ -1,0 +1,38 @@
+# is Button Pressed
+
+Check if a controller button for a player is pressed or not.
+
+```sig
+mp.isButtonPressed(mp.playerSelector(mp.PlayerNumber.One), mp.MultiplayerButton.A)
+```
+
+## Parameters
+
+* **player**: the player to check the controller button state for.
+* **button**: the controller button to check for a pressed condition.
+
+## Returns
+
+* a [boolean](/types/boolean) value for the state of the **button** for the **player**. It is `true` if the button is pressed and `false` if the button is not pressed.
+
+## Example
+
+If `player 2` is pressing the up arrow button for too long, then`player 1` wins.
+
+```blocks
+let pressCount = 0
+game.onUpdateInterval(500, function () {
+    if (mp.isButtonPressed(mp.playerSelector(mp.PlayerNumber.Two), mp.MultiplayerButton.Up)) {
+        pressCount += 1
+        if (pressCount > 1) {
+            mp.gameOverPlayerWin(mp.playerSelector(mp.PlayerNumber.One))
+        }
+    } else {
+        pressCount = 0
+    }
+})
+```
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/is-button-pressed.md
+++ b/libs/multiplayer/docs/reference/multiplayer/is-button-pressed.md
@@ -33,6 +33,12 @@ game.onUpdateInterval(500, function () {
 })
 ```
 
+## See also
+
+[on button pressed](/reference/multiplayer/on-button-pressed),
+[move with buttons](/reference/multiplayer/move-with-buttons)
+
+
 ```package
 multiplayer
 ```

--- a/libs/multiplayer/docs/reference/multiplayer/is-button-pressed.md
+++ b/libs/multiplayer/docs/reference/multiplayer/is-button-pressed.md
@@ -15,7 +15,7 @@ mp.isButtonPressed(mp.playerSelector(mp.PlayerNumber.One), mp.MultiplayerButton.
 
 * a [boolean](/types/boolean) value for the state of the **button** for the **player**. It is `true` if the button is pressed and `false` if the button is not pressed.
 
-## Example
+## Example #example
 
 If `player 2` is pressing the up arrow button for too long, then`player 1` wins.
 
@@ -33,7 +33,7 @@ game.onUpdateInterval(500, function () {
 })
 ```
 
-## See also
+## See also #seealso
 
 [on button pressed](/reference/multiplayer/on-button-pressed),
 [move with buttons](/reference/multiplayer/move-with-buttons)

--- a/libs/multiplayer/docs/reference/multiplayer/move-with-buttons.md
+++ b/libs/multiplayer/docs/reference/multiplayer/move-with-buttons.md
@@ -1,0 +1,19 @@
+# move With Buttons
+
+Add movement control to a player sprite with the controller buttons.
+
+```sig
+mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.One))
+```
+
+## Parameters
+
+* **player**: the player to set movement control for.
+* **vx**: the velocity (speed) to move the player in the left or down direction.
+* **vy**: the velocity (speed) to movet the player the up or down direction.
+
+## See also
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/move-with-buttons.md
+++ b/libs/multiplayer/docs/reference/multiplayer/move-with-buttons.md
@@ -14,7 +14,7 @@ A player's sprite will move vertically or horizontally with the controller's arr
 * **vx**: an optional velocity (speed) to move the player in the left or right direction. The default value is `100`.
 * **vy**: an optional velocity (speed) to move the player the up or down direction. The default value is `100`.
 
-## Example
+## Example #example
 
 Set a character sprite for `player 2` and make it move with the controller buttons.
 
@@ -41,7 +41,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
 mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.Two))
 ```
 
-## See also
+## See also #seealso
 
 [is button pressed](/reference/multiplayer/is-button-pressed)
 

--- a/libs/multiplayer/docs/reference/multiplayer/move-with-buttons.md
+++ b/libs/multiplayer/docs/reference/multiplayer/move-with-buttons.md
@@ -1,18 +1,49 @@
 # move With Buttons
 
-Add movement control to a player sprite with the controller buttons.
+Add movement control to a player sprite with the controller arrow buttons.
 
 ```sig
 mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.One))
 ```
 
+A player's sprite will move vertically or horizontally with the controller's arrow buttons. The horizontal `vx` and vertical `vy` values a speeds (pixels per second) at which the sprite will move when an arrow button is pressed. If no values are set for `vx` and `vy`, the default value of `100` is used.
+
 ## Parameters
 
 * **player**: the player to set movement control for.
-* **vx**: the velocity (speed) to move the player in the left or down direction.
-* **vy**: the velocity (speed) to movet the player the up or down direction.
+* **vx**: an optional velocity (speed) to move the player in the left or right direction. The default value is `100`.
+* **vy**: an optional velocity (speed) to move the player the up or down direction. The default value is `100`.
+
+## Example
+
+Set a character sprite for `player 2` and make it move with the controller buttons.
+
+```blocks
+scene.setBackgroundColor(10)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.Two))
+```
 
 ## See also
+
+[is button pressed](/reference/multiplayer/is-button-pressed)
 
 ```package
 multiplayer

--- a/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
@@ -1,0 +1,90 @@
+# multiplayer State
+
+Get a multiplayer state object for a multiplayer state identifier.
+
+```sig
+mp._multiplayerState(0)
+```
+
+To keep track of different types of sprites, a _kind_ is assigned to them. This is a value that will help identify them and decide what actions to take when events happen in the game. The sprite kinds in your game might be defined like this:
+
+```typescript-ignore
+namespace MultiplayerState {
+    export const score = create()
+    export const life = create()
+}
+```
+
+In blocks, a sprite kind identifier is used to make a sprite kind item that can be assigned to a variable or used as a parameter:
+
+```block
+let lifeState = MultiplayerState.life
+```
+
+In blocks, the multiplayer state list lets you add your own custom state identifers to it. Let's say you wanted to give players 'gems' as rewards during a game. When you add `gems` to the state list, it also adds a new state constant called `gems` to your project code:
+
+```typescript-ignore
+namespace MultiplayerState {
+    export const gems = create()
+}
+```
+
+You can now set state values for the number of `gems` you give a player.
+
+```blocks
+namespace MultiplayerState {
+    export const gems = create()
+}
+mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.gems, 6)
+```
+
+## Parameters
+
+* **kind**: the multiplayer state identifier to get the state object for.
+
+## Returns
+
+* a multiplayer state object for a multiplayer state identifer.
+
+## Example #example
+
+Create several `Food` sprites at random locations on the screen. Use a sprite kind object for the `Food` identifier to destroy all `Food` srprites.
+
+```blocks
+let mySprite: Sprite = null
+let foodKind = SpriteKind.Food
+for (let index = 0; index <= 4; index++) {
+    mySprite = sprites.create(img`
+        . . . . c c c b b b b b . . . . 
+        . . c c b 4 4 4 4 4 4 b b b . . 
+        . c c 4 4 4 4 4 5 4 4 4 4 b c . 
+        . e 4 4 4 4 4 4 4 4 4 5 4 4 e . 
+        e b 4 5 4 4 5 4 4 4 4 4 4 4 b c 
+        e b 4 4 4 4 4 4 4 4 4 4 5 4 4 e 
+        e b b 4 4 4 4 4 4 4 4 4 4 4 b e 
+        . e b 4 4 4 4 4 5 4 4 4 4 b e . 
+        8 7 e e b 4 4 4 4 4 4 b e e 6 8 
+        8 7 2 e e e e e e e e e e 2 7 8 
+        e 6 6 2 2 2 2 2 2 2 2 2 2 6 c e 
+        e c 6 7 6 6 7 7 7 6 6 7 6 c c e 
+        e b e 8 8 c c 8 8 c c c 8 e b e 
+        e e b e c c e e e e e c e b e e 
+        . e e b b 4 4 4 4 4 4 4 4 e e . 
+        . . . c c c c c e e e e e . . . 
+        `, SpriteKind.Food)
+    mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
+}
+for (let value of sprites.allOfKind(foodKind)) {
+    pause(1000)
+    value.destroy()
+}
+```
+
+## See also #seealso
+
+[set player state](/reference/multiplayer/set-player-state)
+
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
@@ -46,40 +46,6 @@ mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.gems,
 
 * a multiplayer state object for a multiplayer state identifer.
 
-## Example #example
-
-Create several `Food` sprites at random locations on the screen. Use a sprite kind object for the `Food` identifier to destroy all `Food` srprites.
-
-```blocks
-let mySprite: Sprite = null
-let foodKind = SpriteKind.Food
-for (let index = 0; index <= 4; index++) {
-    mySprite = sprites.create(img`
-        . . . . c c c b b b b b . . . . 
-        . . c c b 4 4 4 4 4 4 b b b . . 
-        . c c 4 4 4 4 4 5 4 4 4 4 b c . 
-        . e 4 4 4 4 4 4 4 4 4 5 4 4 e . 
-        e b 4 5 4 4 5 4 4 4 4 4 4 4 b c 
-        e b 4 4 4 4 4 4 4 4 4 4 5 4 4 e 
-        e b b 4 4 4 4 4 4 4 4 4 4 4 b e 
-        . e b 4 4 4 4 4 5 4 4 4 4 b e . 
-        8 7 e e b 4 4 4 4 4 4 b e e 6 8 
-        8 7 2 e e e e e e e e e e 2 7 8 
-        e 6 6 2 2 2 2 2 2 2 2 2 2 6 c e 
-        e c 6 7 6 6 7 7 7 6 6 7 6 c c e 
-        e b e 8 8 c c 8 8 c c c 8 e b e 
-        e e b e c c e e e e e c e b e e 
-        . e e b b 4 4 4 4 4 4 4 4 e e . 
-        . . . c c c c c e e e e e . . . 
-        `, SpriteKind.Food)
-    mySprite.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
-}
-for (let value of sprites.allOfKind(foodKind)) {
-    pause(1000)
-    value.destroy()
-}
-```
-
 ## See also #seealso
 
 [set player state](/reference/multiplayer/set-player-state)

--- a/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
@@ -1,12 +1,12 @@
 # multiplayer State
 
-Get a multiplayer state object for a multiplayer state identifier.
+Get the value of a player state identifier.
 
 ```sig
 mp._multiplayerState(0)
 ```
 
-To keep track of different types of sprites, a _kind_ is assigned to them. This is a value that will help identify them and decide what actions to take when events happen in the game. The sprite kinds in your game might be defined like this:
+To keep track of different types of multiplayer states, a _kind_ is assigned to them. This is a value that identifies one of the states set for a [Player](/types/player). The multiplayer state values in your game might be defined like this:
 
 ```typescript-ignore
 namespace MultiplayerState {
@@ -15,7 +15,7 @@ namespace MultiplayerState {
 }
 ```
 
-In blocks, a sprite kind identifier is used to make a sprite kind item that can be assigned to a variable or used as a parameter:
+In blocks, a multiplayer state kind identifier is used to make a state kind item that can be assigned to a variable or used as a parameter:
 
 ```block
 let lifeState = MultiplayerState.life
@@ -40,16 +40,15 @@ mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.gems,
 
 ## Parameters
 
-* **kind**: the multiplayer state identifier to get the state object for.
+* **kind**: the multiplayer state identifier to get the state value for.
 
 ## Returns
 
-* a multiplayer state object for a multiplayer state identifer.
+* a value for a player state identifier.
 
 ## See also #seealso
 
 [set player state](/reference/multiplayer/set-player-state)
-
 
 ```package
 multiplayer

--- a/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/multiplayer-state.md
@@ -6,7 +6,7 @@ Get the value of a player state identifier.
 mp._multiplayerState(0)
 ```
 
-To keep track of different types of multiplayer states, a _kind_ is assigned to them. This is a value that identifies one of the states set for a [Player](/types/player). The multiplayer state values in your game might be defined like this:
+To keep track of different multiplayer states, a _kind_ is assigned to them. This is a value that identifies one of the states set for a [Player](/types/player). The multiplayer state values in your game might be defined like this:
 
 ```typescript-ignore
 namespace MultiplayerState {

--- a/libs/multiplayer/docs/reference/multiplayer/on-button-event.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-button-event.md
@@ -1,0 +1,59 @@
+# on Button Event
+
+Run some code when a button on a player's controller is pressed or released.
+
+```sig
+mp.onButtonEvent(mp.MultiplayerButton.B, ControllerButtonEvent.Pressed, function (player) {})
+```
+
+You can detect a controller button action on a player's controller and run some code in response. A button is chosen and a type of event is selected.
+
+## Parameters
+
+* **button**: the button to detect an action for:
+>* `A` button
+>* `B` button
+>* `up` arrow key
+>* `down` arrow key
+> * `left` arrow key
+> * `right` arrow key
+* **event**: the button event to detect:
+> * `pressed`: a button or arrow key is pressed
+> * `released`: a button or arrow key is released
+> * `repeat`: a button or arrow key is press quickly, multiple times
+* **handler**: the code to run the button event happens.
+
+## Example
+
+```blocks
+mp.onButtonEvent(mp.MultiplayerButton.A, ControllerButtonEvent.Pressed, function (player2) {
+    mp.getPlayerSprite(player2).sayText("I'm pressed!", 500, false)
+})
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setVelocity(40, -30)
+```
+
+[is button pressed](/reference/multiplayer/is-button-pressed),
+[move with buttons](/reference/multiplayer/move-with-buttons)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/on-button-event.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-button-event.md
@@ -23,7 +23,7 @@ You can detect a controller button action on a player's controller and run some 
 > * `repeat`: a button or arrow key is press quickly, multiple times
 * **handler**: the code to run the button event happens.
 
-## Example
+## Example #example
 
 ```blocks
 mp.onButtonEvent(mp.MultiplayerButton.A, ControllerButtonEvent.Pressed, function (player2) {
@@ -50,6 +50,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setBounceOnWall(true)
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setVelocity(40, -30)
 ```
+## See also #seealso
 
 [is button pressed](/reference/multiplayer/is-button-pressed),
 [move with buttons](/reference/multiplayer/move-with-buttons)

--- a/libs/multiplayer/docs/reference/multiplayer/on-controller-event.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-controller-event.md
@@ -1,0 +1,76 @@
+# on Controller Event
+
+Run some code when a player connects or disconnects.
+
+```sig
+mp.onControllerEvent(ControllerEvent.Connected, function (player) {})
+```
+
+When a new player joins (connects) the multiplayer game or leaves (disconnects) the game, a controller event will occur. You can run some code to react to a player joining or leaving the game.
+
+## Parameters
+
+* **event**: the connection action to wait for. The connection actions (events) are:
+> * ``connected``: player is connected
+> * ``disconnected``: button is released from being pressed
+* **handler**: the code you want to run when a player connect event happens.
+> * **player**: the player that connected or disconnected,.
+
+## Example #example
+
+When `player 2` connects, set their character sprite to a yellow duck.
+
+```blocks
+mp.onControllerEvent(ControllerEvent.Connected, function (player) {
+    if (mp.getPlayerProperty(player, mp.PlayerProperty.Number) == 2) {
+        mp.setPlayerSprite(player, sprites.create(img`
+            . . . . . . . . . . b 5 b . . . 
+            . . . . . . . . . b 5 b . . . . 
+            . . . . . . b b b b b b . . . . 
+            . . . . . b b 5 5 5 5 5 b . . . 
+            . . . . b b 5 d 1 f 5 d 4 c . . 
+            . . . . b 5 5 1 f f d d 4 4 4 b 
+            . . . . b 5 5 d f b 4 4 4 4 b . 
+            . . . b d 5 5 5 5 4 4 4 4 b . . 
+            . . b d d 5 5 5 5 5 5 5 5 b . . 
+            . b d d d d 5 5 5 5 5 5 5 5 b . 
+            b d d d b b b 5 5 5 5 5 5 5 b . 
+            c d d b 5 5 d c 5 5 5 5 5 5 b . 
+            c b b d 5 d c d 5 5 5 5 5 5 b . 
+            . b 5 5 b c d d 5 5 5 5 5 d b . 
+            b b c c c d d d d 5 5 5 b b . . 
+            . . . c c c c c c c c b b . . . 
+            `, SpriteKind.Player))
+    }
+})
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setVelocity(40, -30)
+```
+
+## See also #seealso
+
+[on button event](/reference/multiplayer/on-button-event),
+[is button pressed](/reference/multiplayer/is-button-pressed)
+
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/on-life-zero.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-life-zero.md
@@ -10,7 +10,7 @@ mp.onLifeZero(function (player) {})
 
 * **handler**: the code to run when any player's life points reach the value of `0`.
 
-## Example
+## Example #example
 
 Make the player's sprite put up an emergency message when their life points get to zero.
 
@@ -19,7 +19,7 @@ mp.onLifeZero(function (player) {
     mp.getPlayerSprite(player).sayText("Medic, help!!!")
 })
 ```
-## See also
+## See also #seealso
 
 [on score](/reference/multiplayer/on-score)
 

--- a/libs/multiplayer/docs/reference/multiplayer/on-life-zero.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-life-zero.md
@@ -1,0 +1,28 @@
+# on Life Zero
+
+Run some code when a player's life points reach zero.
+
+```sig
+mp.onLifeZero(function (player) {})
+```
+
+## Parameters
+
+* **handler**: the code to run when any player's life points reach the value of `0`.
+
+## Example
+
+Make the player's sprite put up an emergency message when their life points get to zero.
+
+```blocks
+mp.onLifeZero(function (player) {
+    mp.getPlayerSprite(player).sayText("Medic, help!!!")
+})
+```
+## See also
+
+[on score](/reference/multiplayer/on-score)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/on-score.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-score.md
@@ -11,7 +11,7 @@ mp.onScore(100, function (player) {})
 * **score**: a [number](/types/number) that is the score value to trigger the event.
 * **handler**: the code to run when any player's score reaches the value in **score**.
 
-## Example
+## Example #example
 
 Reward each player that reaches a score of `100` with `1` more life point.
 
@@ -21,7 +21,7 @@ mp.onScore(100, function (player) {
 })
 ```
 
-## See also
+## See also #seealso
 
 [on life zero](/reference/multiplayer/on-life-zero)
 

--- a/libs/multiplayer/docs/reference/multiplayer/on-score.md
+++ b/libs/multiplayer/docs/reference/multiplayer/on-score.md
@@ -1,0 +1,30 @@
+# on Score
+
+Run some code when a player's score reaches a given value.
+
+```sig
+mp.onScore(100, function (player) {})
+```
+
+## Parameters
+
+* **score**: a [number](/types/number) that is the score value to trigger the event.
+* **handler**: the code to run when any player's score reaches the value in **score**.
+
+## Example
+
+Reward each player that reaches a score of `100` with `1` more life point.
+
+```blocks
+mp.onScore(100, function (player) {
+    mp.changePlayerStateBy(player, MultiplayerState.score, 1)
+})
+```
+
+## See also
+
+[on life zero](/reference/multiplayer/on-life-zero)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/player-selector.md
+++ b/libs/multiplayer/docs/reference/multiplayer/player-selector.md
@@ -1,0 +1,51 @@
+# player Selector
+
+Get a game Player using a player selector.
+
+```sig
+mp.playerSelector(mp.PlayerNumber.One)
+```
+
+Players in a multiplayer game are represented by the [Player](/types/player) game object. Player objects are usually referenced using a player selector. The selectors are named as a player number, like `player 1`, `player 2`, etc. To use many of the multiplayer game blocks, you need a selector to specify which player or players you're using with the block.
+
+## Parameters
+
+* **player**: a [Player](/types/player) to get using the selector.
+
+## Returns
+
+* the [Player](/types/player) chosen by the selector in **player**.
+
+## Example
+
+Set a character sprite for the player selected by ``||mp:player 2||``.
+
+```blocks
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . f f f f f . . . . . . . 
+    . . . f e e e e e f . . . . . . 
+    . . f d d d d e e e f . . . . . 
+    . c d f d d f d e e f f . . . . 
+    . c d f d d f d e e d d f . . . 
+    c d e e d d d d e e b d c . . . 
+    c d d d d c d d e e b d c . . . 
+    c c c c c d d e e e f c . . . . 
+    . f d d d d e e e f f . . . . . 
+    . . f f f f f e e e e f . . . . 
+    . . . . f f e e e e e e f . f f 
+    . . . f e e f e e f e e f . e f 
+    . . f e e f e e f e e e f . e f 
+    . f b d f d b f b b f e f f e f 
+    . f d d f d d f d d b e f f f f 
+    . . f f f f f f f f f f f f f . 
+    `, SpriteKind.Player))
+```
+
+## See also
+
+[get player by number](/reference/multiplayer/get-player-by-number),
+[get player by index](/reference/multiplayer/get-player-by-index)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/player-selector.md
+++ b/libs/multiplayer/docs/reference/multiplayer/player-selector.md
@@ -16,7 +16,7 @@ Players in a multiplayer game are represented by the [Player](/types/player) gam
 
 * the [Player](/types/player) chosen by the selector in **player**.
 
-## Example
+## Example #example
 
 Set a character sprite for the player selected by ``||mp:player 2||``.
 
@@ -41,7 +41,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
     `, SpriteKind.Player))
 ```
 
-## See also
+## See also #seealso
 
 [get player by number](/reference/multiplayer/get-player-by-number),
 [get player by index](/reference/multiplayer/get-player-by-index)

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-indicators-visible.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-indicators-visible.md
@@ -1,0 +1,19 @@
+# set Player Indicators Visible
+
+```sig
+mp.setPlayerIndicatorsVisible(true)
+```
+
+## Paramters
+
+* **visible**: a [boolean](/types/boolean) value that when set `true` the player's indicating information is visible to other players. Otherwise, if set `false`, the indicators aren't displayed on other player's screens.
+
+## Example
+
+When `player 1` presses button `B`, they go "anonymous" and their indicators aren't displayed.
+
+```blocks
+mp.onButtonEvent(mp.MultiplayerButton.B, ControllerButtonEvent.Pressed, function (player2) {
+    mp.setPlayerIndicatorsVisible(true)
+})
+```

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-indicators-visible.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-indicators-visible.md
@@ -12,7 +12,7 @@ When set as visible, player indicators are displayed on the screen next to the p
 
 * **visible**: a [boolean](/types/boolean) value that when set `true` all player's indicators are visible on the screen to every player. Otherwise, if set `false`, the indicators aren't displayed on any player's screen.
 
-## Example
+## Example #example
 
 Set sprites for both `player 1` and `player 2`. Send them moving around the screen. Turn the visibility of the indicators on so that each player sprite is identified.
 
@@ -60,7 +60,7 @@ mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setBounceOnWall(true)
 mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setVelocity(50, 40)
 ```
 
-## See also
+## See also #seealso
 
 [set player sprite](/reference/multiplayer/set-player-sprite)
 

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-indicators-visible.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-indicators-visible.md
@@ -1,19 +1,69 @@
 # set Player Indicators Visible
 
+Make player sprite indicators visible or not visible.
+
 ```sig
 mp.setPlayerIndicatorsVisible(true)
 ```
 
+When set as visible, player indicators are displayed on the screen next to the player's character sprite. All active players will have an indicator shown.
+
 ## Paramters
 
-* **visible**: a [boolean](/types/boolean) value that when set `true` the player's indicating information is visible to other players. Otherwise, if set `false`, the indicators aren't displayed on other player's screens.
+* **visible**: a [boolean](/types/boolean) value that when set `true` all player's indicators are visible on the screen to every player. Otherwise, if set `false`, the indicators aren't displayed on any player's screen.
 
 ## Example
 
-When `player 1` presses button `B`, they go "anonymous" and their indicators aren't displayed.
+Set sprites for both `player 1` and `player 2`. Send them moving around the screen. Turn the visibility of the indicators on so that each player sprite is identified.
 
 ```blocks
-mp.onButtonEvent(mp.MultiplayerButton.B, ControllerButtonEvent.Pressed, function (player2) {
-    mp.setPlayerIndicatorsVisible(true)
-})
+mp.setPlayerIndicatorsVisible(true)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setVelocity(40, -30)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . c c c c . . . . . . . . 
+    . . c c 5 5 5 5 c c . . . . . . 
+    . c 5 5 5 5 5 5 5 5 c . . . . . 
+    c 5 5 5 5 5 1 f 5 5 5 c . . . . 
+    c 5 5 5 5 5 f f 5 5 5 5 c . . . 
+    c 5 5 5 5 5 5 5 5 5 5 5 c . . . 
+    c c b b 1 b 5 5 5 5 5 5 d c . . 
+    c 5 3 3 3 5 5 5 5 5 d d d c . . 
+    . b 5 5 5 5 5 5 5 5 d d d c . . 
+    . . c b b c 5 5 b d d d d c . . 
+    . c b b c 5 5 b b d d d d c c c 
+    . c c c c c c d d d d d d d d c 
+    . . . c c c c d 5 5 b d d c c . 
+    . . c b b c c c 5 5 b c c . . . 
+    . . c c c c c d 5 5 c . . . . . 
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setBounceOnWall(true)
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two)).setVelocity(50, 40)
+```
+
+## See also
+
+[set player sprite](/reference/multiplayer/set-player-sprite)
+
+```package
+multiplayer
 ```

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-sprite.md
@@ -1,17 +1,49 @@
 # set Player Sprite
 
-Assign a sprite to a player.
+Assign a character sprite to a player.
 
 ```sig
-mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img` `, SpriteKind.Player))
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img``))
 ```
+
+The sprite that is set for a [Player](/types/player) is moved when controller buttons are enabled for the Player. Also, player [indicators]() are displayed with the sprite.
 
 ## Parameters
 
-* **player**:
-* **sprite**:
+* **player**: the [Player](/types/player) to assing a sprite to.
+* **sprite**: the sprite to set as the character sprite for **player**.
+
+## Example
+
+Set a character sprite for `player 2` and make it move with the controller buttons.
+
+```blocks
+scene.setBackgroundColor(10)
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . . f f f f f . . . . . . 
+    . . . . f e e e e e f . . . . . 
+    . . . f d d d d d d e f . . . . 
+    . . f d f f d d f f d f f . . . 
+    . c d d d e e d d d d e d f . . 
+    . c d c d d d d c d d e f f . . 
+    . c d d c c c c d d d e f f f f 
+    . . c d d d d d d d e f f b d f 
+    . . . c d d d d e e f f f d d f 
+    . . . . f f f e e f e e e f f f 
+    . . . . f e e e e e e e f f f . 
+    . . . f e e e e e e f f f e f . 
+    . . f f e e e e f f f f f e f . 
+    . f b d f e e f b b f f f e f . 
+    . f d d f f f f d d b f f f f . 
+    . f f f f f f f f f f f f f . . 
+    `, SpriteKind.Player))
+mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.Two))
+```
 
 ## See also
+
+[get player sprite](/reference/multiplayer/get-player-sprite),
+[set player indicators visible](/reference/multiplayer/set-player-indicators-visible)
 
 ```package
 multiplayer

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-sprite.md
@@ -13,7 +13,7 @@ The sprite that is set for a [Player](/types/player) is moved when controller bu
 * **player**: the [Player](/types/player) to assing a sprite to.
 * **sprite**: the sprite to set as the character sprite for **player**.
 
-## Example
+## Example #example
 
 Set a character sprite for `player 2` and make it move with the controller buttons.
 
@@ -40,7 +40,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
 mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.Two))
 ```
 
-## See also
+## See also #seealso
 
 [get player sprite](/reference/multiplayer/get-player-sprite),
 [set player indicators visible](/reference/multiplayer/set-player-indicators-visible)

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-sprite.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-sprite.md
@@ -1,0 +1,18 @@
+# set Player Sprite
+
+Assign a sprite to a player.
+
+```sig
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img` `, SpriteKind.Player))
+```
+
+## Parameters
+
+* **player**:
+* **sprite**:
+
+## See also
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-state.md
@@ -1,0 +1,19 @@
+# set Player State
+
+```sig
+mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
+```
+
+## Parameters
+
+* **player**:
+* **state**:
+* **value**:
+
+## See also
+
+[change player state by](/reference/multiplayer/change-player-state-by)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-state.md
@@ -31,7 +31,7 @@ namespace MultiplayerState {
 * **state**: the [state item](/reference/multiplayer/multiplayer-state) to set a **value** to, such as `score` or `life`.
 * **value**: a [number](/types/number) which is the new value for the **state**.
 
-## Example
+## Example #example
 
 Set `player 1` score state to `0`. Send the player's shark sprite across the screen to eat a goldfish on the opposite side. When the shark overlaps the goldfish, add `1` to `player 1` score state.
 
@@ -129,7 +129,7 @@ game.onUpdateInterval(500, function () {
 })
 ```
 
-## See also
+## See also #seealso
 
 [get player state](/reference/multiplayer/get-player-state),
 [change player state by](/reference/multiplayer/change-player-state-by)

--- a/libs/multiplayer/docs/reference/multiplayer/set-player-state.md
+++ b/libs/multiplayer/docs/reference/multiplayer/set-player-state.md
@@ -1,17 +1,137 @@
 # set Player State
 
+Set a value for a Player state item.
+
 ```sig
 mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
 ```
 
+Information like the player's score and life count is contained with the [Player](/types/player) game object. The Player object has the ``||mp:score||`` and ``||mp:life||`` state items already added. You can add your own [state items](/reference/multiplayer/multiplayer-state) to the Player's list of states. The state list in the block let's has an option to add your own new states.
+
+As an example, if you want to give game a gems as rewards, you can add the ``||mp:gems||`` state to keep track of how many gems they have.
+
+```block
+namespace MultiplayerState {
+    export const gems = MultiplayerState.create()
+}
+mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.gems, 7)
+```
+
+In Javascript, a new state is created and added to the multiplayer state collection.
+
+```typescript-ignore
+namespace MultiplayerState {
+    export const gems = create()
+}
+```
+
 ## Parameters
 
-* **player**:
-* **state**:
-* **value**:
+* **player**: the [Player](/types/player) to set a state item value for.
+* **state**: the [state item](/reference/multiplayer/multiplayer-state) to set a **value** to, such as `score` or `life`.
+* **value**: a [number](/types/number) which is the new value for the **state**.
+
+## Example
+
+Set `player 1` score state to `0`. Send the player's shark sprite across the screen to eat a goldfish on the opposite side. When the shark overlaps the goldfish, add `1` to `player 1` score state.
+
+```blocks
+namespace MultiplayerState {
+    export const gems = MultiplayerState.create()
+}
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Food, function (sprite, otherSprite) {
+    goldfish.destroy(effects.warmRadial, 200)
+    mp.changePlayerStateBy(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 1)
+})
+let chomp = false
+let goldfish: Sprite = null
+mp.setPlayerState(mp.playerSelector(mp.PlayerNumber.One), MultiplayerState.score, 0)
+goldfish = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . c c c c . . . . 
+    . . . . . . c c d d d d c . . . 
+    . . . . . c c c c c c d c . . . 
+    . . . . c c 4 4 4 4 d c c . . . 
+    . . . c 4 d 4 4 4 4 4 1 c . c c 
+    . . c 4 4 4 1 4 4 4 4 d 1 c 4 c 
+    . c 4 4 4 4 1 4 4 4 4 4 1 c 4 c 
+    f 4 4 4 4 4 1 4 4 4 4 4 1 4 4 f 
+    f 4 4 4 f 4 1 c c 4 4 4 1 f 4 f 
+    f 4 4 4 4 4 1 4 4 f 4 4 d f 4 f 
+    . f 4 4 4 4 1 c 4 f 4 d f f f f 
+    . . f f 4 d 4 4 f f 4 c f c . . 
+    . . . . f f 4 4 4 4 c d b c . . 
+    . . . . . . f f f f d d d c . . 
+    . . . . . . . . . . c c c . . . 
+    `, SpriteKind.Food)
+goldfish.left = 0
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.One), sprites.create(img`
+    .................ccfff..............
+    ................cddbbf..............
+    ...............cddbbf...............
+    ..............fccbbcf............ccc
+    ........ffffffccccccff.........ccbbc
+    ......ffbbbbbbbbbbbbbcfff.....cdbbc.
+    ....ffbbbbbbbbbcbcbbbbcccff..cddbbf.
+    ....fbcbbbbbffbbcbcbbbcccccfffdbbf..
+    ....fbbb1111ff1bcbcbbbcccccccbbbcf..
+    .....fb11111111bbbbbbcccccccccbccf..
+    ......fccc33cc11bbbbccccccccfffbbcf.
+    .......fc131c111bbbcccccbdbc...fbbf.
+    ........f33c111cbbbfdddddcc.....fbbf
+    .........ff1111fbdbbfddcc........fff
+    ...........cccccfbdbbfc.............
+    .................fffff..............
+    `, SpriteKind.Player))
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).right = scene.screenWidth()
+mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).vx = -30
+game.onUpdateInterval(500, function () {
+    if (chomp == true) {
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setImage(img`
+            ....................ccfff...........
+            ..........fffffffffcbbbbf...........
+            .........fbbbbbbbbbfffbf............
+            .........fbb111bffbbbbff............
+            .........fb11111ffbbbbbcff..........
+            .........f1cccc11bbcbcbcccf.........
+            ..........fc1c1c1bbbcbcbcccf...ccccc
+            ............c3331bbbcbcbccccfccddbbc
+            ...........c333c1bbbbbbbcccccbddbcc.
+            ...........c331c11bbbbbcccccccbbcc..
+            ..........cc13c111bbbbccccccffbccf..
+            ..........c111111cbbbcccccbbc.fccf..
+            ...........cc1111cbbbfdddddc..fbbcf.
+            .............cccffbdbbfdddc....fbbf.
+            ..................fbdbbfcc......fbbf
+            ...................fffff.........fff
+            `)
+    } else {
+        mp.getPlayerSprite(mp.playerSelector(mp.PlayerNumber.One)).setImage(img`
+            .................ccfff..............
+            ................cddbbf..............
+            ...............cddbbf...............
+            ..............fccbbcf............ccc
+            ........ffffffccccccff.........ccbbc
+            ......ffbbbbbbbbbbbbbcfff.....cdbbc.
+            ....ffbbbbbbbbbcbcbbbbcccff..cddbbf.
+            ....fbcbbbbbffbbcbcbbbcccccfffdbbf..
+            ....fbbb1111ff1bcbcbbbcccccccbbbcf..
+            .....fb11111111bbbbbbcccccccccbccf..
+            ......fccc33cc11bbbbccccccccfffbbcf.
+            .......fc131c111bbbcccccbdbc...fbbf.
+            ........f33c111cbbbfdddddcc.....fbbf
+            .........ff1111fbdbbfddcc........fff
+            ...........cccccfbdbbfc.............
+            .................fffff..............
+            `)
+    }
+    chomp = !(chomp)
+})
+```
 
 ## See also
 
+[get player state](/reference/multiplayer/get-player-state),
 [change player state by](/reference/multiplayer/change-player-state-by)
 
 ```package

--- a/libs/multiplayer/docs/types/player.md
+++ b/libs/multiplayer/docs/types/player.md
@@ -19,7 +19,7 @@ let myPlayer: mp.Player = null
 myPlayer = mp.playerSelector(mp.PlayerNumber.One)
 ```
 
-## Example
+## Example #example
 
 ```blocks
 namespace MultiplayerState {
@@ -73,7 +73,7 @@ mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
 mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.Two))
 ```
 
-# See also
+# See also #seealso
 
 [multiplayer](/reference/multiplayer)
 

--- a/libs/multiplayer/docs/types/player.md
+++ b/libs/multiplayer/docs/types/player.md
@@ -1,0 +1,82 @@
+# Player
+
+A **Player** is a game object representing one of the players in a [multiplayer](/reference/multiplayer)
+game. A Player object has entities, information, and actions associated with it related to an actual player's state in a game.
+
+Typically, a Player object is assigned a character [Sprite](/types/sprite) and keeps track of it's current score, life points, etc. Actions like controller inputs and connection status are tracked for a Player also.
+
+Player objects are usually referenced using a selector named as the player's number.
+
+```block
+let myPlayer = mp.playerSelector(mp.PlayerNumber.One)
+```
+
+Similarly in Javascript, `myPlayer` is a `Player` object and is set using the selector for ``||mp:player 1||``:
+
+```typescript-ignore
+let myPlayer: mp.Player = null
+
+myPlayer = mp.playerSelector(mp.PlayerNumber.One)
+```
+
+## Example
+
+```blocks
+namespace MultiplayerState {
+    export const gems = MultiplayerState.create()
+}
+mp.onControllerEvent(ControllerEvent.Connected, function (player) {
+    if (player == mp.playerSelector(mp.PlayerNumber.Two)) {
+        mp.getPlayerSprite(player).sayText("Player 2 is on!")
+    }
+})
+mp.onScore(100, function (player) {
+    if (player == mp.playerSelector(mp.PlayerNumber.One)) {
+        mp.gameOverPlayerWin(mp.playerSelector(mp.PlayerNumber.One))
+    }
+})
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . 4 4 4 . . . . 4 4 4 . . . . 
+    . 4 5 5 5 e . . e 5 5 5 4 . . . 
+    4 5 5 5 5 5 e e 5 5 5 5 5 4 . . 
+    4 5 5 4 4 5 5 5 5 4 4 5 5 4 . . 
+    e 5 4 4 5 5 5 5 5 5 4 4 5 e . . 
+    . e e 5 5 5 5 5 5 5 5 e e . . . 
+    . . e 5 f 5 5 5 5 f 5 e . . . . 
+    . . f 5 5 5 4 4 5 5 5 f . . f f 
+    . . f 4 5 5 f f 5 5 6 f . f 5 f 
+    . . . f 6 6 6 6 6 6 4 4 f 5 5 f 
+    . . . f 4 5 5 5 5 5 5 4 4 5 f . 
+    . . . f 5 5 5 5 5 4 5 5 f f . . 
+    . . . f 5 f f f 5 f f 5 f . . . 
+    . . . f f . . f f . . f f . . . 
+    `, SpriteKind.Player))
+mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.One))
+mp.setPlayerSprite(mp.playerSelector(mp.PlayerNumber.Two), sprites.create(img`
+    . . . . f f f f f . . . . . . . 
+    . . . f e e e e e f . . . . . . 
+    . . f d d d d e e e f . . . . . 
+    . c d f d d f d e e f f . . . . 
+    . c d f d d f d e e d d f . . . 
+    c d e e d d d d e e b d c . . . 
+    c d d d d c d d e e b d c . . . 
+    c c c c c d d e e e f c . . . . 
+    . f d d d d e e e f f . . . . . 
+    . . f f f f f e e e e f . . . . 
+    . . . . f f e e e e e e f . f f 
+    . . . f e e f e e f e e f . e f 
+    . . f e e f e e f e e e f . e f 
+    . f b d f d b f b b f e f f e f 
+    . f d d f d d f d d b e f f f f 
+    . . f f f f f f f f f f f f f . 
+    `, SpriteKind.Player))
+mp.moveWithButtons(mp.playerSelector(mp.PlayerNumber.Two))
+```
+
+# See also
+
+[multiplayer](/reference/multiplayer)
+
+```package
+multiplayer
+```

--- a/libs/multiplayer/fieldEditors.ts
+++ b/libs/multiplayer/fieldEditors.ts
@@ -9,6 +9,7 @@ namespace mp {
     //% kindMemberName=value
     //% kindPromptHint="e.g. Cooldown, Speed, Attack..."
     //% blockHidden
+    //% help=multiplayer/multiplayer-state
     export function _multiplayerState(kind: number): number {
         return kind;
     }

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -456,7 +456,7 @@ namespace mp {
     //% group=Controller
     //% weight=100
     //% blockGap=8
-    //% help=controller/move-sprite
+    //% help=multiplayer/move-with-buttons
     //% parts="multiplayer"
     export function moveWithButtons(player: Player, vx?: number, vy?: number) {
         if (!player) return;
@@ -475,7 +475,7 @@ namespace mp {
     //% group=Controller
     //% weight=90
     //% blockGap=8
-    //% help=controller/on-button-event
+    //% help=multiplayer/on-button-event
     //% parts="multiplayer"
     export function onButtonEvent(button: MultiplayerButton, event: ControllerButtonEvent, handler: (player: Player) => void) {
         _mpstate().onButtonEvent(button, event, handler);
@@ -493,7 +493,7 @@ namespace mp {
     //% group=Controller
     //% weight=80
     //% blockGap=8
-    //% help=controller/button/is-pressed
+    //% help=multiplayer/is-button-pressed
     //% parts="multiplayer"
     export function isButtonPressed(player: Player, button: MultiplayerButton): boolean {
         if (!player) return false;
@@ -511,7 +511,7 @@ namespace mp {
     //% group=Controller
     //% weight=70
     //% blockGap=8
-    //% help=controller/on-event
+    //% help=multiplayer/on-controller-event
     //% parts="multiplayer"
     export function onControllerEvent(event: ControllerEvent, handler: (player: Player) => void) {
         _mpstate().onControllerEvent(event, handler);
@@ -609,7 +609,7 @@ namespace mp {
     //% group=Info
     //% weight=70
     //% blockGap=8
-    //% help=info/on-score
+    //% help=multiplayer/on-score
     //% parts="multiplayer"
     export function onScore(score: number, handler: (player: Player) => void) {
         _mpstate().onReachedScore(score, handler);
@@ -625,7 +625,7 @@ namespace mp {
     //% group=Info
     //% weight=60
     //% blockGap=8
-    //% help=info/on-life-zero
+    //% help=multiplayer/on-life-zero
     //% parts="multiplayer"
     export function onLifeZero(handler: (player: Player) => void) {
         _mpstate().onLifeZero(handler);


### PR DESCRIPTION
Add the reference pages for the 'multiplayer' extension APIs.

Closes https://github.com/microsoft/pxt-arcade/issues/5515