### PR TITLE
Add shader package

### DIFF
--- a/libs/microphone/sim/state.ts
+++ b/libs/microphone/sim/state.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../core/sim/analogSensor.ts" />
+
 namespace pxsim {
     export interface MicrophoneBoard {
         microphoneState: MicrophoneState;

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -61,8 +61,8 @@ namespace pxsim {
 }
 
 namespace pxsim.ImageMethods {
-    function XX(x: number) { return (x << 16) >> 16 }
-    function YY(x: number) { return x >> 16 }
+    export function XX(x: number) { return (x << 16) >> 16 }
+    export function YY(x: number) { return x >> 16 }
 
     export function width(img: RefImage) { return img._width }
 
@@ -931,6 +931,40 @@ namespace pxsim.ImageMethods {
             }
         }
         return false;
+    }
+
+    export function _mergeImage(dst: RefImage, src: RefImage, xy: number) {
+        mergeImage(dst, src, XX(xy), YY(xy));
+    }
+
+    function mergeImage(dst: RefImage, src: RefImage, x0: number, y0: number) {
+        for (let x = 0; x < src._width; x++) {
+            for (let y = 0; y < src._height; y++) {
+                setPixel(
+                    dst,
+                    x0 + x,
+                    y0 + y,
+                    Math.min(getPixel(dst, x0 + x, y0 + y), getPixel(src, x, y))
+                )
+            }
+        }
+    }
+
+    export function _mapImage(dst: RefImage, src: RefImage, xy: number, buf: RefBuffer) {
+        mapImage(dst, src, XX(xy), YY(xy), buf);
+    }
+
+    function mapImage(dst: RefImage, src: RefImage, x0: number, y0: number, buf: RefBuffer) {
+        for (let x = 0; x < src._width; x++) {
+            for (let y = 0; y < src._height; y++) {
+                setPixel(
+                    dst,
+                    x0 + x,
+                    y0 + y,
+                    buf.data[getPixel(dst, x0 + x, y0 + y) + (getPixel(src, x, y) << 4)]
+                )
+            }
+        }
     }
 }
 

--- a/libs/shader/pxt.json
+++ b/libs/shader/pxt.json
@@ -1,0 +1,14 @@
+{
+    "name": "shader",
+    "description": "Utility methods for shading images",
+    "files": [
+        "shader.cpp",
+        "shader.ts",
+        "shims.d.ts"
+    ],
+    "public": true,
+    "dependencies": {
+        "core": "file:../core",
+        "screen": "file:../screen"
+    }
+}

--- a/libs/shader/shader.cpp
+++ b/libs/shader/shader.cpp
@@ -1,0 +1,140 @@
+#include "pxt.h"
+
+#define XX(v) (int)(((int16_t)(v)))
+#define YY(v) (int)(((int16_t)(((int32_t)(v)) >> 16)))
+
+namespace ShaderMethods {
+
+void mapImage(Image_ toShade, Image_ shadeLevels, int x, int y, Buffer map) {
+    if (x >= toShade->width() || y >= toShade->height())
+        return;
+
+    if (toShade->bpp() != 4 || shadeLevels->bpp() != 4 || map->length < 16 || map->length % 16 != 0)
+        return;
+
+    int maxShadeLevel = map->length >> 4;
+
+    int x2 = x + shadeLevels->width() - 1;
+    int y2 = y + shadeLevels->height() - 1;
+
+    if (x2 < 0 || y2 < 0)
+        return;
+
+    int x0 = x;
+    int y0 = y;
+
+    toShade->clamp(&x2, &y2);
+    toShade->clamp(&x, &y);
+    int w = x2 - x + 1;
+    int h = y2 - y + 1;
+
+    toShade->makeWritable();
+
+    auto mapData = map->data;
+
+    auto toShadeByteHeight = toShade->byteHeight();
+    uint8_t *toShadeAddr = toShade->pix(x, y);
+
+    auto shadeLevelsByteHeight = shadeLevels->byteHeight();
+    uint8_t *shadeLevelsAddr = shadeLevels->pix(x - x0, y - y0);
+
+    while (w-- > 0) {
+        auto ptr1 = toShadeAddr;
+        auto ptr2 = shadeLevelsAddr;
+        unsigned shift1 = y & 1;
+        unsigned shift2 = (y - y0) & 1;
+        uint8_t shadeLevel = 0;
+        for (int i = 0; i < h; i++) {
+            if (shift2) {
+                shadeLevel = min(*ptr2 >> 4, maxShadeLevel);
+                ptr2++;
+                shift2 = 0;
+            } else {
+                shadeLevel = min(*ptr2 & 0x0f, maxShadeLevel);
+                shift2 = 1;
+            }
+
+            if (shift1) {
+                *ptr1 = (mapData[(*ptr1 >> 4) + (shadeLevel << 4)] << 4) | (*ptr1 & 0x0f);
+                ptr1++;
+                shift1 = 0;
+            } else {
+                *ptr1 = (mapData[(*ptr1 & 0xf) + (shadeLevel << 4)] & 0xf) | (*ptr1 & 0xf0);
+                shift1 = 1;
+            }
+        }
+        toShadeAddr += toShadeByteHeight;
+        shadeLevelsAddr += shadeLevelsByteHeight;
+    }
+}
+
+void mergeImage(Image_ dst, Image_ src, int x, int y) {
+    if (x >= dst->width() || y >= dst->height())
+        return;
+
+    if (dst->bpp() != 4 || src->bpp() != 4)
+        return;
+
+    int x2 = x + src->width() - 1;
+    int y2 = y + src->height() - 1;
+
+    if (x2 < 0 || y2 < 0)
+        return;
+
+    int x0 = x;
+    int y0 = y;
+
+    dst->clamp(&x2, &y2);
+    dst->clamp(&x, &y);
+    int w = x2 - x + 1;
+    int h = y2 - y + 1;
+
+    dst->makeWritable();
+
+    auto dstByteHeight = dst->byteHeight();
+    uint8_t *dstAddr = dst->pix(x, y);
+
+    auto srcByteHeight = src->byteHeight();
+    uint8_t *srcAddr = src->pix(x - x0, y - y0);
+
+    while (w-- > 0) {
+        auto ptr1 = dstAddr;
+        auto ptr2 = srcAddr;
+        unsigned shift1 = y & 1;
+        unsigned shift2 = (y - y0) & 1;
+        int srcValue = 0;
+        for (int i = 0; i < h; i++) {
+            if (shift2) {
+                srcValue = *ptr2 >> 4;
+                ptr2++;
+                shift2 = 0;
+            } else {
+                srcValue = *ptr2 & 0x0f;
+                shift2 = 1;
+            }
+
+            if (shift1) {
+                *ptr1 = (min(*ptr1 >> 4, srcValue) << 4) | (*ptr1 & 0x0f);
+                ptr1++;
+                shift1 = 0;
+            } else {
+                *ptr1 = (min(*ptr1 & 0xf, srcValue) & 0xf) | (*ptr1 & 0xf0);
+                shift1 = 1;
+            }
+        }
+        dstAddr += dstByteHeight;
+        srcAddr += srcByteHeight;
+    }
+}
+
+//%
+void _mapImage(Image_ toShade, Image_ shadeLevels, int xy, Buffer c) {
+    mapImage(toShade, shadeLevels, XX(xy), YY(xy), c);
+}
+
+//%
+void _mergeImage(Image_ toShade, Image_ shadeLevels, int xy) {
+    mergeImage(toShade, shadeLevels, XX(xy), YY(xy));
+}
+
+}

