### PR TITLE
[pxt-common-packages] Fix deprecation of "out" option in tsconfigs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "libs/**/*"
   ],
   "dependencies": {
-    "pxt-core": "8.6.10"
+    "pxt-core": "8.6.32"
   },
   "devDependencies": {
     "typescript": "^4.2.3"

--- a/sim/tsconfig.json
+++ b/sim/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "es2017",
         "noImplicitAny": true,
         "noImplicitReturns": true,
-        "out": "../built/common-sim.js",
+        "outFile": "../built/common-sim.js",
         "lib": [
             "DOM",
             "DOM.Iterable",


### PR DESCRIPTION
See https://github.com/microsoft/pxt/pull/9492 for details.

Marking this as draft the above PR is merged.