### PR TITLE
Multiple score handlers per PlayerState

### DIFF
--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -33,7 +33,7 @@ namespace info {
         // null: reached 0 and callback was invoked
         public life: number;
         public lifeZeroHandler: () => void;
-        public scoreReachedHandler: ScoreReachedHandler[];
+        public scoreReachedHandlers: ScoreReachedHandler[];
 
         public showScore?: boolean;
         public showLife?: boolean;
@@ -45,7 +45,7 @@ namespace info {
             this.showScore = undefined;
             this.showLife = undefined;
             this.showPlayer = undefined;
-            this.scoreReachedHandler = [];
+            this.scoreReachedHandlers = [];
         }
     }
 
@@ -712,7 +712,7 @@ namespace info {
             const oldScore = state.score || 0;
             state.score = (value | 0);
 
-            state?.scoreReachedHandler.forEach(srh => {
+            state.scoreReachedHandlers.forEach(srh => {
                 if ((oldScore < srh.score && state.score >= srh.score) ||
                     (oldScore > srh.score && state.score <= srh.score)) {
                     srh.handler();
@@ -767,14 +767,16 @@ namespace info {
 
         onScore(score: number, handler: () => void) {
             const state = this.getState();
-            state.scoreReachedHandler?.forEach(element => {
+
+            for (const element of state.scoreReachedHandlers) {
                 if (element.score === score) {
                     // Score handlers are implemented as "last one wins."
                     element.handler = handler;
                     return;
                 }
-            });
-            state.scoreReachedHandler?.push(new ScoreReachedHandler(score, handler));
+            }
+
+            state.scoreReachedHandlers.push(new ScoreReachedHandler(score, handler));
         }
 
         raiseLifeZero(gameOver: boolean) {

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -712,15 +712,12 @@ namespace info {
             const oldScore = state.score || 0;
             state.score = (value | 0);
 
-            if (state.scoreReachedHandler) {
-                state.scoreReachedHandler.forEach(srh => {
-                    if ((oldScore < srh.score && state.score >= srh.score) ||
-                        (oldScore > srh.score && state.score <= srh.score)) {
-                        srh.handler();
-                    }
-                });
-            }
-
+            state?.scoreReachedHandler.forEach(srh => {
+                if ((oldScore < srh.score && state.score >= srh.score) ||
+                    (oldScore > srh.score && state.score <= srh.score)) {
+                    srh.handler();
+                }
+            });
         }
 
         changeScoreBy(value: number): void {
@@ -770,14 +767,14 @@ namespace info {
 
         onScore(score: number, handler: () => void) {
             const state = this.getState();
-            state.scoreReachedHandler.forEach(element => {
+            state.scoreReachedHandler?.forEach(element => {
                 if (element.score === score) {
                     // Score handlers are implemented as "last one wins."
                     element.handler = handler;
                     return;
                 }
             });
-            state.scoreReachedHandler.push(new ScoreReachedHandler(score, handler));
+            state.scoreReachedHandler?.push(new ScoreReachedHandler(score, handler));
         }
 
         raiseLifeZero(gameOver: boolean) {

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -246,6 +246,7 @@ namespace mp {
         onReachedScore(score: number, handler: (player: Player) => void) {
             const existing = this.getScoreHandler(score);
 
+            // Overwrite the existing handler for this score. Last one wins.
             if (existing) {
                 existing.handler = handler;
                 return;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5725.

## Context
Today, if you have multiple "on score" blocks, **the last one wins**. Here, on score 6 never runs because onScore 5 is the last one defined after converting to javascript.
![image](https://user-images.githubusercontent.com/4691428/221710330-e9a5bc0a-e52e-4c95-a4ad-58f96a082d3a.png)

[This is because `PlayerState` only contains a single `ScoreReachedHandler`.](https://github.com/microsoft/pxt-common-packages/blob/054b7c4576147e37c6f2ce823a495349e9ac62cc/libs/game/info.ts#L36)

## Changes Made
- `PlayerState` now has an array of `ScoreReachedHandler`s.
- If multiple handlers are added for the same score, last one wins (mimics multiplayer score handler behavior).

## ScoreManager?
There are two places now that handle this "last one wins" behavior. If for some reason we wanted to enable multiple handlers for the same score, we'd need to remember to change two places of code.

Ideally there would be one place in some `ScoreManager` class where you call `AddHandlerForScore` that determines this behavior. The `MPState ` and `PlayerState` would both have this `ScoreManager `and call its functions.

All in all, this is low pri and it's probably too soon to create a `ScoreManager`. I'll create an issue on it for now.

@riknoll suggested putting this into infostate instead of its own manager class because of how state is tracked with the scene stack.