### PR TITLE
Fix block help paths and missing ref pages

### DIFF
--- a/libs/game/docs/reference/animation/animation-frames.md
+++ b/libs/game/docs/reference/animation/animation-frames.md
@@ -1,0 +1,77 @@
+# animation Frames
+
+A sequence of image frames for an animation.
+
+```sig
+animation._animationFrames(null)
+```
+
+The frames of an animation are set as an array of images. The block for containing the frames provides access to the image editor to create new frames and edit the ones already in the animation.
+
+## Parameters
+
+* **frames**: an array of images that create the animation.
+
+## Example #example
+
+Create and run an animation of a person walking. Click on the animation frames block to edit the animation. Loop the animation and then
+stop it by pressing button **A**.
+
+```blocks
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    animation.stopAnimation(animation.AnimationTypes.All, mySprite)
+})
+let mySprite: Sprite = null
+scene.setBackgroundColor(1)
+mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Player)
+let walker = animation._animationFrames([img`
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `])
+animation.runImageAnimation(
+mySprite,
+walker,
+500,
+true
+)
+```
+
+## See Also #seealso
+
+[run image animation](/reference/animation/run-image-animation),
+[run movement animation](/reference/animation/run-movement-animation)
+
+```package
+animation
+```

--- a/libs/game/docs/reference/images/image.md
+++ b/libs/game/docs/reference/images/image.md
@@ -1,0 +1,65 @@
+# image
+
+The container and editor block for an image.
+
+```sig
+images._image(null)
+```
+
+Clicking on the image window in the block will open the image editor and a you can create a new image or edit the current one. The image is used to assign to a sprite or as a frame in an animation.
+
+## Parameters
+
+* **image**: The [image](/types/image) to contain in the block.
+
+## Example #example
+
+Create a new `food` sprite with an image of a donut. When the game score reaches `100`, upgrade food sprite to the `cake` image.
+
+```blocks
+info.onScore(100, function () {
+    mySprite.setImage(cake)
+})
+let cake: Image = null
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    . . . . . . b b b b a a . . . . 
+    . . . . b b d d d 3 3 3 a a . . 
+    . . . b d d d 3 3 3 3 3 3 a a . 
+    . . b d d 3 3 3 3 3 3 3 3 3 a . 
+    . b 3 d 3 3 3 3 3 b 3 3 3 3 a b 
+    . b 3 3 3 3 3 a a 3 3 3 3 3 a b 
+    b 3 3 3 3 3 a a 3 3 3 3 d a 4 b 
+    b 3 3 3 3 b a 3 3 3 3 3 d a 4 b 
+    b 3 3 3 3 3 3 3 3 3 3 d a 4 4 e 
+    a 3 3 3 3 3 3 3 3 3 d a 4 4 4 e 
+    a 3 3 3 3 3 3 3 d d a 4 4 4 e . 
+    a a 3 3 3 d d d a a 4 4 4 e e . 
+    . e a a a a a a 4 4 4 4 e e . . 
+    . . e e b b 4 4 4 4 b e e . . . 
+    . . . e e e e e e e e . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Food)
+cake = img`
+    . . . . . . . . . . b b b . . . 
+    . . . . . . . . b e e 3 3 b . . 
+    . . . . . . b b e 3 2 e 3 a . . 
+    . . . . b b 3 3 e 2 2 e 3 3 a . 
+    . . b b 3 3 3 3 3 e e 3 3 3 a . 
+    b b 3 3 3 3 3 3 3 3 3 3 3 3 3 a 
+    b 3 3 3 d d d d 3 3 3 3 3 d d a 
+    b b b b b b b 3 d d d d d d 3 a 
+    b d 5 5 5 5 d b b b a a a a a a 
+    b 3 d d 5 5 5 5 5 5 5 d d d d a 
+    b 3 3 3 3 3 3 d 5 5 5 d d d d a 
+    b 3 d 5 5 5 3 3 3 3 3 3 b b b a 
+    b b b 3 d 5 5 5 5 5 5 5 d d b a 
+    . . . b b b 3 d 5 5 5 5 d d 3 a 
+    . . . . . . b b b b 3 d d d b a 
+    . . . . . . . . . . b b b a a . 
+    `
+```
+
+## See also
+
+[create](/reference/images/create)

