### PR TITLE
Correct the help path for 'controller.dy'

### DIFF
--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -458,7 +458,7 @@ namespace controller {
      * Get the vertical movement, given the step and state of buttons
      * @param step the distance, eg: 100
      */
-    //% weight=49 help=keys/dy
+    //% weight=49 help=controller/dy
     //% blockId=keydy block="dy (up-down buttons)||scaled by %step"
     //% step.defl=100
     //% group="Single Player"

--- a/libs/game/controller.ts
+++ b/libs/game/controller.ts
@@ -303,7 +303,7 @@ namespace controller {
          * Get the vertical movement, given the step and state of buttons
          * @param step the distance, eg: 100
          */
-        //% weight=49 help=keys/dy
+        //% weight=49 help=controller/dy
         //% blockId=ctrldy block="%controller dy (up-down buttons)||scaled by %step"
         //% step.defl=100
         //% group="Multiplayer"


### PR DESCRIPTION
The help path for `controller.dy()` was incorrectly set to `help='keys/dy'`.

Fixes https://github.com/microsoft/pxt-arcade/issues/6287