### PR TITLE
null protection for sprite destroy

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -854,6 +854,7 @@ class Sprite extends sprites.BaseSprite {
     //% duration.shadow=timePicker
     //% expandableArgumentMode="toggle"
     //% help=sprites/sprite/destroy
+    //% deprecated=1
     destroy(effect?: effects.ParticleEffect, duration?: number) {
         if (this.flags & sprites.Flag.Destroyed)
             return;

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -62,7 +62,9 @@ namespace sprites {
 
     //% group="Effects"
     //% weight=80
-    //% blockId=spritedestroy2 block="destroy $sprite=variables_get(mySprite) || with $effect effect for $duration ms"
+    //% blockId=spritedestroy2 block="destroy $sprite || with $effect effect for $duration ms"
+    //% sprite.shadow=variables_get
+    //% sprite.defl=mySprite
     //% duration.shadow=timePicker
     //% expandableArgumentMode="toggle"
     //% help=sprites/sprite/destroy

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -60,6 +60,17 @@ namespace sprites {
         return sprites.create(img, kind);
     }
 
+    //% group="Effects"
+    //% weight=80
+    //% blockId=spritedestroy2 block="destroy $sprite=variables_get(mySprite) || with $effect effect for $duration ms"
+    //% duration.shadow=timePicker
+    //% expandableArgumentMode="toggle"
+    //% help=sprites/sprite/destroy
+    export function destroy(sprite: Sprite, effect?: effects.ParticleEffect, duration?: number) {
+        if (!sprite) return;
+        sprite.destroy(effect, duration);
+    }
+
     /**
      * Return an array of all sprites of the given kind.
      * @param kind the target kind


### PR DESCRIPTION
Let's eliminate one of the leading causes of the dread "sim error: failed cast on null".

If this error message were at all helpful, we might choose to leverage it as a teaching moment. But as it stands, it only serves as a blocking condition a beginner will hit and have no recourse but to walk away from Arcade.