--- a/libs/game/docs/reference/images/image/equals.md
+++ b/libs/game/docs/reference/images/image/equals.md
@@ -1,0 +1,68 @@
+# equals
+
+Compare this image to another image to see if they are the same.
+
+```sig
+image.create(0, 0).equals(null)
+```
+
+Each pixel in the image is compared with another image. If all the pixels in both images are identical, then the images are considered "equal".
+
+## Parameters
+
+* **other**: the other image to compare this one to.
+
+## Returns
+
+* a [boolean](/types/boolean) value that is `true` if all of the pixels in the two images are identical, or a value of `false` otherwise.
+
+## Example #example
+
+Create sprite with using a `burger` image. Create just an image of the same burger using a variable. Compare that image with the image in the sprite to see if they are equal.
+
+```blocks
+let mySprite = sprites.create(img`
+    . . . . c c c b b b b b . . . . 
+    . . c c b 4 4 4 4 4 4 b b b . . 
+    . c c 4 4 4 4 4 5 4 4 4 4 b c . 
+    . e 4 4 4 4 4 4 4 4 4 5 4 4 e . 
+    e b 4 5 4 4 5 4 4 4 4 4 4 4 b c 
+    e b 4 4 4 4 4 4 4 4 4 4 5 4 4 e 
+    e b b 4 4 4 4 4 4 4 4 4 4 4 b e 
+    . e b 4 4 4 4 4 5 4 4 4 4 b e . 
+    8 7 e e b 4 4 4 4 4 4 b e e 6 8 
+    8 7 2 e e e e e e e e e e 2 7 8 
+    e 6 6 2 2 2 2 2 2 2 2 2 2 6 c e 
+    e c 6 7 6 6 7 7 7 6 6 7 6 c c e 
+    e b e 8 8 c c 8 8 c c c 8 e b e 
+    e e b e c c e e e e e c e b e e 
+    . e e b b 4 4 4 4 4 4 4 4 e e . 
+    . . . c c c c c e e e e e . . . 
+    `, SpriteKind.Food)
+let burger = img`
+    . . . . c c c b b b b b . . . . 
+    . . c c b 4 4 4 4 4 4 b b b . . 
+    . c c 4 4 4 4 4 5 4 4 4 4 b c . 
+    . e 4 4 4 4 4 4 4 4 4 5 4 4 e . 
+    e b 4 5 4 4 5 4 4 4 4 4 4 4 b c 
+    e b 4 4 4 4 4 4 4 4 4 4 5 4 4 e 
+    e b b 4 4 4 4 4 4 4 4 4 4 4 b e 
+    . e b 4 4 4 4 4 5 4 4 4 4 b e . 
+    8 7 e e b 4 4 4 4 4 4 b e e 6 8 
+    8 7 2 e e e e e e e e e e 2 7 8 
+    e 6 6 2 2 2 2 2 2 2 2 2 2 6 c e 
+    e c 6 7 6 6 7 7 7 6 6 7 6 c c e 
+    e b e 8 8 c c 8 8 c c c 8 e b e 
+    e e b e c c e e e e e c e b e e 
+    . e e b b 4 4 4 4 4 4 4 4 e e . 
+    . . . c c c c c e e e e e . . . 
+    `
+if (burger.equals(mySprite.image)) {
+    mySprite.sayText("I'm a burger!", 2000, false)
+}
+```
+
+## See Also #seealso
+
+[clone](/reference/images/image/clone),
+[get pixel](/reference/images/image/get-pixel)

