### PR TITLE
Add an extension page for 'edge-connector'

### DIFF
--- a/libs/edge-connector/docs/reference/edge-connector.md
+++ b/libs/edge-connector/docs/reference/edge-connector.md
@@ -1,0 +1,5 @@
+# Edge Connector
+
+Some MakeCode Arcade compatible [hardware](/arcade-devices) devices have edge connectors which can add programmable pins which are accessible through the [pins](/reference/pins) namespace. The edge connector extension will map the pins of a 20-pin conncector for both analog and digital I/O.
+
+The [Meowbit](https://www.kittenbot.cc/collections/frontpage/products/meowbit-codable-console-for-microsoft-makecode-arcade) from KittenBot is an example of a MakeCode Arcade device with an edge connector.


### PR DESCRIPTION
Put in a page for the 'edge connector' extension as a link destination for the "Learn More" link.

This extension maps the pins P0-P20 of a micro:bit style edge connector. The extension adds no blocks to the `pins` namespace.

Closes https://github.com/microsoft/pxt-arcade/issues/5579