### PR TITLE
Music playable pages linking

### DIFF
--- a/libs/mixer/docs/reference/music/create-song.md
+++ b/libs/mixer/docs/reference/music/create-song.md
@@ -6,7 +6,7 @@ Create a song from the notes of one or more musical instruments.
 music.createSong(hex`00780004080200`)
 ```
 
-A song is composed of notes from different instruments in the Song Editor. The Song Editor is displayed by clicking on the music staff window in the ``||music:song||`` block.
+A song is composed of notes from different instruments in the Song Editor. The [Song Editor](/reference/music/song-editor) is displayed by clicking on the music staff window in the ``||music:song||`` block.
 
 ```block
 music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`)
@@ -34,4 +34,5 @@ music.play(music.createSong(hex`0078000408020200001c00010a006400f401640000040000
 
 [tone playable](/reference/music/tone-playable),
 [string playable](/reference/music/string-playable),
-[melody playable](/reference/music/melody-playable)
+[melody playable](/reference/music/melody-playable),
+[song editor](/reference/music/song-editor)

--- a/libs/mixer/docs/reference/music/play.md
+++ b/libs/mixer/docs/reference/music/play.md
@@ -21,7 +21,7 @@ music.play(music.stringPlayable("D F E A E A C B ", 120), music.PlaybackMode.Unt
 music.play(music.melodyPlayable(music.magicWand), music.PlaybackMode.UntilDone)
 ```
 
-The most complex playabe object is a **song**. Songs are composed in the Song Editor using many notes from different instruments.
+The most complex playabe object is a **song**. Songs are composed in the [Song Editor](/reference/music/song-editor) using many notes from different instruments.
 
 ```block
 music.play(music.createSong(hex`0078000408020200001c00010a006400f40164000004000000000000000000000000000500000430000400080001220c001000012514001800011e1c00200001222400280001252c003000012934003800012c3c004000011e03001c0001dc00690000045e010004000000000000000000000564000104000330000400080001290c001000011e1400180001251c002000012924002800011b2c003000012234003800011e3c0040000129`), music.PlaybackMode.UntilDone)
@@ -128,4 +128,5 @@ sprites.onOverlap(SpriteKind.Player, SpriteKind.Enemy, function (sprite, otherSp
 [string playable](/reference/music/string-playable),
 [melody playable](/reference/music/melody-playable),
 [create song](/reference/music/create-song),
-[stop all sounds](/reference/music/stop-all-sounds)
+[stop all sounds](/reference/music/stop-all-sounds),
+[song editor](/reference/music/song-editor)

--- a/libs/mixer/docs/reference/music/song-editor.md
+++ b/libs/mixer/docs/reference/music/song-editor.md
@@ -1,0 +1,92 @@
+# Song Editor
+
+A song is contained inside the ``||music:song||`` block. The song is created and modified using the Song Editor which opens when you click on the song parameter window of the block.
+
+```block
+music.createSong(hex`00780004080200`)
+```
+
+More often though, you'll see the ``||music:song||`` block as part of the ``||music:play||`` block.
+
+```block
+music.play(music.createSong(hex`00780004080200`), music.PlaybackMode.UntilDone)
+```
+
+Clicking on the song parameter window opens the Song Editor. If the ``||music:song||`` block contains no song information, the Song Editor will display with an empty song.
+
+## JavaScript and Python
+
+When you edit your code in the JavaScript or Python workspaces, the musical notes symbol (♫) appears in the margin of the line containing the ``||music:song||`` equivalent function, [createSong()](/reference/music/create-song). Clicking on this symbol will open the Song Editor too.
+
+```
+   1   let mySprite = sprites.create(assets.image`myImage`, SpriteKind.Player)
+♫  2   music.play(music.createSong(hex`00780004080200`), music.PlaybackMode.InBackground)
+   3   mySprite.startEffect(effects.confetti)
+   4
+```
+
+## Music staff
+
+Notes of a song are placed on the music **staff** which is a set of horizontal lines arranged from low to high. The notes are placed at **grid** positions from left to right. The grid divides a **measure** to determine how may notes the measure contains. A grid of **1/8** has **8** note positons per measure. If a note position has no notes in it, that position is a rest (no sound). Placing notes higher or lower on the staff, of course, sets the pitch of the note.
+
+### Measures
+
+You can change the length of the song by adding or removing measures. The **Measures** control lets you choose how long your song will play for. In this example, measures is set to **4** to add 2 more measures to the song.
+
+### Bass clef
+
+You can put notes on the **Bass Clef** too. Just check the **Show base clef** option. The bass clef is displayed in the Song Editor to match the default treble clef.
+
+Notes are added to the bass clef in the same way as the treble clef.
+
+### Grid
+
+The number of note positions (divisions) in each measure is set by the **Grid** control. The grid setting will set the number of note divisions in the measures using a measure fraction. This example is using an grid setting of 1/16 so there are 16 notes shown in the measure.
+
+### Example
+
+This example contains a song with notes on both clefs having measures at 1/8 divisions.
+
+```blocks
+let mySprite = sprites.create(img`
+    ....................
+    ....................
+    ....................
+    ....2222...2222.....
+    ...222222.222222....
+    ..222222222222222...
+    ..222222222222222...
+    ..222222222222222...
+    ..222222222222222...
+    ..222222222222222...
+    ..222222222222222...
+    ...2222222222222....
+    ....22222222222.....
+    .....222222222......
+    ......2222222.......
+    .......22222........
+    ........222.........
+    .........2..........
+    .........2..........
+    ....................
+    `, SpriteKind.Player)
+music.play(music.createSong(hex`0078000408040200001c00010a006400f401640000040000000000000000000000000005000004a30000000400012a04000800012708000c0001200c001000012410001400012a14001800012018001c00011d1c002000012020002400012724002800012a28002c0001252c003000012030003400012434003800012738003c00012a3c004000012740004400012044004800012548004c00012a4c005000012050005400012454005800021e2758005c00012a5c00600001206000640001276400680001246c007000012004001c00100500640000041e000004000000000000000000000000000a040004600000000400010804000800011208000c00010c0c001000011210001400010814001800011218001c00010c1c002000011220002400010824002800011228002c00010c2c003000011230003400010834003800011238003c00010c3c0040000112`), music.PlaybackMode.InBackground)
+mySprite.startEffect(effects.confetti, 5000)
+```
+
+## Instruments
+
+You can play notes for several different **instruments**. You select an instrument from the instrument bar at the top of the editor window.
+
+The instruments are represented by various character symbols and make different sounds for the same notes. These are MakeCode intruments and don't exaclty have the same sound as typical instruments like a violin, cello, drums, or guitar.
+
+If you need to focus on placing notes for a particular instrument, you can use the **Only show selected instrument** option to temporarily remove the other instruments from the staff. This makes it easier to compose for a single instrument since only the notes for the currently selected instrument will show.
+
+## Playing the song
+
+While editing a song, you can play, stop, or loop play the music you currently have composed. Also, you can change the tempo (beats per minute) of the song with the **Tempo** setting.
+
+## See also
+
+[play](/reference/music/play),
+[create song](/reference/music/create-song)


### PR DESCRIPTION
Add a base doc for the [Song Editor](https://github.com/microsoft/pxt-arcade/pull/5789) page without the images. Also, include links to this page from the `create-song` and `play` pages.

RE: https://github.com/microsoft/pxt-arcade/pull/5789