### PR TITLE
update checkout, setup-node actions

### DIFF
--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [8.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@main
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@main
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install

--- a/.github/workflows/pxt-buildmain.yml
+++ b/.github/workflows/pxt-buildmain.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/pxt-buildpr.yml
+++ b/.github/workflows/pxt-buildpr.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [8.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@main
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@main
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install

--- a/.github/workflows/pxt-buildpr.yml
+++ b/.github/workflows/pxt-buildpr.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [8.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@main
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@main
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install

--- a/.github/workflows/pxt-buildpush.yml
+++ b/.github/workflows/pxt-buildpush.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
see https://github.com/microsoft/pxt/pull/9550; we're getting a spurious diagnostic on every build 
![image](https://github.com/microsoft/pxt-common-packages/assets/5615930/77d130ec-5240-4655-944e-b31974c46819)
that appeared to be causing some build inconsistencies on occasion (in the build linked from that pr, it's my best guess as the random build error can come from wrong node version being used).

will do the same pr over in microbit, minecraft, arcade for now~