--- a/libs/game/docs/reference/images/sprite-image.md
+++ b/libs/game/docs/reference/images/sprite-image.md
@@ -1,0 +1,43 @@
+# sprite Image
+
+The container and editor block for a sprite image.
+
+```sig
+images._spriteImage(null)
+```
+
+Clicking on the image window in the block will open the image editor and a you can create a new image or edit the current one. The image is used when a sprite is created or as a different image to assign to a sprite.
+
+## Parameters
+
+* **image**: The [image](/types/image) to use for a sprite.
+
+## Example #example
+
+Create a new sprite with an image of a donut.
+
+```blocks
+let mySprite = sprites.create(img`
+    . . . . . . b b b b a a . . . . 
+    . . . . b b d d d 3 3 3 a a . . 
+    . . . b d d d 3 3 3 3 3 3 a a . 
+    . . b d d 3 3 3 3 3 3 3 3 3 a . 
+    . b 3 d 3 3 3 3 3 b 3 3 3 3 a b 
+    . b 3 3 3 3 3 a a 3 3 3 3 3 a b 
+    b 3 3 3 3 3 a a 3 3 3 3 d a 4 b 
+    b 3 3 3 3 b a 3 3 3 3 3 d a 4 b 
+    b 3 3 3 3 3 3 3 3 3 3 d a 4 4 e 
+    a 3 3 3 3 3 3 3 3 3 d a 4 4 4 e 
+    a 3 3 3 3 3 3 3 d d a 4 4 4 e . 
+    a a 3 3 3 d d d a a 4 4 4 e e . 
+    . e a a a a a a 4 4 4 4 e e . . 
+    . . e e b b 4 4 4 4 b e e . . . 
+    . . . e e e e e e e e . . . . . 
+    . . . . . . . . . . . . . . . . 
+    `, SpriteKind.Food)
+```
+
+## See also
+
+[create](/reference/sprites/create),
+[set image](/reference/sprites/sprite/set-image)

--- a/libs/game/docs/reference/info/change-countdown-by.md
+++ b/libs/game/docs/reference/info/change-countdown-by.md
@@ -1,0 +1,26 @@
+# change Countdown By
+
+Change the current game countdown time up or down by this amount.
+
+```sig
+info.changeCountdownBy(0)
+```
+
+The current game countdown time amount is increased by adding the change value when it is greater than zero (positive). If the change number is less than zero (negative), the game countdown is reduced by the value of the change number.
+
+## Parameters
+
+* **value**: a [number](/types/number) seconds to change the game countdown by.
+
+## Example #example
+
+Reduce game countdown time by `3` seconds.
+
+```blocks
+info.changeCountdown(-3)
+```
+
+## See also #seealso
+
+[countdown](/reference/info/score),
+[on countdown end](/reference/info/on-countdown-end)

--- a/libs/game/docs/reference/info/change-score-by.md
+++ b/libs/game/docs/reference/info/change-score-by.md
@@ -10,7 +10,7 @@ The total score amount is increased by adding the change value when it is greate
 
 ## Parameters
 
-* **value**: a [number](/types/number) to set the current score to.
+* **value**: a [number](/types/number) whice is the amount to change the current score by.
 
 ## Example #example
 

--- a/libs/game/docs/reference/info/countdown.md
+++ b/libs/game/docs/reference/info/countdown.md
@@ -1,0 +1,52 @@
+# countdown
+
+Get the current game countdown time.
+
+```sig
+info.changeCountdownBy(0)
+```
+
+The current game countdown time amount is increased by adding the change value when it is greater than zero (positive). If the change number is less than zero (negative), the game countdown is reduced by the value of the change number.
+
+## Parameters
+
+* **value**: a [number](/types/number) to set the game countdown by.
+
+## Returns
+
+* a [number](/types/number) that is the amount of time remaining for the game countdown in seconds.
+
+## Example #example
+
+Give a sprite warning message when the game countdown time is less than `5` seconds.
+
+```blocks
+info.startCountdown(30)
+let mySprite = sprites.create(img`
+    . . . . . . . . . . . . . . . . 
+    . . 4 4 4 . . . . 4 4 4 . . . . 
+    . 4 5 5 5 e . . e 5 5 5 4 . . . 
+    4 5 5 5 5 5 e e 5 5 5 5 5 4 . . 
+    4 5 5 4 4 5 5 5 5 4 4 5 5 4 . . 
+    e 5 4 4 5 5 5 5 5 5 4 4 5 e . . 
+    . e e 5 5 5 5 5 5 5 5 e e . . . 
+    . . e 5 f 5 5 5 5 f 5 e . . . . 
+    . . f 5 5 5 4 4 5 5 5 f . f f . 
+    . . . 4 5 5 f f 5 5 6 f f 5 f . 
+    . . . f 6 6 6 6 6 6 4 f 5 5 f . 
+    . . . f 5 5 5 5 5 5 5 4 5 f . . 
+    . . . . f 5 4 5 f 5 f f f . . . 
+    . . . . . f f f f f f f . . . . 
+    `, SpriteKind.Player)
+game.onUpdateInterval(500, function () {
+    if (info.countdown() < 5) {
+        mySprite.sayText("Short on time!")
+    }
+})
+```
+
+## See also #seealso
+
+[start countdown](/reference/info/start-countdown),
+[change countdown by](/reference/info/change-countdown-by),
+[on countdown end](/reference/info/on-countdown-end)

