### PR TITLE
Sprite scaling extension main page

### DIFF
--- a/libs/sprite-scaling/docs/reference/sprite-scaling.md
+++ b/libs/sprite-scaling/docs/reference/sprite-scaling.md
@@ -1,0 +1,23 @@
+# Sprite Scaling
+
+Scale sprites to expand or shrink their size.
+
+## Scaling
+
+```cards
+scaling.scaleByPercent(null, 50, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+scaling.scaleByPixels(null, 1, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+scaling.scaleToPercent(null, 100, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+scaling.scaleToPixels(null, 1, ScaleDirection.Uniformly, ScaleAnchor.Middle)
+```
+
+## See also
+
+[scale by percent](/reference/sprites/scaling/scale-by-pixels),
+[scale by pixels](/reference/sprites/scaling/scale-by-percent),
+[scale to pixels](/reference/sprites/scaling/scale-to-pixels),
+[scale to percent](/reference/sprites/scaling/scale-to-percent)
+
+```package
+sprite-scaling
+```

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-pixels.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-by-pixels.md
@@ -137,7 +137,7 @@ info.setScore(mySprite.width)
 
 ## See also #seealso
 
-[scale by pixels](/reference/sprites/scaling/scale-by-pixels)
+[scale to pixels](/reference/sprites/scaling/scale-to-pixels)
 
 ```package
 sprite-scaling

--- a/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-pixels.md
+++ b/libs/sprite-scaling/docs/reference/sprites/scaling/scale-to-pixels.md
@@ -133,7 +133,7 @@ info.setScore(mySprite.width)
 
 ## See also #seealso
 
-[scale by pixels](/reference/sprites/scaling/scale-to-pixels)
+[scale by pixels](/reference/sprites/scaling/scale-by-pixels)
 
 ```package
 sprite-scaling

--- a/libs/sprite-scaling/scaling.ts
+++ b/libs/sprite-scaling/scaling.ts
@@ -1,5 +1,11 @@
 //% color="#95078E" weight=99 icon="\uf338"
 namespace scaling {
+    /**
+    * Scale a sprite to a percentage of its original size.
+    * @param sprite to scale to a percentage of its original size
+    * @param value that is the percentage to scale the sprite, eg: 150
+    * @param direction from the sprite anchor point, eg: ScaleDirection.Uniformly
+    */
     //% blockId=sprite_scale_to_percent_ex
     //% block="set $sprite=variables_get(mySprite) scale to $value percent $direction anchor $anchor"
     //% expandableArgumentMode=enabled
@@ -22,6 +28,12 @@ namespace scaling {
         sprite.setScaleCore(sx, sy, anchor);
     }
 
+    /**
+    * Scale a sprite by a percentage of its original size.
+    * @param sprite to scale to a percentage of its original size
+    * @param value that is the percentage to scale the sprite by, eg: 50
+    * @param direction from the sprite anchor point, eg: ScaleDirection.Uniformly
+    */
     //% blockId=sprite_scale_by_percent_ex
     //% block="change $sprite=variables_get(mySprite) scale by $value percent $direction anchor $anchor"
     //% expandableArgumentMode=enabled
@@ -44,6 +56,12 @@ namespace scaling {
         sprite.setScaleCore(sx, sy, anchor);
     }
 
+    /**
+    * Scale a sprite to a number of pixels.
+    * @param sprite to scale to new pixel size
+    * @param value that is the number of pixels to scale the sprite to, eg: 32
+    * @param direction from the sprite anchor point, eg: ScaleDirection.Horizontally
+    */
     //% blockId=sprite_scale_to_pixels_ex
     //% block="set $sprite=variables_get(mySprite) scale to $value pixels $direction anchor $anchor || proportional $proportional"
     //% expandableArgumentMode=enabled
@@ -77,6 +95,12 @@ namespace scaling {
         sprite.setScaleCore(sx, sy, anchor, proportional);
     }
 
+    /**
+    * Scale a sprite by a number of pixels.
+    * @param sprite to scale to new pixel size
+    * @param value that is the number of pixels to scale the sprite by, eg: 10
+    * @param direction from the sprite anchor point, eg: ScaleDirection.Horizontally
+    */
     //% blockId=sprite_scale_by_pixels_ex
     //% block="change $sprite=variables_get(mySprite) scale by $value pixels $direction anchor $anchor || proportional $proportional"
     //% expandableArgumentMode=enabled


### PR DESCRIPTION
Include a reference main page for 'Sprite Scaling' extension. This satisfies the destination for the "Learn More" link.

Also, add some jsDoc that is missing for the API functions.

Closes https://github.com/microsoft/pxt-arcade/issues/5575