### PR TITLE
hook up player leave / join to multiplayer state

### DIFF
--- a/libs/game/multiplayer.ts
+++ b/libs/game/multiplayer.ts
@@ -25,6 +25,8 @@ namespace multiplayer {
         game.pushScene();
     }
 
+    const MULTIPLAYER_PLAYER_JOINED_ID = 3241;
+    const MULTIPLAYER_PLAYER_LEFT_ID = 3242;
     export function initServer() {
         if (getOrigin() === "server") {
             game.eventContext().registerFrameHandler(scene.MULTIPLAYER_POST_SCREEN_PRIORITY, () => {
@@ -32,7 +34,44 @@ namespace multiplayer {
                     postImage(screen);
                 }
             })
+
+            for (let p = 1; p <= 4; p++) {
+                registerPlayerConnectionListeners(p);
+            }
         }
+    }
+
+    function registerPlayerConnectionListeners(playerNumber: number) {
+        control.onEvent(
+            MULTIPLAYER_PLAYER_JOINED_ID,
+            playerNumber,
+            () => receiveConnectionChangedEvent(playerNumber, true)
+        );
+        control.onEvent(
+            MULTIPLAYER_PLAYER_LEFT_ID,
+            playerNumber,
+            () => receiveConnectionChangedEvent(playerNumber, false)
+        );
+    }
+
+    function receiveConnectionChangedEvent(playerNumber: number, connected: boolean) {
+        let c: controller.Controller;
+        switch (playerNumber) {
+            case 1:
+                c = controller.player1;
+                break;
+            case 2:
+                c = controller.player2;
+                break;
+            case 3:
+                c = controller.player3;
+                break;
+            case 4:
+                c = controller.player4;
+                break;
+        }
+        if (c)
+            c.connected = connected;
     }
 }
 


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-arcade/issues/5193

event ids are a little tricky, I guess we just do "roll a dice and hope it doesn't collide" after checking `dal.d.ts` (e.g. https://github.com/microsoft/pxt-common-packages/pull/1119/files#diff-3446560eec31e791faeaee0c3b08bfefebbb06df29fd92a46bd5054576a1c094R3 is the other 'recent' sim only one that comes to mind)

quick test build: https://arcade.makecode.com/app/d83a329c52d33eb16de47b9b06193c1f1db0a87f-e53085d68d--multiplayer?host=_Rkud4LTboCqc, only host really matters for testing / it's fine if guests are just on beta

<img width="500" alt="image" src="https://user-images.githubusercontent.com/5615930/214992151-cecaccd4-c554-40e1-b35e-6a43c1d74eae.png">

pxt side over in https://github.com/microsoft/pxt/pull/9332