--- a/libs/game/docs/reference/sprites/all-of-kind.md
+++ b/libs/game/docs/reference/sprites/all-of-kind.md
@@ -1,0 +1,71 @@
+# all Of Kind
+
+Get all the sprites of a certain kind.
+
+```sig
+sprites.allOfKind(SpriteKind.Player)
+```
+
+You can get an array of the current sprites of a particular kind. For example, you want to find out where of all of the `Enemy` sprites in your game are, you could get an array of them and check their location.
+
+## Parameters
+
+* **kind**: the kind of the sprites you want an array of, such as `Player` or `Enemy`.
+
+## Example #example
+
+Set a player in the center of the screen. Make a bunch of blobs appear at random positions. If there are any blobs too close to the player, have them destroyed when button `A` is pressed.
+
+```blocks
+namespace SpriteKind {
+    export const Blob = SpriteKind.create()
+}
+controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
+    for (let icky of sprites.allOfKind(SpriteKind.Blob)) {
+        x2 = (icky.x - mySprite.x) ** 2
+        y2 = (icky.y - mySprite.y) ** 2
+        if (Math.sqrt(x2 + y2) < mySprite.width * 2) {
+            sprites.destroy(icky, effects.disintegrate, 500)
+        }
+    }
+})
+let y2 = 0
+let x2 = 0
+let blob: Sprite = null
+let mySprite: Sprite = null
+mySprite = sprites.create(img`
+    . . . . . f f f f . . . . . 
+    . . . f f 5 5 5 5 f f . . . 
+    . . f 5 5 5 5 5 5 5 5 f . . 
+    . f 5 5 5 5 5 5 5 5 5 5 f . 
+    . f 5 5 5 d b b d 5 5 5 f . 
+    f 5 5 5 b 4 4 4 4 b 5 5 5 f 
+    f 5 5 c c 4 4 4 4 c c 5 5 f 
+    f b b f b f 4 4 f b f b b f 
+    f b b 4 1 f d d f 1 4 b b f 
+    . f b f d d d d d d f b f . 
+    . f e f e 4 4 4 4 e f e f . 
+    . e 4 f 6 9 9 9 9 6 f 4 e . 
+    . 4 d c 9 9 9 9 9 9 c d 4 . 
+    . 4 f b 3 b 3 b 3 b b f 4 . 
+    . . f f 3 b 3 b 3 3 f f . . 
+    . . . . f f b b f f . . . . 
+    `, SpriteKind.Player)
+for (let index = 0; index < 40; index++) {
+    blob = sprites.create(img`
+        . 2 2 2 . 2 2 . 
+        2 2 5 2 2 2 2 2 
+        2 f 2 2 5 2 2 . 
+        2 2 2 2 2 2 2 2 
+        2 2 2 2 2 2 2 2 
+        2 2 f 2 f 2 2 2 
+        . 2 2 2 2 2 2 . 
+        . 2 . 2 2 5 2 . 
+        `, SpriteKind.Blob)
+    blob.setPosition(randint(0, scene.screenWidth()), randint(0, scene.screenHeight()))
+}
+```
+
+## See also #seealso
+
+[destroy all sprites of kind](/reference/sprites/sprite/destroy-all-sprites-of-kind)

