### PR TITLE
Reference pages for new 'game over' blocks

### DIFF
--- a/libs/game/docs/reference/game.md
+++ b/libs/game/docs/reference/game.md
@@ -4,6 +4,10 @@ Game control and text display actions.
 
 ```cards
 game.over()
+game.setGameOverEffect(true, effects.confetti)
+game.setGameOverMessage(true, "GAME OVER!")
+game.setGameOverPlayable(true, music.melodyPlayable(music.powerUp), false)
+game.setGameOverScoringType(game.ScoringType.HighScore)
 game.onUpdate(function () {})
 game.onUpdateInterval(500, function () {})
 game.ask("")
@@ -20,6 +24,10 @@ game.showLongText("", DialogLayout.Bottom)
 ## See also #seealso
 
 [over](/reference/game/over),
+[set game over effect](/reference/game/set-game-over-effect),
+[set game over message](/reference/game/set-game-over-message),
+[set game over playable](/reference/game/set-game-over-playable),
+[set game over scoring type](/reference/game/set-game-over-scoring-type),
 [on update](/reference/game/on-update),
 [on update interval](/reference/game/on-update-interval),
 [ask](/reference/game/ask),

--- a/libs/game/docs/reference/game/set-game-over-effect.md
+++ b/libs/game/docs/reference/game/set-game-over-effect.md
@@ -1,0 +1,47 @@
+# set Game Over Effect
+
+Set an effect to display when the game is over.
+
+```sig
+game.setGameOverEffect(true, effects.confetti)
+```
+
+## Parameters
+
+* **win**: a [boolean](/types/boolean) value set to `true` to start the effect if the player wins the game. Set to `false` to start the effect if the player loses.
+* **effect**: the effect to display when the game is over, such as `confettti`, `hearts`, or `smiles`.
+
+## Example #example
+
+Make the game over when the kitten sprite touches the left of the screen. Show the splatter effect when the game is over.
+
+```blocks
+game.setGameOverEffect(true, effects.splatter)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . 
+    e e e . . . . e e e . . . . 
+    c d d c . . c d d c . . . . 
+    c b d d f f d d b c . . . . 
+    c 3 b d d b d b 3 c . . . . 
+    f b 3 d d d d 3 b f . . . . 
+    e d d d d d d d d e . . . . 
+    e d f d d d d f d e . b f b 
+    f d d f d d f d d f . f d f 
+    f b d d b b d d 2 b f f d f 
+    . f 2 2 2 2 2 2 d b b d b f 
+    . f d d d d d d d f f f f . 
+    . . f d b d f d f . . . . . 
+    . . . f f f f f f . . . . . 
+    `, SpriteKind.Player)
+mySprite.vx = -20
+game.onUpdateInterval(500, function () {
+    if (mySprite.left < 0) {
+        game.gameOver(true)
+    }
+})
+```
+
+## See also #seealso
+
+[set game over message](/reference/game/set-game-over-message),
+[set game over playable](/reference/game/set-game-over-playable)

--- a/libs/game/docs/reference/game/set-game-over-message.md
+++ b/libs/game/docs/reference/game/set-game-over-message.md
@@ -1,0 +1,47 @@
+# set Game Over Message
+
+Set a message to display when the game is over.
+
+```sig
+game.setGameOverMessage(true, "GAME OVER!")
+```
+
+## Parameters
+
+* **win**: a [boolean](/types/boolean) value set to `true` to start the **sound** if the player wins the game. Set to `false` to start the **sound** if the player loses.
+* **message**: a message [string](/types/string) to show when the game is over.
+
+## Example #example
+
+Make the game over when the kitten sprite touches the left of the screen. Show a message when the player wins the game.
+
+```blocks
+game.setGameOverMessage(true, "Yeah, you WIN!")
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . 
+    e e e . . . . e e e . . . . 
+    c d d c . . c d d c . . . . 
+    c b d d f f d d b c . . . . 
+    c 3 b d d b d b 3 c . . . . 
+    f b 3 d d d d 3 b f . . . . 
+    e d d d d d d d d e . . . . 
+    e d f d d d d f d e . b f b 
+    f d d f d d f d d f . f d f 
+    f b d d b b d d 2 b f f d f 
+    . f 2 2 2 2 2 2 d b b d b f 
+    . f d d d d d d d f f f f . 
+    . . f d b d f d f . . . . . 
+    . . . f f f f f f . . . . . 
+    `, SpriteKind.Player)
+mySprite.vx = -20
+game.onUpdateInterval(500, function () {
+    if (mySprite.left < 0) {
+        game.gameOver(true)
+    }
+})
+```
+
+## See also #seealso
+
+[set game over effect](/reference/game/set-game-over-effect),
+[set game over playabe](/reference/game/set-game-over-playable)

--- a/libs/game/docs/reference/game/set-game-over-playable.md
+++ b/libs/game/docs/reference/game/set-game-over-playable.md
@@ -1,0 +1,48 @@
+# set Game Over Playable
+
+Set a sound to play when the game is over.
+
+```sig
+game.setGameOverPlayable(true, music.melodyPlayable(music.powerUp), false)
+```
+
+## Parameters
+
+* **win**: a [boolean](/types/boolean) value set to `true` to start the **sound** if the player wins the game. Set to `false` to start the **sound** if the player loses.
+* **sound**: the sound to play when the game is over, such as `ba ding`, `siren`, or `buzzer`.
+* **looping**: loop the **sound** when set to `true`. Play the **sound** only once if `false`.
+
+## Example #example
+
+Make the game over when the kitten sprite touches the left of the screen. Play the `siren` sound when the player wins the game.
+
+```blocks
+game.setGameOverPlayable(true, music.melodyPlayable(music.siren), false)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . 
+    e e e . . . . e e e . . . . 
+    c d d c . . c d d c . . . . 
+    c b d d f f d d b c . . . . 
+    c 3 b d d b d b 3 c . . . . 
+    f b 3 d d d d 3 b f . . . . 
+    e d d d d d d d d e . . . . 
+    e d f d d d d f d e . b f b 
+    f d d f d d f d d f . f d f 
+    f b d d b b d d 2 b f f d f 
+    . f 2 2 2 2 2 2 d b b d b f 
+    . f d d d d d d d f f f f . 
+    . . f d b d f d f . . . . . 
+    . . . f f f f f f . . . . . 
+    `, SpriteKind.Player)
+mySprite.vx = -20
+game.onUpdateInterval(500, function () {
+    if (mySprite.left < 0) {
+        game.gameOver(true)
+    }
+})
+```
+
+## See also #seealso
+
+[set game over effect](/reference/game/set-game-over-effect),
+[set game over message](/reference/game/set-game-over-message)

