### PR TITLE
Add icon blit helper function

### DIFF
--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1086,6 +1086,7 @@ bool blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
     int hSrc = pxt::toInt(args->getAt(7));
     bool transparent = pxt::toBoolQuick(args->getAt(8));
     bool check = pxt::toBoolQuick(args->getAt(9));
+    int color = pxt::toInt(args->getAt(10));
 
     int xSrcStep = (wSrc << 16) / wDst;
     int ySrcStep = (hSrc << 16) / hDst;
@@ -1118,7 +1119,12 @@ bool blit(Image_ dst, Image_ src, pxt::RefCollection *args) {
                 continue;
             }
             if (!transparent || cSrc) {
-                setCore(dst, xDstCur, yDstCur, cSrc);
+                if (color) {
+                    setCore(dst, xDstCur, yDstCur, color);
+                }
+                else {
+                    setCore(dst, xDstCur, yDstCur, cSrc);
+                }
             }
         }
     }

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -164,6 +164,23 @@ namespace helpers {
         _blitArgs[7] = hSrc | 0;
         _blitArgs[8] = transparent ? 1 : 0;
         _blitArgs[9] = check ? 1 : 0;
+        _blitArgs[10] = 0;
+        return _blit(img, src, _blitArgs);
+    }
+
+    export function iconBlit(img: Image, xDst: number, yDst: number, wDst: number, hDst: number, src: Image, xSrc: number, ySrc: number, wSrc: number, hSrc: number, transparent: boolean, check: boolean, color: number): boolean {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = xDst | 0;
+        _blitArgs[1] = yDst | 0;
+        _blitArgs[2] = wDst | 0;
+        _blitArgs[3] = hDst | 0;
+        _blitArgs[4] = xSrc | 0;
+        _blitArgs[5] = ySrc | 0;
+        _blitArgs[6] = wSrc | 0;
+        _blitArgs[7] = hSrc | 0;
+        _blitArgs[8] = transparent ? 1 : 0;
+        _blitArgs[9] = check ? 1 : 0;
+        _blitArgs[10] = color;
         return _blit(img, src, _blitArgs);
     }
 

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -895,6 +895,7 @@ namespace pxsim.ImageMethods {
         const hSrc = args.getAt(7) as number;
         const transparent = args.getAt(8) as number;
         const check = args.getAt(9) as number;
+        const color = args.getAt(10) as number;
 
         const xSrcStep = ((wSrc << 16) / wDst) | 0;
         const ySrcStep = ((hSrc << 16) / hDst) | 0;
@@ -927,7 +928,12 @@ namespace pxsim.ImageMethods {
                     continue;
                 }
                 if (!transparent || cSrc) {
-                    setPixel(dst, xDstCur, yDstCur, cSrc);
+                    if (color) {
+                        setPixel(dst, xDstCur, yDstCur, color);
+                    }
+                    else {
+                        setPixel(dst, xDstCur, yDstCur, cSrc);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds a helper method for using the blit function with icons.

Icons in arcade are 1 bit per pixel, so they don't contain any color information. Our other icon methods take a color argument to use for the non-transparent pixels; this simply adds a copy of blit that passes such an argument.

I need this for my fancy text extension (or, rather, for my mini-menu extension which I am converting to use the fancy-text extension).