### PR TITLE
Change image field editor to sprite editor

### DIFF
--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -83,10 +83,11 @@ namespace images {
      * An image
      * @param image the image
      */
-    //% blockId=image_picker block="%image" shim=TD_ID
-    //% image.fieldEditor="images"
-    //% image.fieldOptions.columns=6
-    //% image.fieldOptions.width=600
+    //% blockId=image_picker block="$image" shim=TD_ID
+    //% image.fieldEditor="sprite"
+    //% image.fieldOptions.taggedTemplate="img"
+    //% image.fieldOptions.decompileIndirectFixedInstances="true"
+    //% image.fieldOptions.decompileArgumentAsString="true"
     //% weight=0 group="Create"
     export function _image(image: Image): Image {
         return image;


### PR DESCRIPTION
This change is a partial fix for having qualified names for images result in a sprite editor instead of an image picker in blocks. 

When a qualified name is used, the resulting editor will have all image types in the gallery including tiles, dialogs, and backgrounds. This is different from the default editors for sprites, backgrounds, tiles, and dialogs which filter out images accordingly.