### PR TITLE
Triangle fill / polygon fill from aqeeaqee

### DIFF
--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1164,8 +1164,17 @@ void fillTriangle(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, in
 }
 
 //%
-void _fillTriangle(Image_ img, int xy0, int xy1, int xy2, int c) {
-    fillTriangle(img, XX(xy0), YY(xy0), XX(xy1), YY(xy1), XX(xy2), YY(xy2), c);
+void _fillTriangle(Image_ img, pxt::RefCollection *args) {
+    fillTriangle(
+        img,
+        pxt::toInt(args->getAt(0)),
+        pxt::toInt(args->getAt(1)),
+        pxt::toInt(args->getAt(2)),
+        pxt::toInt(args->getAt(3)),
+        pxt::toInt(args->getAt(4)),
+        pxt::toInt(args->getAt(5)),
+        pxt::toInt(args->getAt(6))
+    );
 }
 
 } // namespace ImageMethods

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1159,7 +1159,7 @@ void _fillCircle(Image_ img, int cxy, int r, int c) {
     fillCircle(img, XX(cxy), YY(cxy), r, c);
 }
 
-typedef struct 
+typedef struct
 {
     int x, y;
     int x0, y0;
@@ -1169,13 +1169,13 @@ typedef struct
     int yi, xi;
     int D;
     int nextFuncIndex;
-}LineGenState; // For keeping track of the state when generating Y values for a line, even when moving to the next X.
+} LineGenState; // For keeping track of the state when generating Y values for a line, even when moving to the next X.
 
 typedef struct
 {
     int min;
     int max;
-}ValueRange;
+} ValueRange;
 
 void nextYRange_Low(int x, LineGenState *line, ValueRange *yRange) {
     while (line->x == x && line->x <= line->x1 && line->x < line->W) {
@@ -1281,16 +1281,17 @@ void fillTriangle(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, in
         swap(y0, y1);
     }
 
-    LineGenState lines[]={
+    LineGenState lines[] = {
         initYRangeGenerator(x0, y0, x2, y2),
         initYRangeGenerator(x0, y0, x1, y1),
-        initYRangeGenerator(x1, y1, x2, y2)};
-    
-    lines[0].W = lines[1].W = lines[2].W = width(img);
-    lines[0].H = lines[1].H= lines[2].H = height(img);
+        initYRangeGenerator(x1, y1, x2, y2)
+    };
 
-// We have 3 different sub-functions to generate Ys of edges, each particular edge maps to one of them. 
-// Use function pointers to avoid judging which function to call at every X.
+    lines[0].W = lines[1].W = lines[2].W = width(img);
+    lines[0].H = lines[1].H = lines[2].H = height(img);
+
+    // We have 3 different sub-functions to generate Ys of edges, each particular edge maps to one of them.
+    // Use function pointers to avoid judging which function to call at every X.
     typedef void (*FP_NEXT)(int x, LineGenState *line, ValueRange *yRange);
     FP_NEXT nextFuncList[] = { nextYRange_Low, nextYRange_HighUp, nextYRange_HighDown };
     FP_NEXT fpNext0 = nextFuncList[lines[0].nextFuncIndex];
@@ -1303,16 +1304,16 @@ void fillTriangle(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, in
         yRange.min = lines[0].H; yRange.max = -1;
         fpNext0(x, &lines[0], &yRange);
         fpNext1(x, &lines[1], &yRange);
-        fillRect(img, x,yRange.min, 1, yRange.max - yRange.min + 1, c);
+        fillRect(img, x, yRange.min, 1, yRange.max - yRange.min + 1, c);
     }
 
     fpNext2(lines[2].x0, &lines[2], &yRange);
 
-    for (int x = lines[2].x0+1; x <= lines[2].x1; x++) {
+    for (int x = lines[2].x0 + 1; x <= lines[2].x1; x++) {
         yRange.min = lines[0].H; yRange.max = -1;
         fpNext0(x, &lines[0], &yRange);
         fpNext2(x, &lines[2], &yRange);
-        fillRect(img, x, yRange.min, 1, yRange.max - yRange.min +1, c);
+        fillRect(img, x, yRange.min, 1, yRange.max - yRange.min + 1, c);
     }
 }
 
@@ -1322,12 +1323,12 @@ void fillPolygon4(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, in
         (x1 < x2) ? initYRangeGenerator(x1, y1, x2, y2) : initYRangeGenerator(x2, y2, x1, y1),
         (x2 < x3) ? initYRangeGenerator(x2, y2, x3, y3) : initYRangeGenerator(x3, y3, x2, y2),
         (x0 < x3) ? initYRangeGenerator(x0, y0, x3, y3) : initYRangeGenerator(x3, y3, x0, y0)};
-    
+
     lines[0].W = lines[1].W = lines[2].W = lines[3].W = width(img);
     lines[0].H = lines[1].H = lines[2].H = lines[3].H = height(img);
 
     int minX = min(min(x0, x1), min(x2, x3));
-    int maxX= min(max(max(x0, x1), max(x2, x3)), lines[0].W - 1);
+    int maxX = min(max(max(x0, x1), max(x2, x3)), lines[0].W - 1);
 
     typedef void (*FP_NEXT)(int x, LineGenState *line, ValueRange *yRange);
     FP_NEXT nextFuncList[] = { nextYRange_Low, nextYRange_HighUp, nextYRange_HighDown };
@@ -1344,7 +1345,7 @@ void fillPolygon4(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, in
         fpNext1(x, &lines[1], &yRange);
         fpNext2(x, &lines[2], &yRange);
         fpNext3(x, &lines[3], &yRange);
-        fillRect(img, x,yRange.min, 1, yRange.max - yRange.min+1, c);
+        fillRect(img, x,yRange.min, 1, yRange.max - yRange.min + 1, c);
     }
 }
 

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1242,7 +1242,7 @@ LineGenState initYRangeGenerator(int16_t X0, int16_t Y0, int16_t X1, int16_t Y1)
         line.dx <<= 1;
         line.dy <<= 1;
 
-        line.nextFuncIndex=0;
+        line.nextFuncIndex = 0;
         return line;
     } else {
         line.xi = 1;
@@ -1318,7 +1318,7 @@ void fillTriangle(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, in
 }
 
 void fillPolygon4(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, int x3, int y3, int c) {
-    LineGenState lines[]={
+    LineGenState lines[] = {
         (x0 < x1) ? initYRangeGenerator(x0, y0, x1, y1) : initYRangeGenerator(x1, y1, x0, y0),
         (x1 < x2) ? initYRangeGenerator(x1, y1, x2, y2) : initYRangeGenerator(x2, y2, x1, y1),
         (x2 < x3) ? initYRangeGenerator(x2, y2, x3, y3) : initYRangeGenerator(x3, y3, x2, y2),

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1159,6 +1159,15 @@ void _fillCircle(Image_ img, int cxy, int r, int c) {
     fillCircle(img, XX(cxy), YY(cxy), r, c);
 }
 
+void fillTriangle(Image_ img, int x0, int y0, int x1, int y1, int x2, int y2, int c) {
+    // Fill triangle here!
+}
+
+//%
+void _fillTriangle(Image_ img, int xy0, int xy1, int xy2, int c) {
+    fillTriangle(img, XX(xy0), YY(xy0), XX(xy1), YY(xy1), XX(xy2), YY(xy2), c);
+}
+
 } // namespace ImageMethods
 
 namespace image {

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -71,7 +71,7 @@ interface Image {
      * Fills a triangle
      */
     //% helper=imageFillTriangle
-    fillCircle(cx: number, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number): void;
+    fillTriangle(cx: number, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number): void;
 
     /**
      * Returns an image rotated by -90, 0, 90, 180, 270 deg clockwise

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -68,6 +68,12 @@ interface Image {
     fillCircle(cx: number, cy: number, r: number, c: color): void;
 
     /**
+     * Fills a triangle
+     */
+    //% helper=imageFillTriangle
+    fillCircle(cx: number, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number): void;
+
+    /**
      * Returns an image rotated by -90, 0, 90, 180, 270 deg clockwise
      */
     //% helper=imageRotated
@@ -127,6 +133,9 @@ namespace helpers {
 
     //% shim=ImageMethods::_blit
     declare function _blit(img: Image, src: Image, args: number[]): boolean;
+
+    //% shim=ImageMethods::_blit
+    declare function _fillTriangle(img: Image, xy0: number, xy1: number, xy2: number, c: color): void;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
@@ -209,6 +218,10 @@ namespace helpers {
 
     export function imageFillCircle(img: Image, cx: number, cy: number, r: number, col: number) {
         _fillCircle(img, pack(cx, cy), r, col);
+    }
+
+    export function imageFillTriangle(img: Image, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number) {
+        _fillTriangle(img, pack(x0, y0), pack(x1, y1), pack(x2, y2), col);
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -74,6 +74,12 @@ interface Image {
     fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number): void;
 
     /**
+     * Fills a 4-side-polygon
+     */
+    //% helper=imageFillPolygon4
+    fillPolygon4(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, col: number): void;
+
+    /**
      * Returns an image rotated by -90, 0, 90, 180, 270 deg clockwise
      */
     //% helper=imageRotated
@@ -136,6 +142,9 @@ namespace helpers {
 
     //% shim=ImageMethods::_fillTriangle
     declare function _fillTriangle(img: Image, args: number[]): void;
+
+    //% shim=ImageMethods::_fillPolygon4
+    declare function _fillPolygon4(img: Image, args: number[]): void;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
@@ -230,6 +239,20 @@ namespace helpers {
         _blitArgs[5] = y2;
         _blitArgs[6] = col;
         _fillTriangle(img, _blitArgs);
+    }
+
+    export function imageFillPolygon4(img: Image, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, col: number) {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = x0;
+        _blitArgs[1] = y0;
+        _blitArgs[2] = x1;
+        _blitArgs[3] = y1;
+        _blitArgs[4] = x2;
+        _blitArgs[5] = y2;
+        _blitArgs[6] = x3;
+        _blitArgs[7] = y3;
+        _blitArgs[8] = col;
+        _fillPolygon4(img, _blitArgs);
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -71,7 +71,7 @@ interface Image {
      * Fills a triangle
      */
     //% helper=imageFillTriangle
-    fillTriangle(cx: number, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number): void;
+    fillTriangle(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number): void;
 
     /**
      * Returns an image rotated by -90, 0, 90, 180, 270 deg clockwise

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -134,8 +134,8 @@ namespace helpers {
     //% shim=ImageMethods::_blit
     declare function _blit(img: Image, src: Image, args: number[]): boolean;
 
-    //% shim=ImageMethods::_blit
-    declare function _fillTriangle(img: Image, xy0: number, xy1: number, xy2: number, c: color): void;
+    //% shim=ImageMethods::_fillTriangle
+    declare function _fillTriangle(img: Image, args: number[]): void;
 
     function pack(x: number, y: number) {
         return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
@@ -221,7 +221,15 @@ namespace helpers {
     }
 
     export function imageFillTriangle(img: Image, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, col: number) {
-        _fillTriangle(img, pack(x0, y0), pack(x1, y1), pack(x2, y2), col);
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = x0;
+        _blitArgs[1] = y0;
+        _blitArgs[2] = x1;
+        _blitArgs[3] = y1;
+        _blitArgs[4] = x2;
+        _blitArgs[5] = y2;
+        _blitArgs[6] = col;
+        _fillTriangle(img, _blitArgs);
     }
 
     /**

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -612,8 +612,182 @@ namespace pxsim.ImageMethods {
         fillCircle(img, XX(cxy), YY(cxy), r, c);
     }
 
+    interface LineGenState {
+        x: number;
+        y: number;
+        x0: number;
+        y0: number;
+        x1: number;
+        y1: number;
+        W: number;
+        H: number;
+        dx: number;
+        dy: number;
+        yi: number;
+        xi: number;
+        D: number;
+        nextFuncIndex: number;
+    }
+    interface ValueRange {
+        min: number;
+        max: number;
+    }
+
+    function nextYRange_Low(x: number, line: LineGenState, yRange: ValueRange) {
+        while (line.x === x && line.x <= line.x1 && line.x < line.W) {
+            if (0 <= line.x) {
+                if (line.y < yRange.min) yRange.min = line.y;
+                if (line.y > yRange.max) yRange.max = line.y
+            }
+            if (line.D > 0) {
+                line.y += line.yi;
+                line.D -= line.dx;
+            }
+            line.D += line.dy;
+            ++line.x;
+        }
+    }
+
+    function nextYRange_HighUp(x: number, line: LineGenState, yRange: ValueRange) {
+        while (line.x == x && line.y >= line.y1 && line.x < line.W) {
+            if (0 <= line.x) {
+                if (line.y < yRange.min) yRange.min = line.y;
+                if (line.y > yRange.max) yRange.max = line.y;
+            }
+            if (line.D > 0) {
+                line.x += line.xi;
+                line.D += line.dy;
+            }
+            line.D += line.dx;
+            --line.y;
+        }
+    }
+
+    function nextYRange_HighDown(x: number, line: LineGenState, yRange: ValueRange) {
+        while (line.x == x && line.y <= line.y1 && line.x < line.W) {
+            if (0 <= line.x) {
+                if (line.y < yRange.min) yRange.min = line.y;
+                if (line.y > yRange.max) yRange.max = line.y;
+            }
+            if (line.D > 0) {
+                line.x += line.xi;
+                line.D -= line.dy;
+            }
+            line.D += line.dx;
+            ++line.y;
+        }
+    }
+
+    function initYRangeGenerator(X0: number, Y0: number, X1: number, Y1: number): LineGenState {
+        let line: LineGenState = {
+            x: 0,
+            y: 0,
+            x0: 0,
+            y0: 0,
+            x1: 0,
+            y1: 0,
+            W: 0,
+            H: 0,
+            dx: 0,
+            dy: 0,
+            yi: 0,
+            xi: 0,
+            D: 0,
+            nextFuncIndex: 0,
+        };
+
+        line.x0 = X0, line.y0 = Y0, line.x1 = X1, line.y1 = Y1;
+
+        line.dx = line.x1 - line.x0;
+        line.dy = line.y1 - line.y0;
+        line.y = line.y0;
+        line.x = line.x0;
+
+        if ((line.dy < 0 ? -line.dy : line.dy) < line.dx) {
+            line.yi = 1;
+            if (line.dy < 0) {
+                line.yi = -1;
+                line.dy = -line.dy;
+            }
+            line.D = 2 * line.dy - line.dx;
+            line.dx = line.dx << 1;
+            line.dy = line.dy << 1;
+
+            line.nextFuncIndex=0;
+            return line;
+        } else {
+            line.xi = 1;
+            if (line.dy < 0) {
+                line.D = 2 * line.dx + line.dy;
+                line.dx = line.dx << 1;
+                line.dy = line.dy << 1;
+
+                line.nextFuncIndex = 1;
+                return line;
+            } else {
+                line.D = 2 * line.dx - line.dy;
+                line.dx = line.dx << 1;
+                line.dy = line.dy << 1;
+
+                line.nextFuncIndex = 2;
+                return line;
+            }
+        }
+    }
+
     export function fillTriangle(img: RefImage, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, c: number) {
-        // Simulator implementation of fill triangle
+        if (x1 < x0) {
+            [x1, x0] = [x0, x1];
+            [y1, y0] = [y0, y1];
+        }
+        if (x2 < x1) {
+            [x2, x1] = [x1, x2];
+            [y2, y1] = [y1, y2];
+        }
+        if (x1 < x0) {
+            [x1, x0] = [x0, x1];
+            [y1, y0] = [y0, y1];
+        }
+
+        const lines: LineGenState[] = [
+            initYRangeGenerator(x0, y0, x2, y2),
+            initYRangeGenerator(x0, y0, x1, y1),
+            initYRangeGenerator(x1, y1, x2, y2)
+        ];
+
+        lines[0].W = lines[1].W = lines[2].W = width(img);
+        lines[0].H = lines[1].H = lines[2].H = height(img);
+
+        type FP_NEXT = (x: number, line: LineGenState, yRange: ValueRange) => void;
+        const nextFuncList: FP_NEXT[] = [
+            nextYRange_Low,
+            nextYRange_HighUp,
+            nextYRange_HighDown
+        ];
+        const fpNext0 = nextFuncList[lines[0].nextFuncIndex];
+        const fpNext1 = nextFuncList[lines[1].nextFuncIndex];
+        const fpNext2 = nextFuncList[lines[2].nextFuncIndex];
+
+        const yRange= {
+            min: lines[0].H,
+            max: -1
+        };
+
+        for (let x = lines[1].x0; x <= lines[1].x1; x++) {
+            yRange.min = lines[0].H; yRange.max = -1;
+            fpNext0(x, lines[0], yRange);
+            fpNext1(x, lines[1], yRange);
+            fillRect(img, x, yRange.min, 1, yRange.max - yRange.min + 1, c);
+        }
+
+        fpNext2(lines[2].x0, lines[2], yRange);
+
+        for (let x = lines[2].x0 + 1; x <= lines[2].x1; x++) {
+            yRange.min = lines[0].H; yRange.max = -1;
+            fpNext0(x, lines[0], yRange);
+            fpNext2(x, lines[2], yRange);
+            fillRect(img, x, yRange.min, 1, yRange.max - yRange.min + 1, c);
+        }
     }
 
     export function _fillTriangle(img: RefImage, args: RefCollection) {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -791,13 +791,13 @@ namespace pxsim.ImageMethods {
     export function _fillTriangle(img: RefImage, args: RefCollection) {
         fillTriangle(
             img,
-            args.getAt(0) as number,
-            args.getAt(1) as number,
-            args.getAt(2) as number,
-            args.getAt(3) as number,
-            args.getAt(4) as number,
-            args.getAt(5) as number,
-            args.getAt(6) as number,
+            args.getAt(0) | 0,
+            args.getAt(1) | 0,
+            args.getAt(2) | 0,
+            args.getAt(3) | 0,
+            args.getAt(4) | 0,
+            args.getAt(5) | 0,
+            args.getAt(6) | 0,
         );
     }
 
@@ -845,15 +845,15 @@ namespace pxsim.ImageMethods {
     export function _fillPolygon4(img: RefImage, args: RefCollection) {
         fillPolygon4(
             img,
-            args.getAt(0) as number,
-            args.getAt(1) as number,
-            args.getAt(2) as number,
-            args.getAt(3) as number,
-            args.getAt(4) as number,
-            args.getAt(5) as number,
-            args.getAt(6) as number,
-            args.getAt(7) as number,
-            args.getAt(8) as number,
+            args.getAt(0) | 0,
+            args.getAt(1) | 0,
+            args.getAt(2) | 0,
+            args.getAt(3) | 0,
+            args.getAt(4) | 0,
+            args.getAt(5) | 0,
+            args.getAt(6) | 0,
+            args.getAt(7) | 0,
+            args.getAt(8) | 0,
         );
     }
 

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -629,6 +629,25 @@ namespace pxsim.ImageMethods {
         );
     }
 
+    export function fillPolygon4(img: RefImage, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, x3: number, y3: number, c: number) {
+        // Simulator implementation of fill triangle
+    }
+
+    export function _fillPolygon4(img: RefImage, args: RefCollection) {
+        fillPolygon4(
+            img,
+            args.getAt(0) as number,
+            args.getAt(1) as number,
+            args.getAt(2) as number,
+            args.getAt(3) as number,
+            args.getAt(4) as number,
+            args.getAt(5) as number,
+            args.getAt(6) as number,
+            args.getAt(7) as number,
+            args.getAt(8) as number,
+        );
+    }
+
     export function _blitRow(img: RefImage, xy: number, from: RefImage, xh: number) {
         blitRow(img, XX(xy), YY(xy), from, XX(xh), YY(xh))
     }

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -612,6 +612,14 @@ namespace pxsim.ImageMethods {
         fillCircle(img, XX(cxy), YY(cxy), r, c);
     }
 
+    export function fillTriangle(img: RefImage, x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, c: number) {
+        // Simulator implementation of fill triangle
+    }
+
+    export function _fillTriangle(img: RefImage, xy0: number, xy1: number, xy2: number, c: number) {
+        fillTriangle(img, XX(xy0), YY(xy0), XX(xy1), YY(xy1), XX(xy2), YY(xy2), c);
+    }
+
     export function _blitRow(img: RefImage, xy: number, from: RefImage, xh: number) {
         blitRow(img, XX(xy), YY(xy), from, XX(xh), YY(xh))
     }

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -616,8 +616,17 @@ namespace pxsim.ImageMethods {
         // Simulator implementation of fill triangle
     }
 
-    export function _fillTriangle(img: RefImage, xy0: number, xy1: number, xy2: number, c: number) {
-        fillTriangle(img, XX(xy0), YY(xy0), XX(xy1), YY(xy1), XX(xy2), YY(xy2), c);
+    export function _fillTriangle(img: RefImage, args: RefCollection) {
+        fillTriangle(
+            img,
+            args.getAt(0) as number,
+            args.getAt(1) as number,
+            args.getAt(2) as number,
+            args.getAt(3) as number,
+            args.getAt(4) as number,
+            args.getAt(5) as number,
+            args.getAt(6) as number,
+        );
     }
 
     export function _blitRow(img: RefImage, xy: number, from: RefImage, xh: number) {

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -680,26 +680,21 @@ namespace pxsim.ImageMethods {
 
     function initYRangeGenerator(X0: number, Y0: number, X1: number, Y1: number): LineGenState {
         const line: LineGenState = {
-            x: 0,
-            y: 0,
+            x: X0,
+            y: Y0,
             x0: X0,
             y0: Y0,
             x1: X1,
             y1: Y1,
             W: 0,
             H: 0,
-            dx: 0,
-            dy: 0,
+            dx: X1 - X0,
+            dy: Y1 - Y0,
             yi: 0,
             xi: 0,
             D: 0,
             nextFuncIndex: 0,
         };
-
-        line.dx = line.x1 - line.x0;
-        line.dy = line.y1 - line.y0;
-        line.y = line.y0;
-        line.x = line.x0;
 
         if ((line.dy < 0 ? -line.dy : line.dy) < line.dx) {
             line.yi = 1;


### PR DESCRIPTION
I mirrored over the code from the cpp to the sim side in https://github.com/microsoft/pxt-common-packages/commit/9b878f8bf9ded9d9f372269be2e881270a6127b5 and https://github.com/microsoft/pxt-common-packages/commit/45d18049986d57511cb780147e77cf22049284bd + one more coercing out decimal places, left the cpp as is besides a few more nitpicks on spacing that I had missed before. CPP side already reviewed in https://github.com/microsoft/pxt-common-packages/pull/1439

here's richard's pretty test: 

![trianglz](https://user-images.githubusercontent.com/5615930/228708384-5e7e6979-c5ca-4c22-b773-50783a1bbdff.gif)

https://arcade.makecode.com/app/7695d0da8f8e68416984aa13f6e208cc78d11849-a60c32b437#pub:S49613-21549-53722-36190

(I haven't actually run the polygon4 one yet as I'm going to make dinner / didn't have a test case handy)

It's not letting me explicitly add you as a reviewer but I'd love it if you checked over / gave any feedback if you have any / gave it a thumbs up if you have time @aqeeaqee! Thanks again for the great pr, and I saw that you were working on a few more tweaks; feel free to the changes against this branch still (or we can approve / merge this in and you can make them against the master branch if preferred!)