### PR TITLE
Add second tagged template to song field editor

### DIFF
--- a/libs/mixer/melody.ts
+++ b/libs/mixer/melody.ts
@@ -595,7 +595,7 @@ namespace music {
     //% block="song $song"
     //% song.fieldEditor=musiceditor
     //% song.fieldOptions.decompileLiterals=true
-    //% song.fieldOptions.taggedTemplate="hex"
+    //% song.fieldOptions.taggedTemplate="hex;assets.song"
     //% song.fieldOptions.decompileIndirectFixedInstances="true"
     //% song.fieldOptions.decompileArgumentAsString="true"
     //% toolboxParent=music_playable_play


### PR DESCRIPTION
Requires https://github.com/microsoft/pxt-arcade/issues/5738

This is the authoring change to support multiple tagged templates. This should not be merged until the other one is