### PR TITLE
Add `Color` Enum

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -17,6 +17,10 @@ namespace game {
         None
     }
 
+    /**
+     * The available colors for Arcade.
+     * NOTE: If the color pallette is changed, these values will change along with it.
+     */
     export enum Color {
         transparent = 0,
         white = 1,

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -17,11 +17,11 @@ namespace game {
         None
     }
 
+    // To stay synchronized with https://github.com/microsoft/pxt/blob/stable8.5/webapp/src/components/ImageEditor/sprite/Palette.tsx#L98.
     /**
      * The available colors for Arcade.
-     * To stay synchronized with https://github.com/microsoft/pxt/blob/stable8.5/webapp/src/components/ImageEditor/sprite/Palette.tsx#L98.
-     * NOTE: If the color pallette is changed, these values will change along with it.
-     */
+     * NOTE: If the color palette is changed, these values will change along with it.
+     **/
     export enum Color {
         Transparent = 0,
         White = 1,

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -19,6 +19,7 @@ namespace game {
 
     /**
      * The available colors for Arcade.
+     * To stay synchronized with https://github.com/microsoft/pxt/blob/stable8.5/webapp/src/components/ImageEditor/sprite/Palette.tsx#L98.
      * NOTE: If the color pallette is changed, these values will change along with it.
      */
     export enum Color {

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -22,22 +22,22 @@ namespace game {
      * NOTE: If the color pallette is changed, these values will change along with it.
      */
     export enum Color {
-        transparent = 0,
-        white = 1,
-        red = 2,
-        pink = 3,
-        orange = 4,
-        yellow = 5,
-        teal = 6,
-        green = 7,
-        blue = 8,
-        lightblue = 9,
-        purple = 0xa,
-        lightpurple = 0xb,
-        darkpurple = 0xc,
-        tan = 0xd,
-        brown = 0xe,
-        black = 0xf
+        Transparent = 0,
+        White = 1,
+        Red = 2,
+        Pink = 3,
+        Orange = 4,
+        Yellow = 5,
+        Teal = 6,
+        Green = 7,
+        Blue = 8,
+        LightBlue = 9,
+        Purple = 0xa,
+        LightPurple = 0xb,
+        DarkPurple = 0xc,
+        Tan = 0xd,
+        Brown = 0xe,
+        Black = 0xf
     }
 
     export class GameOverConfig {

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -17,6 +17,25 @@ namespace game {
         None
     }
 
+    export enum Color {
+        transparent = 0,
+        white = 1,
+        red = 2,
+        pink = 3,
+        orange = 4,
+        yellow = 5,
+        teal = 6,
+        green = 7,
+        blue = 8,
+        lightblue = 9,
+        purple = 0xa,
+        lightpurple = 0xb,
+        darkpurple = 0xc,
+        tan = 0xd,
+        brown = 0xe,
+        black = 0xf
+    }
+
     export class GameOverConfig {
         scoringType: ScoringType;
         winEffect: effects.BackgroundEffect;


### PR DESCRIPTION
### Problem
See this snippet from one of the MakeCode tutorials

```ts
function startGame() {
    // Set the background color to cyan
    scene.setBackgroundColor(9);
```

You could plug in numbers to see what happens, but that isn't a good experience. So I added a color enum to make our javascript "onboarding experience" smoother:

![image](https://user-images.githubusercontent.com/4691428/226024038-804ff4a5-c6a4-4845-a707-4f942c7439d0.png)

cc @riknoll the templates are going to be super helpful, so it'd be nice to update your template project to include the enum when this eventually gets merged.

### Testing
Tested by running arcade locally