### PR TITLE
Better support for playing songs in the browser sim

### DIFF
--- a/libs/mixer/instrument.ts
+++ b/libs/mixer/instrument.ts
@@ -133,18 +133,36 @@ namespace music.sequencer {
         }
 
         play(playbackMode: PlaybackMode) {
-            if (currentSequencer) currentSequencer.stop();
-            currentSequencer = new sequencer.Sequencer(this);
+            if (control.deviceDalVersion() === "sim") {
+                const seq = new _SimulatorSequencer();
 
-            if (playbackMode === PlaybackMode.UntilDone) {
-                currentSequencer.start(false);
-                pause(this.measures * this.beatsPerMeasure * this.beatsPerMinute * 60 * 1000)
-            }
-            else if (playbackMode === PlaybackMode.InBackground) {
-                currentSequencer.start(false);
+                if (playbackMode === PlaybackMode.UntilDone) {
+                    seq.play(this.buf, false);
+
+                    pauseUntil(() => seq.state() === "stop");
+                }
+                else if (playbackMode === PlaybackMode.InBackground) {
+                    seq.play(this.buf, false);
+                }
+                else {
+                    seq.play(this.buf, true);
+                }
             }
             else {
-                currentSequencer.start(true);
+                if (currentSequencer) currentSequencer.stop();
+                currentSequencer = new sequencer.Sequencer(this);
+
+                if (playbackMode === PlaybackMode.UntilDone) {
+                    let seq = currentSequencer;
+                    currentSequencer.start(false);
+                    pauseUntil(() => !seq.isRunning);
+                }
+                else if (playbackMode === PlaybackMode.InBackground) {
+                    currentSequencer.start(false);
+                }
+                else {
+                    currentSequencer.start(true);
+                }
             }
         }
     }
@@ -817,5 +835,6 @@ namespace music.sequencer {
             currentSequencer.stop();
             currentSequencer = undefined;
         }
+        _stopAllSimSequencers();
     }
 }

--- a/libs/mixer/melody.cpp
+++ b/libs/mixer/melody.cpp
@@ -426,6 +426,49 @@ WSynthesizer::WSynthesizer() : upstream(NULL), out(*this) {
     PXT_REGISTER_RESET(stopPlaying);
 }
 
