### PR TITLE
Add hitbox overlaps flag

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -694,6 +694,8 @@ class Sprite extends sprites.BaseSprite {
             return false
         if (other.flags & SPRITE_NO_SPRITE_OVERLAPS)
             return false
+        if (this.flags & sprites.Flag.HitboxOverlaps || other.flags & sprites.Flag.HitboxOverlaps)
+            return other._hitbox.overlapsWith(this._hitbox);
         if (!other._hitbox.overlapsWith(this._hitbox))
             return false;
         if (!this.isScaled() && !other.isScaled()) {

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -196,6 +196,7 @@ namespace sprites {
         GhostThroughTiles = 1 << 10, // No overlaps with tiles
         GhostThroughWalls = 1 << 11, // No collisions with walls
         GhostThroughSprites = 1 << 12, // No overlaps with other sprites
+        HitboxOverlaps = 1 << 13, // If set, overlaps with this sprite are based off of both sprites' hitboxes and not pixel perfect
         Ghost = sprites.Flag.GhostThroughSprites | sprites.Flag.GhostThroughWalls | sprites.Flag.GhostThroughTiles, // doesn't collide with other sprites or walls
     }
 }


### PR DESCRIPTION
This flag turns off pixel perfect overlaps for a sprite. Adding for use with things that extend the Sprite class but don't necessarily have an image associated with them (like TextSprites from my fancy text extension).

I suppose you could also use it to make your bullet hell game run faster.