--- a/libs/game/docs/reference/sprites/on-overlap.md
+++ b/libs/game/docs/reference/sprites/on-overlap.md
@@ -76,7 +76,7 @@ sprites.onOverlap(SpriteKind.Mortal, SpriteKind.Ball, function (sprite, otherSpr
     sprite.x += -1
 })
 controller.A.onEvent(ControllerButtonEvent.Pressed, function () {
-    ghost.type = SpriteKind.Mortal
+    ghost.setKind(SpriteKind.Mortal)
 })
 sprites.onDestroyed(SpriteKind.Mortal, function (sprite) {
     game.over()

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -283,7 +283,7 @@ namespace game {
     //% group="Game Over"
     //% weight=80
     //% blockGap=8
-    //% help=game/set-game-over-sound
+    //% help=game/set-game-over-playable
     export function setGameOverPlayable(win: boolean, sound: music.Playable, looping: boolean) {
         init();
         const goc = game.gameOverConfig();

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -422,7 +422,7 @@ namespace info {
      */
     //% block="countdown"
     //% blockId=gamegetcountdown
-    //% weight=79
+    //% weight=79 help=info/countdown
     //% group="Countdown"
     export function countdown(): number {
         initHUD();
@@ -448,7 +448,7 @@ namespace info {
      */
     //% block="change countdown by $seconds (s)"
     //% blockId=gamechangecountdown
-    //% weight=77
+    //% weight=77 help=info/change-countdown-by
     //% group="Countdown"
     export function changeCountdownBy(seconds: number) {
         startCountdown((countdown() + seconds));

--- a/libs/game/spriteevents.ts
+++ b/libs/game/spriteevents.ts
@@ -46,7 +46,7 @@ namespace sprites {
     //% group="Overlaps"
     //% weight=100 draggableParameters="reporter"
     //% blockId=spritesoverlap block="on $sprite of kind $kind=spritekind overlaps $otherSprite of kind $otherKind=spritekind"
-    //% help=scene/on-overlap
+    //% help=sprites/on-overlap
     //% blockGap=8
     export function onOverlap(kind: number, otherKind: number, handler: (sprite: Sprite, otherSprite: Sprite) => void) {
         if (kind == undefined || otherKind == undefined || !handler) return;

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -78,7 +78,7 @@ namespace sprites {
      * @param kind the target kind
      */
     //% blockId=allOfKind block="array of sprites of kind %kind=spritekind"
-    //% weight=87
+    //% weight=87 help=sprites/all-of-kind
     export function allOfKind(kind: number): Sprite[] {
         const spritesByKind = game.currentScene().spritesByKind;
         if (!(kind >= 0) || !spritesByKind[kind]) return [];

--- a/libs/screen/fieldeditors.ts
+++ b/libs/screen/fieldeditors.ts
@@ -12,6 +12,7 @@ namespace images {
     //% img.fieldOptions.decompileArgumentAsString="true"
     //% img.fieldOptions.filter="!tile !dialog !background"
     //% weight=100 group="Create" duplicateShadowOnDrag
+    //% help=images/sprite-image
     export function _spriteImage(img: Image) {
         return img
     }
@@ -89,6 +90,7 @@ namespace images {
     //% image.fieldOptions.decompileIndirectFixedInstances="true"
     //% image.fieldOptions.decompileArgumentAsString="true"
     //% weight=0 group="Create"
+    //% help=images/image
     export function _image(image: Image): Image {
         return image;
     }

--- a/libs/screen/image.d.ts
+++ b/libs/screen/image.d.ts
@@ -103,6 +103,7 @@ interface Image {
     //% this.shadow=variables_get
     //% this.defl="picture"
     //% other.shadow=screen_image_picker
+    //% help=images/image/equals
     equals(other: Image): boolean;
 
     //% shim=ImageMethods::isStatic


### PR DESCRIPTION
Add some missing block reference pages and correct some bad help paths.

**Note**: There is no mechanism for setting help paths for class properties (e.g.: `mySprite.vx`), or ``blockcombine`` attributed methods. So, such properties, like `mySprite.vx`, are documented but not linked to the block help menu item. For example,
https://arcade.makecode.com/reference/sprites/sprite/vx. I've asked for a way to link these up but such a feature has yet to get in.

Closes https://github.com/microsoft/pxt-arcade/issues/6231