### PR TITLE
Music 'playable' ref pages

### DIFF
--- a/libs/mixer/docs/reference/music.md
+++ b/libs/mixer/docs/reference/music.md
@@ -2,20 +2,24 @@
 
 Make music and play tones.
 
+## Songs
+
+```cards
+music.createSong(hex`00780004080200`)
+```
+
 ## Melodies
 
 ```cards
-music.playMelody("", 120);
-music.baDing.play()
-music.baDing.playUntilDone()
-music.baDing.loop()
-music.baDing.stop()
+music.stringPlayable("", 120)
+music.melodyPlayable(music.baDing)
 ```
 
 ## Sound
 
 ```cards
-music.playTone(0, 0);
+music.play(null, music.PlaybackMode.UntilDone)
+music.tonePlayable(262, music.beat(BeatFraction.Whole))
 music.ringTone(0);
 music.rest(0);
 music.noteFrequency(Note.C);
@@ -29,7 +33,8 @@ music.stopAllSounds()
 
 ## See Also
 
-[play melody](/reference/music/play-melody), [play tone](/reference/music/play-tone),
+[play](/reference/music/play), [tone playable](/reference/music/tone-playable),
+[string playable](/reference/music/string-playable), [melody playable](/reference/music/melody-playable), [create song](/reference/music/create-song),
 [ring tone](/reference/music/ring-tone), [rest](/reference/music/rest),
 [beat](/reference/music/beat), [tempo](/reference/music/tempo),
 [change tempo by](/reference/music/change-tempo-by),[set tempo](/reference/music/set-tempo)

--- a/libs/mixer/docs/reference/music/create-song.md
+++ b/libs/mixer/docs/reference/music/create-song.md
@@ -1,0 +1,37 @@
+# create Song
+
+Create a song from the notes of one or more musical instruments.
+
+```sig
+music.createSong(hex`00780004080200`)
+```
+
+A song is composed of notes from different instruments in the Song Editor. The Song Editor is displayed by clicking on the music staff window in the ``||music:song||`` block.
+
+```block
+music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`)
+```
+
+The Song Editor contains a `Treble` and `Bass` clef for you to compose your music with the notes from your selected instruments. You can set `tempo` an add measures to the staff shown in the editor window. When you're done, the song is set as general data into the **buffer** parameter.
+
+## Parameters
+
+* **buffer**: the data containing the notes played by each instrument in the song.
+
+## Returns
+
+* a [playable](/types/playable) object for the notes contained in **buffer**.
+
+## Example #example
+
+Play a song composed in the Song Editor.
+
+```blocks
+music.play(music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`), music.PlaybackMode.UntilDone)
+```
+
+## See also #seealso
+
+[tone playable](/reference/music/tone-playable),
+[string playable](/reference/music/string-playable),
+[melody playable](/reference/music/melody-playable)

--- a/libs/mixer/docs/reference/music/melody-playable.md
+++ b/libs/mixer/docs/reference/music/melody-playable.md
@@ -1,0 +1,30 @@
+# melody Playable
+
+Create a playable melody from a built-in melody.
+
+```sig
+music.melodyPlayable(music.baDing)
+```
+
+Melodies are a sequence of notes that played one after the other. There are several built-in melodies you can play in your games. An easy way to add music to your game is to choose one of the built-in melodies.
+
+## Parameters
+
+* **melody**: a built-in melody to create a playable object for, such as `ba ding`, `magic wand`, or `siren`.
+
+## Returns
+
+* a [playable](/types/playable) object that contains the built-in **melody**.
+
+## Example #example
+
+Play the `magic wand` melody until it is done.
+
+```blocks
+music.play(music.melodyPlayable(music.magicWand), music.PlaybackMode.UntilDone)
+```
+
+## See also #seealso
+
+[tone playable](/reference/music/tone-playable),
+[string playable](/reference/music/string-playable)

--- a/libs/mixer/docs/reference/music/play.md
+++ b/libs/mixer/docs/reference/music/play.md
@@ -35,6 +35,14 @@ music.play(music.createSong(hex`0078000408020200001c00010a006400f401640000040000
 >* `in background`: play the music source in **toPlay** but continue with the rest of the program before music play is done.
 >* `in background looping`: play the music source in **toPlay** but continue with the rest of the program before music play is done. The music will remain playing, returning to the first note of the music after its duration.
 
