### PR TITLE
Fix radio send string to allow 19 chars

### DIFF
--- a/libs/radio/radio.ts
+++ b/libs/radio/radio.ts
@@ -395,7 +395,7 @@ namespace radio {
     function getMaxStringLength(packetType: number) {
         switch (packetType) {
             case PACKET_TYPE_STRING:
-                return MAX_PAYLOAD_LENGTH - 2;
+                return MAX_PAYLOAD_LENGTH - 1;
             case PACKET_TYPE_VALUE:
             case PACKET_TYPE_DOUBLE_VALUE:
                 return MAX_FIELD_DOUBLE_NAME_LENGTH;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/4849

A while back, when rewriting radio from C++ code to Typescript (https://github.com/microsoft/pxt-microbit/pull/2000/files), we accidentally subtracted 2 instead of 1 from the max payload for sending strings. We only need to adjust by 1 so we have room to store the length. 

I tested this change on hardware as well and everything is working fine.