### PR TITLE
Add an extension page for 'feather'

### DIFF
--- a/libs/feather/docs/reference/feather.md
+++ b/libs/feather/docs/reference/feather.md
@@ -1,0 +1,11 @@
+# Feather
+
+Feather is a family of microcontroller and accessory boards from [Adafruit](https://www.adafruit.com/category/943). The **feather** extension enables pin mapping for MakeCode Arcade on the feather board.
+
+You can learn more about the Adafruit feather in general at:
+
+https://learn.adafruit.com/adafruit-feather
+
+The pinout diagram for Adafruit Feather M4 Express is here:
+
+https://learn.adafruit.com/assets/78438


### PR DESCRIPTION
Put in a page for the 'feather' extension as a link destination for the "Learn More" link.

The feather extension has no APIs. It just maps pin IDs.

Closes https://github.com/microsoft/pxt-arcade/issues/5582