--- a/libs/game/docs/reference/game/set-game-over-scoring-type.md
+++ b/libs/game/docs/reference/game/set-game-over-scoring-type.md
@@ -1,0 +1,78 @@
+# set Game Over Scoring Type
+
+Set the scoring type to decide the best game score for multiple games.
+
+```sig
+game.setGameOverScoringType(game.ScoringType.HighScore)
+```
+
+When mulitple games are played with your game program, you can set the method to record the best game score. You can use the highest score, lowest score, or no score as the best game score.
+
+## Parameters
+
+* **type**: the type of score used to record the best game score for multiple games:
+>* `highest`: use the highest score as the best game score.
+>* `lowest`: use the lowest score as the best game score.
+>* `none`: don't record any score as the best score.
+
+## Example #example
+
+Set the best score type to `lowest`. Move the player sprite up or down to avoid the projectiles. If your player is hit by projectiles, your score is increased. The lowest score is recorded for all of the games you play.
+
+```blocks
+info.onCountdownEnd(function () {
+    game.gameOver(true)
+})
+sprites.onOverlap(SpriteKind.Player, SpriteKind.Projectile, function (sprite, otherSprite) {
+    info.changeScoreBy(1)
+})
+let projectile: Sprite = null
+game.setGameOverScoringType(game.ScoringType.LowScore)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . b 5 b . . . 
+    . . . . . . . . . b 5 b . . . . 
+    . . . . . . . . . b c . . . . . 
+    . . . . . . b b b b b b . . . . 
+    . . . . . b b 5 5 5 5 5 b . . . 
+    . . . . b b 5 d 1 f 5 5 d f . . 
+    . . . . b 5 5 1 f f 5 d 4 c . . 
+    . . . . b 5 5 d f b d d 4 4 . . 
+    b d d d b b d 5 5 5 4 4 4 4 4 b 
+    b b d 5 5 5 b 5 5 4 4 4 4 4 b . 
+    b d c 5 5 5 5 d 5 5 5 5 5 b . . 
+    c d d c d 5 5 b 5 5 5 5 5 5 b . 
+    c b d d c c b 5 5 5 5 5 5 5 b . 
+    . c d d d d d d 5 5 5 5 5 d b . 
+    . . c b d d d d d 5 5 5 b b . . 
+    . . . c c c c c c c c b b . . . 
+    `, SpriteKind.Player)
+mySprite.left = 10
+controller.moveSprite(mySprite, 0, 100)
+info.startCountdown(10)
+game.onUpdateInterval(500, function () {
+    projectile = sprites.createProjectileFromSide(img`
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . 2 2 . . . . . . . 
+        . . . . . . 3 1 1 3 . . . . . . 
+        . . . . . 2 1 1 1 1 2 . . . . . 
+        . . . . . 2 1 1 1 1 2 . . . . . 
+        . . . . . . 3 1 1 3 . . . . . . 
+        . . . . . . . 2 2 . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        . . . . . . . . . . . . . . . . 
+        `, -60, randint(-30, 30))
+})
+```
+
+## See also #seealso
+
+[set game over effect](/reference/game/set-game-over-effect),
+[set game over playable](/reference/game/set-game-over-playable),
+[set game over message](/reference/game/set-game-over-message)


### PR DESCRIPTION
Add the reference pages for the new 'game over' blocks.

Closes https://github.com/microsoft/pxt-arcade/issues/5549