### PR TITLE
New microphone state to keep track of level, etc for simulator

### DIFF
--- a/libs/microphone/sim/state.ts
+++ b/libs/microphone/sim/state.ts
@@ -1,6 +1,27 @@
 namespace pxsim {
     export interface MicrophoneBoard {
-        microphoneState: AnalogSensorState;
+        microphoneState: MicrophoneState;
+    }
+
+    export class MicrophoneState extends AnalogSensorState {
+        public onSoundRegistered: boolean = false;
+        public soundLevelRequested: boolean = false;
+        private pingUsed: ReturnType<typeof setTimeout>;
+
+        public pingSoundLevel = () => {
+            if (this.onSoundRegistered) {
+                return;
+            }
+            this.soundLevelRequested = true;
+            runtime.queueDisplayUpdate();
+            clearTimeout(this.pingUsed);
+            this.pingUsed = setTimeout(() => {
+                this.soundLevelRequested = false;
+                runtime.queueDisplayUpdate();
+                this.pingUsed = undefined;
+            }, 100);
+        }
+
     }
 
     export function microphoneState() {


### PR DESCRIPTION
In order to avoid cluttering the AnalogSensor, @jwunderl helped me create a MicrophoneState for the mic in the simulator to update the functionality to better reflect the hardware.

