### PR TITLE
fix camera stuttering on following on size sprite

### DIFF
--- a/libs/game/camera.ts
+++ b/libs/game/camera.ts
@@ -86,8 +86,8 @@ namespace scene {
             if (this.sprite) {
                 this._lastUpdatedSpriteX = this.sprite.x;
                 this._lastUpdatedSpriteY = this.sprite.y;
-                this.offsetX = this.sprite.x - (screen.width >> 1);
-                this.offsetY = this.sprite.y - (screen.height >> 1);
+                this.offsetX = this.sprite.left + (this.sprite.width >> 1) - (screen.width >> 1);
+                this.offsetY = this.sprite.top + (this.sprite.width >> 1) - (screen.height >> 1);
             }
 
             this.drawOffsetX = this.offsetX;


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6115 . Fx8 rounding issue

https://github.com/microsoft/pxt-common-packages/blob/fixCameraOddSize/libs/game/sprite.ts#L112 looks like the root cause (/ potentially better point to fix), putting this up for ref but may change after grabbing lunch to fix over there instead. Need to test more but feels like they could be related to a few of the other issues relating to odd sized sprites in general. e.g. inconsistency in overlaps with 1px wide sprites