### PR TITLE
Fix draw icon in the simulator

### DIFF
--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -525,58 +525,59 @@ namespace pxsim.ImageMethods {
     }
 
     export function drawIcon(img: RefImage, icon: RefBuffer, x: number, y: number, color: number) {
-        const img2: Uint8Array = icon.data
+        const src: Uint8Array = icon.data
         if (!image.isValidImage(icon))
             return
-        if (img2[1] != 1)
+        if (src[1] != 1)
             return // only mono
-        let w = image.bufW(img2)
-        let h = image.bufH(img2)
-        let byteH = image.byteHeight(h, 1)
+        let width = image.bufW(src)
+        let height = image.bufH(src)
+        let byteH = image.byteHeight(height, 1)
 
         x |= 0
         y |= 0
-        const sh = img._height
-        const sw = img._width
+        const destHeight = img._height
+        const destWidth = img._width
 
-        if (x + w <= 0) return
-        if (x >= sw) return
-        if (y + h <= 0) return
-        if (y >= sh) return
+        if (x + width <= 0) return
+        if (x >= destWidth) return
+        if (y + height <= 0) return
+        if (y >= destHeight) return
 
         img.makeWritable()
 
-        let p = 8
+        let srcPointer = 8
         color = img.color(color)
         const screen = img.data
 
-        for (let i = 0; i < w; ++i) {
-            let xxx = x + i
-            if (0 <= xxx && xxx < sw) {
-                let dst = xxx + y * sw
-                let src = p
-                let yy = y
-                let end = Math.min(sh, h + y)
+        for (let i = 0; i < width; ++i) {
+            let destX = x + i
+            if (0 <= destX && destX < destWidth) {
+                let destIndex = destX + y * destWidth
+                let srcIndex = srcPointer
+                let destY = y
+                let destEnd = Math.min(destHeight, height + y)
                 if (y < 0) {
-                    src += ((-y) >> 3)
-                    yy += ((-y) >> 3) * 8
+                    srcIndex += ((-y) >> 3)
+                    destY += ((-y) >> 3) * 8
+                    destIndex += (destY - y) * destWidth
                 }
                 let mask = 0x01
-                let v = img2[src++]
-                while (yy < end) {
-                    if (yy >= 0 && (v & mask)) {
-                        screen[dst] = color
+                let srcByte = src[srcIndex++]
+                while (destY < destEnd) {
+                    if (destY >= 0 && (srcByte & mask)) {
+                        screen[destIndex] = color
                     }
                     mask <<= 1
                     if (mask == 0x100) {
                         mask = 0x01
-                        v = img2[src++]
+                        srcByte = src[srcIndex++]
                     }
-                    dst += sw
-                    yy++
+                    destIndex += destWidth
+                    destY++
                 }
             }
-            p += byteH
+            srcPointer += byteH
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5994

The issue is that when drawing started at a negative y position, we were adjusting the start index from the icon so that we were only reading the pixels that actually appear on screen. However, we weren't adjusting the destination index in the image we were drawing to which resulted in everything being shifted up a few pixels.

I also renamed all of the variables to make it easier to read. The only actual change is line 563