+### ~ hint
+
+#### Stop the music!
+
+You can stop any music currently playing with the ``||music:stop all sounds||`` block. This is useful if **playbackMode** is set to `in background looping` and you wish to stop the music for a scene change or respond to an event with a different sound.
+
+### ~
+
 ## Examples #example
 
 ### Play a melody
@@ -62,9 +70,62 @@ for (let someMusic of playables) {
 }
 ```
 
+### Looping music play
+
+Play a simple song in the background while a monkey moves around the screen. When the monkey hits the bubble in the middle of the screen, stop the song and play a bursting sound.
+
+```blocks
+let bubble = sprites.create(img`
+    . . . . . b b b b b b . . . . . 
+    . . . b b 9 9 9 9 9 9 b b . . . 
+    . . b b 9 9 9 9 9 9 9 9 b b . . 
+    . b b 9 d 9 9 9 9 9 9 9 9 b b . 
+    . b 9 d 9 9 9 9 9 1 1 1 9 9 b . 
+    b 9 d d 9 9 9 9 9 1 1 1 9 9 9 b 
+    b 9 d 9 9 9 9 9 9 1 1 1 9 9 9 b 
+    b 9 3 9 9 9 9 9 9 9 9 9 1 9 9 b 
+    b 5 3 d 9 9 9 9 9 9 9 9 9 9 9 b 
+    b 5 3 3 9 9 9 9 9 9 9 9 9 d 9 b 
+    b 5 d 3 3 9 9 9 9 9 9 9 d d 9 b 
+    . b 5 3 3 3 d 9 9 9 9 d d 5 b . 
+    . b d 5 3 3 3 3 3 3 3 d 5 b b . 
+    . . b d 5 d 3 3 3 3 5 5 b b . . 
+    . . . b b 5 5 5 5 5 5 b b . . . 
+    . . . . . b b b b b b . . . . . 
+    `, SpriteKind.Player)
+let monkey = sprites.create(img`
+    . . . . f f f f f . . . . . . . 
+    . . . f e e e e e f . . . . . . 
+    . . f d d d d e e e f . . . . . 
+    . c d f d d f d e e f f . . . . 
+    . c d f d d f d e e d d f . . . 
+    c d e e d d d d e e b d c . . . 
+    c d d d d c d d e e b d c . f f 
+    c c c c c d d d e e f c . f e f 
+    . f d d d d d e e f f . . f e f 
+    . . f f f f f e e e e f . f e f 
+    . . . . f e e e e e e e f f e f 
+    . . . f e f f e f e e e e f f . 
+    . . . f e f f e f e e e e f . . 
+    . . . f d b f d b f f e f . . . 
+    . . . f d d c d d b b d f . . . 
+    . . . . f f f f f f f f f . . . 
+    `, SpriteKind.Enemy)
+monkey.setBounceOnWall(true)
+monkey.x = scene.screenWidth()
+monkey.setVelocity(50, 40)
+music.play(music.stringPlayable("C5 A B G A F A C5 ", 120), music.PlaybackMode.LoopingInBackground)
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSprite) {
+    music.stopAllSounds()
+    sprites.destroy(sprite, effects.blizzard, 500)
+    music.play(music.melodyPlayable(music.zapped), music.PlaybackMode.UntilDone)
+})
+```
+
 ## See also #seealso
 
 [tone playable](/reference/music/tone-playable),
 [string playable](/reference/music/string-playable),
 [melody playable](/reference/music/melody-playable),
-[create song](/reference/music/create-song)
+[create song](/reference/music/create-song),
+[stop all sounds](/reference/music/stop-all-sounds)

--- a/libs/mixer/docs/reference/music/play.md
+++ b/libs/mixer/docs/reference/music/play.md
@@ -1,0 +1,70 @@
+# play
+
+Play a song, melody, or tone from a playable music source.
+
+```sig
+music.play(music.createSong(hex`00780004080200`), music.PlaybackMode.UntilDone)
+```
+
+Music is played for a simple tone, a melody, or a song. Each of these music sources is called a [playble](/types/playable) object. The ``||music:play||`` block can take any of these playable objects and play them as sound output for your game.
+
+The simpliest music source is a **tone**, on note play for a duration of time:
+
+```block
+music.play(music.tonePlayable(262, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
+```
+
+Then, there is the **melody** which is a series of notes played at a certain speed, or `tempo`. You can create your own melody of choose a built-in one to play:
+
+```block
+music.play(music.stringPlayable("D F E A E A C B ", 120), music.PlaybackMode.UntilDone)
+music.play(music.melodyPlayable(music.magicWand), music.PlaybackMode.UntilDone)
+```
+
+The most complex playabe object is a **song**. Songs are composed in the Song Editor using many notes from different instruments.
+
+```block
+music.play(music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`), music.PlaybackMode.UntilDone)
+```
+
+## Parameters
+
+* **toPlay**: the [playable](/types/playable) object, or music source, to play.
+* **playbackMode**: the playback mode for continuing the program:
+>* `play until done`: play the music source in **toPlay** but wait to run the next part of the program until music play is done.
+>* `in background`: play the music source in **toPlay** but continue with the rest of the program before music play is done.
+>* `in background looping`: play the music source in **toPlay** but continue with the rest of the program before music play is done. The music will remain playing, returning to the first note of the music after its duration.
+
+## Examples #example
+
+### Play a melody
+
+Play a short melody created in the Melody Editor.
+
+```blocks
+music.play(music.stringPlayable("D F E A E A C B ", 120), music.PlaybackMode.UntilDone)
+```
+
+### Different music sources, one block to play them all
+
+Put 4 different playable music sources in an array. Play one after the other.
+
+```blocks
+let playables = [
+music.tonePlayable(262, music.beat(BeatFraction.Whole)),
+music.stringPlayable("D F E A E A C B ", 120),
+music.melodyPlayable(music.baDing),
+music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`)
+]
+for (let someMusic of playables) {
+    music.play(someMusic, music.PlaybackMode.UntilDone)
+    pause(500)
+}
+```
+
+## See also #seealso
+
+[tone playable](/reference/music/tone-playable),
+[string playable](/reference/music/string-playable),
+[melody playable](/reference/music/melody-playable),
+[create song](/reference/music/create-song)

--- a/libs/mixer/docs/reference/music/string-playable.md
+++ b/libs/mixer/docs/reference/music/string-playable.md
@@ -1,0 +1,41 @@
+# string Playable
+
+Created a short melody of notes composed in a string.
+
+```sig
+music.stringPlayable("D F E A E A C B ", 120)
+```
+
+The **melody** is short series of notes composed in a string. The melody is played at a rate set by the **tempo** value you give. The melody string contains a sequence of notes formatted like this:
+
+``"E B C5 A B G A F "``
+
+The melody is shown in the ``||music:melody||`` block as note symbols which also appear in the Melody Editor.
+
+```block
+music.stringPlayable("E F G F E G B C5 ", 120)
+```
+
+The melodies are most often created in the Melody Editor from the block so that valid notes are chosen and the correct melody length is set.
+
+## Parameters
+
+* **melody**: a [string](/types/string) which contains the notes of the melody.
+* **tempo**: a [number](/types/number) which is the rate to play the melody at in beats per minute.
+
+## Returns
+
+* a [playable](/types/playable) object that contains the **melody** and **tempo**.
+
+## Example #example
+
+Play the ``Mystery`` melody continuously.
+
+```blocks
+music.play(music.stringPlayable("E F G F E G B C5 ", 120), music.PlaybackMode.LoopingInBackground)
+```
+
+## See also #seealso
+
+[tone playable](/reference/music/tone-playable),
+[melody playable](/reference/music/melody-playable)

--- a/libs/mixer/docs/reference/music/tone-playable.md
+++ b/libs/mixer/docs/reference/music/tone-playable.md
@@ -1,0 +1,30 @@
+# tone Playable
+
+Create a musical tone that will play for some amount of time.
+
+```sig
+music.tonePlayable(262, music.beat(BeatFraction.Whole))
+```
+
+## Parameters
+
+* **note**: is the note frequency as a [number](/types/number) of [Hertz](https://wikipedia.org/wiki/Hertz) (how high or low the tone is, also known as _pitch_). If **note** is less or equal to zero, no sound is played.
+* **duration**: is the [number](/types/number) of milliseconds (one-thousandth of a second) that the tone lasts for. If **duration** is negative or zero, the sound will play continuously.
+
+## Returns
+
+* a [playable](/types/playable) object that contains the tone.
+
+## Example #example
+
+Store the musical note 'C' in the variable `note` and play that note for 1000 milliseconds (one second).
+
+```blocks
+let note = music.noteFrequency(Note.C);
+music.play(music.tonePlayable(note, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
+```
+
+## See also #seealso
+
+[melody playable](/reference/music/melody-playable),
+[string playable](/reference/music/string-playable)

--- a/libs/mixer/docs/types/playable.md
+++ b/libs/mixer/docs/types/playable.md
@@ -1,0 +1,76 @@
+# playable
+
+The **playable** data object provides a common format to play tones, melodies, and songs. Each of these music sources are created in different ways but are transformed into playable objects so that a single playback method is used to [play](/refernece/music/play) them.
+
+## Music sources for playable objects
+
+The blocks used to create playable music soucres are the following:
+
+### Tone
+
+A tone is a musical note, or a sound frequency, and a duration. The duration is often set as the length of a `beat`.
+
+```block
+music.tonePlayable(262, music.beat(BeatFraction.Whole))
+```
+
+### Melody
+
+Melodies are a series of notes and a tempo to play them at.
+
+```block
+music.stringPlayable("D F E A E A C B ", 120)
+```
+
+### Built-in sound
+
+A built-in sound is a simple melody already composed for you. There are several you can choose from.
+
+```block
+music.melodyPlayable(music.baDing)
+```
+
+### Song
+
+Songs are complex music sources which have many notes from different instruments. Songs are made in the Song Editor.
+
+```block
+music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`)
+```
+
+## Play the music
+
+In your programs, you can simply use the ``||music:play||`` blocks for each playable object. Like this one for tone:
+
+```block
+music.play(music.tonePlayable(262, music.beat(BeatFraction.Whole)), music.PlaybackMode.UntilDone)
+```
+
+Or, this one for song:
+
+```block
+music.play(music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`), music.PlaybackMode.UntilDone)
+```
+
+## Example #example
+
+Put 4 different playable music sources in an array. Play one after the other.
+
+```blocks
+let playables = [
+music.tonePlayable(262, music.beat(BeatFraction.Whole)),
+music.stringPlayable("D F E A E A C B ", 120),
+music.melodyPlayable(music.baDing),
+music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`)
+]
+for (let someMusic of playables) {
+    music.play(someMusic, music.PlaybackMode.UntilDone)
+    pause(500)
+}
+```
+
+## See also #seealso
+
+[play](/reference/music/play), [tone playable](/reference/music/tone-playable),
+[string playable](/reference/music/string-playable), [melody playable](/reference/music/melody-playable),
+[create song](/reference/music/create-song)

--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -598,6 +598,7 @@ namespace music {
     //% toolboxParentArgument=toPlay
     //% group="Songs"
     //% duplicateShadowOnDrag
+    //% help=music/create-song
     export function createSong(song: Buffer): Playable {
         return new sequencer.Song(song);
     }

--- a/libs/mixer/playable.ts
+++ b/libs/mixer/playable.ts
@@ -108,6 +108,7 @@ namespace music {
     //% block="play $toPlay $playbackMode"
     //% toPlay.shadow=music_melody_playable
     //% group="Sounds"
+    //% help="music/play"
     export function play(toPlay: Playable, playbackMode: PlaybackMode) {
         toPlay.play(playbackMode);
     }
@@ -119,6 +120,7 @@ namespace music {
     //% group="Sounds"
     //% duplicateShadowOnDrag
     //% blockHidden
+    //% help=music/melody-playable
     export function melodyPlayable(melody: Melody): Playable {
         return new MelodyPlayable(melody);
     }
@@ -135,6 +137,7 @@ namespace music {
     //% melody.shadow=melody_editor
     //% tempo.min=40 tempo.max=500
     //% tempo.defl=120
+    //% help=music/string-playable
     export function stringPlayable(melody: string, tempo: number): Playable {
         let notes: string[] = melody.split(" ").filter(n => !!n);
         let formattedMelody = "";
@@ -171,6 +174,7 @@ namespace music {
     //% note.shadow=device_note
     //% duration.shadow=device_beat
     //% parts="headphone"
+    //% help=music/tone-playable
     export function tonePlayable(note: number, duration: number): Playable {
         return new TonePlayable(note, duration);
     }


### PR DESCRIPTION
Add in some reference pages for the new "playable" blocks.

Do we need a page for the Song Editor like micro:bit has for its [Sound Editor](https://makecode.microbit.org/types/sound#sound-editing)?

Closes https://github.com/microsoft/pxt-arcade/issues/5599