### PR TITLE
raise events for disconnected/connected on scene pop

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -13,6 +13,30 @@ enum ControllerEvent {
 //% blockGap=8
 namespace controller {
     let _players: Controller[];
+    game.addScenePopHandler(() => {
+        const stateWhenPushed = game.currentScene().controllerConnectionState;
+        if (!stateWhenPushed)
+            return;
+        for (let i = 0; i < stateWhenPushed.length; i++) {
+            const p = _players[i];
+            if (p && (!!stateWhenPushed[i] != !!p.connected)) {
+                // connection state changed while in another scene; raise the event.
+                control.raiseEvent(
+                    p.id,
+                    p.connected ? ControllerEvent.Connected : ControllerEvent.Disconnected
+                );
+            }
+        }
+
+    })
+    game.addScenePushHandler(oldScene => {
+        oldScene.controllerConnectionState = [];
+        for (let i = 0; i < _players.length; i++) {
+            if (_players[i]) {
+                oldScene.controllerConnectionState[i] = _players[i].connected;
+            }
+        }
+    })
 
     function addController(ctrl: Controller) {
         if (!_players) {

--- a/libs/game/scene.ts
+++ b/libs/game/scene.ts
@@ -94,6 +94,7 @@ namespace scene {
         gameForeverHandlers: GameForeverHandler[];
         particleSources: particles.ParticleSource[];
         controlledSprites: controller.ControlledSprite[][];
+        controllerConnectionState: boolean[]
         followingSprites: sprites.FollowingSprite[];
         buttonEventHandlers: controller.ButtonEventHandlerState[];
 


### PR DESCRIPTION
connected / disconnected events are treated like all the other controller events, which only run in the context of the screen. These events 'feel' more global though so this tracks when connection state has changed while the scene was behind in the stack and runs the events when it pops up again.

Super easy repro with this is just to press menu button and disconnect someone in https://arcade.makecode.com/app/d83a329c52d33eb16de47b9b06193c1f1db0a87f-e53085d68d--multiplayer?host=_Rkud4LTboCqc