### PR TITLE
Fix simulator build

### DIFF
--- a/sim/tsconfig.json
+++ b/sim/tsconfig.json
@@ -12,7 +12,8 @@
         "rootDir": "../libs",
         "newLine": "LF",
         "declaration": true,
-        "sourceMap": false
+        "sourceMap": false,
+        "types": []
     },
     "include": [
         "../libs/*/sim/*.ts"

--- a/sim/tsconfig.json
+++ b/sim/tsconfig.json
@@ -12,8 +12,7 @@
         "rootDir": "../libs",
         "newLine": "LF",
         "declaration": true,
-        "sourceMap": false,
-        "typeRoots": ["../node_modules/@types"]
+        "sourceMap": false
     },
     "include": [
         "../libs/*/sim/*.ts"


### PR DESCRIPTION
Not sure why this broke all of a sudden; seems like the build started randomly including the node typings. I expect it's a change in a dependency.