+//% promise
+int _createSequencer() {
+    return 0;
+}
+
+//%
+String _sequencerState(int id) {
+    return NULL;
+}
+
+//%
+int _sequencerCurrentTick(int id) {
+    return 0;
+}
+
+//%
+void _sequencerPlaySong(int id, Buffer buf, bool loop) {
+}
+
+//%
+void _sequencerStop(int id) {
+}
+
+//%
+void _sequencerSetVolume(int id, int volume) {
+}
+
+//%
+void _sequencerSetVolumeForAll(int volume) {
+}
+
+//%
+void _sequencerSetTrackVolume(int id, int trackIndex, int volume) {
+}
+
+//%
+void _sequencerSetDrumTrackVolume(int id, int trackIndex, int drumIndex, int volume) {
+}
+
+//%
+void _sequencerDispose(int id) {
+}
+
 } // namespace music
 
 namespace pxt {

--- a/libs/mixer/sequencer.ts
+++ b/libs/mixer/sequencer.ts
@@ -1,4 +1,9 @@
 namespace music.sequencer {
+    const SEQUENCER_STOP_MESSAGE = 3243;
+    const SEQUENCER_TICK_MESSAGE = 3244;
+    const SEQUENCER_STATE_CHANGE_MESSAGE = 3245;
+    const SEQUENCER_LOOPED_MESSAGE = 3246;
+
     export class Sequencer {
         currentTick: number;
         isPlaying: boolean;
@@ -85,4 +90,115 @@ namespace music.sequencer {
             }
         }
     }
+
+    let activeSimSequencers: _SimulatorSequencer[];
+    export function _stopAllSimSequencers() {
+        if (activeSimSequencers) {
+            for (const seq of activeSimSequencers) {
+                seq.stop();
+                seq.dispose();
+            }
+            activeSimSequencers = [];
+        }
+    }
+
+    // Simulator only! Does nothing on hardware
+    export class _SimulatorSequencer {
+        protected id: number;
+
+        constructor() {
+            if (!activeSimSequencers) activeSimSequencers = [];
+            activeSimSequencers.push(this);
+            this.id = _createSequencer();
+            this.setVolume(music.volume());
+        }
+
+        play(song: Buffer, loop: boolean) {
+            this.setVolume(music.volume());
+            _sequencerPlaySong(this.id, song, loop)
+        }
+
+        stop() {
+            _sequencerStop(this.id);
+        }
+
+        setVolume(volume: number) {
+            _sequencerSetVolume(this.id, volume);
+        }
+
+        setTrackVolume(trackIndex: number, volume: number) {
+            _sequencerSetTrackVolume(this.id, trackIndex, volume)
+        }
+
+        setDrumTrackVolume(trackIndex: number, drumIndex: number, volume: number) {
+            _sequencerSetDrumTrackVolume(this.id, drumIndex, trackIndex, volume)
+        }
+
+        state() {
+            return _sequencerState(this.id) || "stop";
+        }
+
+        currentTick() {
+            return _sequencerCurrentTick(this.id);
+        }
+
+        dispose() {
+            _sequencerDispose(this.id);
+        }
+
+        onTick(handler: (tick: number) => void) {
+            control.onEvent(SEQUENCER_TICK_MESSAGE, this.id, () => {
+                handler(this.currentTick());
+            });
+        }
+
+        onStateChange(handler: (state: string) => void) {
+            control.onEvent(SEQUENCER_STATE_CHANGE_MESSAGE, this.id, () => {
+                handler(this.state());
+            });
+        }
+
+        onStop(handler: () => void) {
+            control.onEvent(SEQUENCER_STOP_MESSAGE, this.id, () => {
+                handler();
+            });
+        }
+
+        onLooped(handler: () => void) {
+            control.onEvent(SEQUENCER_LOOPED_MESSAGE, this.id, () => {
+                handler();
+            });
+        }
+    }
+
+    //% promise
+    //% shim=music::_createSequencer
+    declare function _createSequencer(): number
+
+    //% shim=music::_sequencerState
+    declare function _sequencerState(id: number): string;
+
+    //% shim=music::_sequencerCurrentTick
+    declare function _sequencerCurrentTick(id: number): number;
+
+    //% shim=music::_sequencerPlaySong
+    declare function _sequencerPlaySong(id: number, song: Buffer, loop: boolean): void;
+
+    //% shim=music::_sequencerStop
+    declare function _sequencerStop(id: number): void;
+
+    //% shim=music::_sequencerSetVolume
+    declare function _sequencerSetVolume(id: number, volume: number): void;
+
+    //% shim=music::_sequencerSetVolumeForAll
+    declare function _sequencerSetVolumeForAll(volume: number): void;
+
+    //% shim=music::_sequencerSetTrackVolume
+    declare function _sequencerSetTrackVolume(id: number, trackIndex: number, volume: number): void;
+
+    //% shim=music::_sequencerSetDrumTrackVolume
+    declare function _sequencerSetDrumTrackVolume(id: number, trackIndex: number, drumIndex: number, volume: number): void;
+
+    //% shim=music::_sequencerDispose
+    declare function _sequencerDispose(id: number): void;
 }

