### PR TITLE
(hotfix stable10.3) cherry-pick: null protection for sprite destroy (#1415)

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -854,6 +854,7 @@ class Sprite extends sprites.BaseSprite {
     //% duration.shadow=timePicker
     //% expandableArgumentMode="toggle"
     //% help=sprites/sprite/destroy
+    //% deprecated=1
     destroy(effect?: effects.ParticleEffect, duration?: number) {
         if (this.flags & sprites.Flag.Destroyed)
             return;

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -60,6 +60,19 @@ namespace sprites {
         return sprites.create(img, kind);
     }
 
+    //% group="Effects"
+    //% weight=80
+    //% blockId=spritedestroy2 block="destroy $sprite || with $effect effect for $duration ms"
+    //% sprite.shadow=variables_get
+    //% sprite.defl=mySprite
+    //% duration.shadow=timePicker
+    //% expandableArgumentMode="toggle"
+    //% help=sprites/sprite/destroy
+    export function destroy(sprite: Sprite, effect?: effects.ParticleEffect, duration?: number) {
+        if (!sprite) return;
+        sprite.destroy(effect, duration);
+    }
+
     /**
      * Return an array of all sprites of the given kind.
      * @param kind the target kind


### PR DESCRIPTION
* null protection for sprite destroy

* Update libs/game/sprites.ts

Co-authored-by: Joey Wunderlich <jwunderl@users.noreply.github.com>

---------

Co-authored-by: Joey Wunderlich <jwunderl@users.noreply.github.com>