--- a/libs/shader/shader.ts
+++ b/libs/shader/shader.ts
@@ -1,0 +1,19 @@
+namespace helpers {
+    //% shim=ShaderMethods::_mapImage
+    function _mapImage(toShade: Image, shadeLevels: Image, xy: number, m: Buffer): void { }
+
+    export function mapImage(toShade: Image, shadeLevels: Image, x: number, y: number, m: Buffer) {
+        _mapImage(toShade, shadeLevels, pack(x, y), m);
+    }
+
+    //% shim=ShaderMethods::_mergeImage
+    function _mergeImage(dst: Image, src: Image, xy: number): void { }
+
+    export function mergeImage(dst: Image, src: Image, x: number, y: number) {
+        _mergeImage(dst, src, pack(x, y));
+    }
+
+    function pack(x: number, y: number) {
+        return (Math.clamp(-30000, 30000, x | 0) & 0xffff) | (Math.clamp(-30000, 30000, y | 0) << 16)
+    }
+}

--- a/libs/shader/sim/shader.ts
+++ b/libs/shader/sim/shader.ts
@@ -1,0 +1,37 @@
+/// <reference path="../../screen/sim/image.ts" />
+
+namespace pxsim.ShaderMethods {
+    export function _mergeImage(dst: RefImage, src: RefImage, xy: number) {
+        mergeImage(dst, src, pxsim.ImageMethods.XX(xy), pxsim.ImageMethods.YY(xy));
+    }
+
+    function mergeImage(dst: RefImage, src: RefImage, x0: number, y0: number) {
+        for (let x = 0; x < src._width; x++) {
+            for (let y = 0; y < src._height; y++) {
+                pxsim.ImageMethods.setPixel(
+                    dst,
+                    x0 + x,
+                    y0 + y,
+                    Math.min(pxsim.ImageMethods.getPixel(dst, x0 + x, y0 + y), pxsim.ImageMethods.getPixel(src, x, y))
+                )
+            }
+        }
+    }
+
+    export function _mapImage(dst: RefImage, src: RefImage, xy: number, buf: RefBuffer) {
+        mapImage(dst, src, pxsim.ImageMethods.XX(xy), pxsim.ImageMethods.YY(xy), buf);
+    }
+
+    function mapImage(dst: RefImage, src: RefImage, x0: number, y0: number, buf: RefBuffer) {
+        for (let x = 0; x < src._width; x++) {
+            for (let y = 0; y < src._height; y++) {
+                pxsim.ImageMethods.setPixel(
+                    dst,
+                    x0 + x,
+                    y0 + y,
+                    buf.data[pxsim.ImageMethods.getPixel(dst, x0 + x, y0 + y) + (pxsim.ImageMethods.getPixel(src, x, y) << 4)]
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a new package called shader that has some useful functions for shading:

1. mapImage - similar to mapRect except that it remaps colors according to an image. It takes in a buffer of color mappings and each color in the map image will point to a different section of the buffer, allowing you to shade the destination image by different amounts.
2. mergeImage - takes two images and finds the minimum pixel value at each coordinate. Useful for merging multiple light sources into one "lightSpace" that you can shade all at once