--- a/libs/mixer/sim/music.ts
+++ b/libs/mixer/sim/music.ts
@@ -9,7 +9,109 @@ namespace pxsim.music {
 
     export function stopPlaying() {
         AudioContextManager.muteAllChannels()
+
+        if (sequencers) {
+            for (const seq of sequencers) {
+                seq.sequencer.stop();
+                seq.sequencer.dispose();
+            }
+        }
     }
 
     export function forceOutput(mode: number) { }
+
+    export const SEQUENCER_STOP_MESSAGE = 3243;
+    export const SEQUENCER_TICK_MESSAGE = 3244;
+    export const SEQUENCER_STATE_CHANGE_MESSAGE = 3245;
+    export const SEQUENCER_LOOPED_MESSAGE = 3246;
+
+    interface SequencerWithId {
+        id: number;
+        sequencer: Sequencer;
+    }
+
+    let sequencers: SequencerWithId[];
+    let nextSequencerId = 0;
+
+    export async function _createSequencer(): Promise<number> {
+        if (!sequencers) {
+            pxsim.AudioContextManager.onStopAll(() => {
+                for (const seq of sequencers) {
+                    seq.sequencer.stop();
+                    seq.sequencer.dispose();
+                }
+                sequencers = [];
+            })
+
+            sequencers = [];
+        }
+        const res = {
+            id: nextSequencerId++,
+            sequencer: new Sequencer()
+        };
+
+        sequencers.push(res)
+
+        await res.sequencer.initAsync();
+        res.sequencer.addEventListener("stop", () => {
+            board().bus.queue(SEQUENCER_STOP_MESSAGE, this.id);
+        });
+        res.sequencer.addEventListener("state-change", () => {
+            board().bus.queue(SEQUENCER_STATE_CHANGE_MESSAGE, this.id);
+        });
+        res.sequencer.addEventListener("looped", () => {
+            board().bus.queue(SEQUENCER_LOOPED_MESSAGE, this.id);
+        });
+        res.sequencer.addEventListener("tick", () => {
+            board().bus.queue(SEQUENCER_TICK_MESSAGE, this.id);
+        });
+
+
+        return res.id;
+    }
+
+    export function _sequencerState(id: number): string {
+        return lookupSequencer(id)?.state();
+    }
+
+    export function _sequencerCurrentTick(id: number): number {
+        return lookupSequencer(id)?.currentTick();
+    }
+
+    export function _sequencerPlaySong(id: number, song: RefBuffer, loop: boolean): void {
+        const decoded = decodeSong(song.data);
+        lookupSequencer(id)?.start(decoded, loop);
+    }
+
+    export function _sequencerStop(id: number): void {
+        lookupSequencer(id)?.stop();
+    }
+
+    export function _sequencerSetVolume(id: number, volume: number): void {
+        lookupSequencer(id)?.setVolume(volume);
+    }
+
+    export function _sequencerSetVolumeForAll(volume: number): void {
+        for (const seq of sequencers) {
+            seq.sequencer.setVolume(volume);
+        }
+    }
+
+    export function _sequencerSetTrackVolume(id: number, trackIndex: number, volume: number): void {
+        lookupSequencer(id)?.setTrackVolume(trackIndex, volume);
+    }
+
+    export function _sequencerSetDrumTrackVolume(id: number, trackIndex: number, drumIndex: number, volume: number): void {
+        lookupSequencer(id)?.setDrumTrackVolume(trackIndex, drumIndex, volume);
+    }
+
+    export function _sequencerDispose(id: number) {
+        lookupSequencer(id)?.dispose();
+        sequencers = sequencers.filter(s => s.id !== id);
+    }
+
+    function lookupSequencer(id: number) {
+        for (const seq of sequencers) if (seq.id === id) return seq.sequencer;
+        return undefined;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "libs/**/*"
   ],
   "dependencies": {
-    "pxt-core": "8.4.16"
+    "pxt-core": "8.6.10"
   },
   "devDependencies": {
     "typescript": "^4.2.3"


### PR DESCRIPTION
This PR requires https://github.com/microsoft/pxt/pull/9381

Fixes https://github.com/microsoft/pxt-arcade/issues/5675

This separates playback of songs between hardware and the browser sim. On hardware, nothing changes (except the bug I fixed). The simulator now uses the same sequencer used by the music editor, which has much more accurate timing.

Here is a program that illustrates the issue:

https://arcade.makecode.com/S22715-41600-35351-76629

Try playing that in the sim and then opening the code and playing it in the music editor. The sim is significantly slower and drifts over time.

While I was at it, I also added some events for the browser simulator that I thought would be useful.

Here's an upload target with these changes: https://arcade.makecode.com/app/abc67de31823239df2cb53cc6844fdecb7f10558-06911e4696'

