### PR TITLE
Add keyboard and mouse events extension

### DIFF
--- a/libs/browser-events/browserEvents.cpp
+++ b/libs/browser-events/browserEvents.cpp
@@ -1,0 +1,29 @@
+#include "pxt.h"
+
+namespace browserEvents {
+
+//%
+int mouseX() {
+    return -1;
+}
+
+//%
+int mouseY() {
+    return -1;
+}
+
+//%
+int wheelDx() {
+    return -1;
+}
+
+//%
+int wheelDy() {
+    return -1;
+}
+
+//%
+int wheelDz() {
+    return -1;
+}
+}

--- a/libs/browser-events/browserEvents.ts
+++ b/libs/browser-events/browserEvents.ts
@@ -1,0 +1,167 @@
+
+//% icon="\uf245"
+//% color="#9c1355"
+//% block="Browser Events"
+namespace browserEvents {
+    export enum Event {
+        PointerDown = 6857,
+        PointerUp = 6858,
+        PointerMove = 6859,
+        PointerLeave = 6860,
+        PointerEnter = 6861,
+        PointerCancel = 6862,
+        PointerOver = 6863,
+        PointerOut = 6864,
+        Wheel = 6865,
+        KeyDown = 6866,
+        KeyUp = 6867
+    }
+
+    export enum MouseButtonId {
+        Left = 1,
+        Right = 2,
+        Wheel = 3,
+        Back = 4,
+        Forward = 5
+    }
+
+    export enum MouseButtonEvent {
+        Pressed = Event.PointerDown,
+        Released = Event.PointerUp,
+    }
+
+    //% fixedInstances
+    export class MouseButton {
+        protected _pressed: boolean;
+        protected pressHandler: (x: number, y: number) => void;
+        protected pressListeners: ((x: number, y: number) => void)[];
+        protected releaseHandler: (x: number, y: number) => void;
+        protected releaseListeners: ((x: number, y: number) => void)[];
+
+        constructor(public id: number) {
+            control.internalOnEvent(Event.PointerDown, this.id, () => this.setPressed(false), 16);
+            control.internalOnEvent(Event.PointerUp, this.id, () => this.setPressed(true), 16);
+
+            this._pressed = false;
+            this.pressListeners = [];
+            this.releaseListeners = [];
+        }
+
+        setPressed(pressed: boolean) {
+            this._pressed = pressed;
+            if (pressed) {
+                if (this.pressHandler) {
+                    this.pressHandler(mouseX(), mouseY());
+                }
+                for (const handler of this.pressListeners) {
+                    handler(mouseX(), mouseY());
+                }
+            }
+            else {
+                if (this.releaseHandler) {
+                    this.releaseHandler(mouseX(), mouseY());
+                }
+                for (const handler of this.releaseListeners) {
+                    handler(mouseX(), mouseY());
+                }
+            }
+        }
+
+        //% blockId=browserEvents_mouseButton_onEvent
+        //% block="on $this mouse button $event $x $y"
+        //% draggableParameters="reporter"
+        //% group="Mouse"
+        //% weight=50
+        onEvent(event: MouseButtonEvent, handler: (x: number, y: number) => void) {
+            if (event === MouseButtonEvent.Pressed) {
+                this.pressHandler = handler;
+            }
+            else {
+                this.releaseHandler = handler;
+            }
+        }
+
+        //% blockId=browserEvents_mouseButton_isPressed
+        //% block="is $this mouse button is pressed"
+        //% group="Mouse"
+        //% weight=40
+        isPressed() {
+            return this._pressed;
+        }
+
+        //% blockId=browserEvents_mouseButton_pauseUntil
+        //% block="pause until $this mouse button is $event"
+        //% group="Mouse"
+        //% weight=30
+        pauseUntil(event: KeyEvent) {
+            control.waitForEvent(event, this.id)
+        }
+
+        addEventListener(event: KeyEvent, handler: (x: number, y: number) => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressListeners.push(handler);
+            }
+            else {
+                this.releaseListeners.push(handler);
+            }
+        }
+
+        removeEventListener(event: KeyEvent, handler: (x: number, y: number) => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressListeners = this.pressListeners.filter(p => p !== handler);
+            }
+            else {
+                this.releaseListeners = this.releaseListeners.filter(p => p !== handler);
+            }
+        }
+    }
+
+    //% blockId=browserEvents_onEvent
+    //% block="on browser event $event"
+    //% draggableParameters="reporter"
+    //% group="Mouse"
+    //% weight=10
+    export function onEvent(event: Event, handler: () => void) {
+        control.onEvent(event, 0, handler);
+    }
+
+    //% blockId=browserEvents_onMouseMove
+    //% block="on mouse move $x $y"
+    //% draggableParameters="reporter"
+    //% group="Mouse"
+    //% weight=100
+    export function onMouseMove(handler: (x: number, y: number) => void) {
+        control.onEvent(Event.PointerMove, 0, () => {
+            handler(mouseX(), mouseY());
+        });
+    }
+
+    //% blockId=browserEvents_onWheel
+    //% block="on mouse wheel $dx $dy $dz"
+    //% draggableParameters="reporter"
+    //% group="Mouse"
+    //% weight=20
+    export function onWheel(handler: (dx: number, dy: number, dz: number) => void) {
+        control.onEvent(Event.Wheel, 0, () => {
+            handler(wheelDx(), wheelDy(), wheelDz());
+        });
+    }
+
+    //% fixedInstance whenUsed block="left"
+    export const MouseLeft = new MouseButton(MouseButtonId.Left);
+
+    //% fixedInstance whenUsed block="right"
+    export const MouseRight = new MouseButton(MouseButtonId.Right);
+
+    //% fixedInstance whenUsed block="wheel"
+    export const MouseWheel = new MouseButton(MouseButtonId.Wheel);
+
+    //% fixedInstance whenUsed block="back"
+    export const MouseBack = new MouseButton(MouseButtonId.Back);
+
+    //% fixedInstance whenUsed block="forward"
+    export const MouseForward = new MouseButton(MouseButtonId.Forward);
+
+    //% fixedInstance whenUsed block="any"
+    export const MouseAny = new MouseButton(0);
+}

--- a/libs/browser-events/keyboard.ts
+++ b/libs/browser-events/keyboard.ts
@@ -1,0 +1,481 @@
+namespace browserEvents {
+    export enum Key {
+        Zero = 48,
+        One = 49,
+        Two = 50,
+        Three = 51,
+        Four = 52,
+        Five = 53,
+        Six = 54,
+        Seven = 55,
+        Eight = 56,
+        Nine = 57,
+        BackTick = 192,
+        Hyphen = 189,
+        Equals = 187,
+        Q = 81,
+        W = 87,
+        E = 69,
+        R = 82,
+        T = 84,
+        Y = 89,
+        U = 85,
+        I = 73,
+        O = 79,
+        P = 80,
+        OpenBracket = 219,
+        CloseBracket = 221,
+        BackSlash = 220,
+        A = 65,
+        S = 83,
+        D = 68,
+        F = 70,
+        G = 71,
+        H = 72,
+        Space = 32,
+        PageUp = 33,
+        J = 74,
+        K = 75,
+        L = 76,
+        SemiColon = 186,
+        Apostrophe = 222,
+        Z = 90,
+        X = 88,
+        C = 67,
+        V = 86,
+        B = 66,
+        N = 78,
+        M = 77,
+        Comma = 188,
+        Period = 190,
+        ForwardSlash = 191,
+        Shift = 16,
+        Enter = 13,
+        CapsLock = 20,
+        Tab = 9,
+        Control = 17,
+        Meta = 91,
+        Alt = 18,
+        ArrowUp = 38,
+        ArrowDown = 40,
+        ArrowLeft = 37,
+        ArrowRight = 39,
+        PageDown = 34,
+        End = 35,
+        Home = 36
+    }
+
+    export enum KeyEvent {
+        Pressed,
+        Released
+    }
+
+    export function keyToString(key: Key) {
+        switch (key) {
+            case Key.Q:
+                return "Q";
+            case Key.W:
+                return "W";
+            case Key.E:
+                return "E";
+            case Key.R:
+                return "R";
+            case Key.T:
+                return "T";
+            case Key.Y:
+                return "Y";
+            case Key.U:
+                return "U";
+            case Key.I:
+                return "I";
+            case Key.O:
+                return "O";
+            case Key.P:
+                return "P";
+            case Key.OpenBracket:
+                return "[";
+            case Key.CloseBracket:
+                return "]";
+            case Key.BackSlash:
+                return "\\";
+            case Key.A:
+                return "A";
+            case Key.S:
+                return "S";
+            case Key.D:
+                return "D";
+            case Key.F:
+                return "F";
+            case Key.G:
+                return "G";
+            case Key.H:
+                return "H";
+            case Key.Space:
+                return " ";
+            case Key.PageUp:
+                return "PageUp";
+            case Key.J:
+                return "J";
+            case Key.K:
+                return "K";
+            case Key.L:
+                return "L";
+            case Key.SemiColon:
+                return ";";
+            case Key.Apostrophe:
+                return "'";
+            case Key.Z:
+                return "Z";
+            case Key.X:
+                return "X";
+            case Key.C:
+                return "C";
+            case Key.V:
+                return "V";
+            case Key.B:
+                return "B";
+            case Key.N:
+                return "N";
+            case Key.M:
+                return "M";
+            case Key.Comma:
+                return ",";
+            case Key.Period:
+                return ".";
+            case Key.ForwardSlash:
+                return "/";
+            case Key.Shift:
+                return "Shift";
+            case Key.Enter:
+                return "Enter";
+            case Key.CapsLock:
+                return "CapsLock";
+            case Key.Tab:
+                return "Tab";
+            case Key.Control:
+                return "Control";
+            case Key.Meta:
+                return "Meta";
+            case Key.Alt:
+                return "Alt";
+            case Key.ArrowUp:
+                return "ArrowUp";
+            case Key.ArrowDown:
+                return "ArrowDown";
+            case Key.ArrowLeft:
+                return "ArrowLeft";
+            case Key.ArrowRight:
+                return "ArrowRight";
+            case Key.PageDown:
+                return "PageDown";
+            case Key.End:
+                return "End";
+            case Key.Home:
+                return "Home";
+            case Key.Zero:
+                return "0";
+            case Key.One:
+                return "1";
+            case Key.Two:
+                return "2";
+            case Key.Three:
+                return "3";
+            case Key.Four:
+                return "4";
+            case Key.Five:
+                return "5";
+            case Key.Six:
+                return "6";
+            case Key.Seven:
+                return "7";
+            case Key.Eight:
+                return "8";
+            case Key.Nine:
+                return "9";
+            case Key.BackTick:
+                return "`";
+            case Key.Hyphen:
+                return "-";
+            case Key.Equals:
+                return "=";
+        }
+    }
+
+
+    //% fixedInstances
+    export class KeyButton {
+        protected _pressed: boolean;
+        protected pressHandler: () => void;
+        protected pressListeners: (() => void)[];
+        protected releaseHandler: () => void;
+        protected releaseListeners: (() => void)[];
+
+        constructor(public id: number) {
+            control.onEvent(Event.KeyUp, this.id, () => this.setPressed(false), 16);
+            control.onEvent(Event.KeyDown, this.id, () => this.setPressed(true), 16);
+
+            this._pressed = false;
+            this.pressListeners = [];
+            this.releaseListeners = [];
+        }
+
+        setPressed(pressed: boolean) {
+            this._pressed = pressed;
+            if (pressed) {
+                if (this.pressHandler) {
+                    this.pressHandler();
+                }
+                for (const handler of this.pressListeners) {
+                    handler();
+                }
+            }
+            else {
+                if (this.releaseHandler) {
+                    this.releaseHandler();
+                }
+                for (const handler of this.releaseListeners) {
+                    handler();
+                }
+            }
+        }
+
+        //% blockId=browserEvents_key_onEvent
+        //% block="on $this key $event"
+        //% group="Keyboard"
+        //% weight=100
+        onEvent(event: KeyEvent, handler: () => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressHandler = handler;
+            }
+            else {
+                this.releaseHandler = handler;
+            }
+        }
+
+        //% blockId=browserEvents_key_isPressed
+        //% block="is $this key is pressed"
+        //% group="Keyboard"
+        //% weight=90
+        isPressed() {
+            return this._pressed;
+        }
+
+        //% blockId=browserEvents_key_pauseUntil
+        //% block="pause until $this key is $event"
+        //% group="Keyboard"
+        //% weight=80
+        pauseUntil(event: KeyEvent) {
+            control.waitForEvent(event, this.id)
+        }
+
+        addEventListener(event: KeyEvent, handler: () => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressListeners.push(handler);
+            }
+            else {
+                this.releaseListeners.push(handler);
+            }
+        }
+
+        removeEventListener(event: KeyEvent, handler: () => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressListeners = this.pressListeners.filter(p => p !== handler);
+            }
+            else {
+                this.releaseListeners = this.releaseListeners.filter(p => p !== handler);
+            }
+        }
+    }
+
+    //% fixedInstance whenUsed
+    export const A = new KeyButton(Key.A);
+
+    //% fixedInstance whenUsed
+    export const B = new KeyButton(Key.B);
+
+    //% fixedInstance whenUsed
+    export const C = new KeyButton(Key.C);
+
+    //% fixedInstance whenUsed
+    export const D = new KeyButton(Key.D);
+
+    //% fixedInstance whenUsed
+    export const E = new KeyButton(Key.E);
+
+    //% fixedInstance whenUsed
+    export const F = new KeyButton(Key.F);
+
+    //% fixedInstance whenUsed
+    export const G = new KeyButton(Key.G);
+
+    //% fixedInstance whenUsed
+    export const H = new KeyButton(Key.H);
+
+    //% fixedInstance whenUsed
+    export const I = new KeyButton(Key.I);
+
+    //% fixedInstance whenUsed
+    export const J = new KeyButton(Key.J);
+
+    //% fixedInstance whenUsed
+    export const K = new KeyButton(Key.K);
+
+    //% fixedInstance whenUsed
+    export const L = new KeyButton(Key.L);
+
+    //% fixedInstance whenUsed
+    export const M = new KeyButton(Key.M);
+
+    //% fixedInstance whenUsed
+    export const N = new KeyButton(Key.N);
+
+    //% fixedInstance whenUsed
+    export const O = new KeyButton(Key.O);
+
+    //% fixedInstance whenUsed
+    export const P = new KeyButton(Key.P);
+
+    //% fixedInstance whenUsed
+    export const Q = new KeyButton(Key.Q);
+
+    //% fixedInstance whenUsed
+    export const R = new KeyButton(Key.R);
+
+    //% fixedInstance whenUsed
+    export const S = new KeyButton(Key.S);
+
+    //% fixedInstance whenUsed
+    export const T = new KeyButton(Key.T);
+
+    //% fixedInstance whenUsed
+    export const U = new KeyButton(Key.U);
+
+    //% fixedInstance whenUsed
+    export const V = new KeyButton(Key.V);
+
+    //% fixedInstance whenUsed
+    export const W = new KeyButton(Key.W);
+
+    //% fixedInstance whenUsed
+    export const X = new KeyButton(Key.X);
+
+    //% fixedInstance whenUsed
+    export const Y = new KeyButton(Key.Y);
+
+    //% fixedInstance whenUsed
+    export const Z = new KeyButton(Key.Z);
+
+    //% fixedInstance whenUsed
+    export const Zero = new KeyButton(Key.Zero);
+
+    //% fixedInstance whenUsed
+    export const One = new KeyButton(Key.One);
+
+    //% fixedInstance whenUsed
+    export const Two = new KeyButton(Key.Two);
+
+    //% fixedInstance whenUsed
+    export const Three = new KeyButton(Key.Three);
+
+    //% fixedInstance whenUsed
+    export const Four = new KeyButton(Key.Four);
+
+    //% fixedInstance whenUsed
+    export const Five = new KeyButton(Key.Five);
+
+    //% fixedInstance whenUsed
+    export const Six = new KeyButton(Key.Six);
+
+    //% fixedInstance whenUsed
+    export const Seven = new KeyButton(Key.Seven);
+
+    //% fixedInstance whenUsed
+    export const Eight = new KeyButton(Key.Eight);
+
+    //% fixedInstance whenUsed
+    export const Nine = new KeyButton(Key.Nine);
+
+    //% fixedInstance whenUsed
+    export const Shift = new KeyButton(Key.Shift);
+
+    //% fixedInstance whenUsed
+    export const Enter = new KeyButton(Key.Enter);
+
+    //% fixedInstance whenUsed
+    export const CapsLock = new KeyButton(Key.CapsLock);
+
+    //% fixedInstance whenUsed
+    export const Tab = new KeyButton(Key.Tab);
+
+    //% fixedInstance whenUsed
+    export const Control = new KeyButton(Key.Control);
+
+    //% fixedInstance whenUsed
+    export const Meta = new KeyButton(Key.Meta);
+
+    //% fixedInstance whenUsed
+    export const Alt = new KeyButton(Key.Alt);
+
+    //% fixedInstance whenUsed
+    export const ArrowUp = new KeyButton(Key.ArrowUp);
+
+    //% fixedInstance whenUsed
+    export const ArrowDown = new KeyButton(Key.ArrowDown);
+
+    //% fixedInstance whenUsed
+    export const ArrowLeft = new KeyButton(Key.ArrowLeft);
+
+    //% fixedInstance whenUsed
+    export const ArrowRight = new KeyButton(Key.ArrowRight);
+
+    //% fixedInstance whenUsed
+    export const BackTick = new KeyButton(Key.BackTick);
+
+    //% fixedInstance whenUsed
+    export const Hyphen = new KeyButton(Key.Hyphen);
+
+    //% fixedInstance whenUsed
+    export const Equals = new KeyButton(Key.Equals);
+
+    //% fixedInstance whenUsed
+    export const OpenBracket = new KeyButton(Key.OpenBracket);
+
+    //% fixedInstance whenUsed
+    export const CloseBracket = new KeyButton(Key.CloseBracket);
+
+    //% fixedInstance whenUsed
+    export const BackSlash = new KeyButton(Key.BackSlash);
+
+    //% fixedInstance whenUsed
+    export const Space = new KeyButton(Key.Space);
+
+    //% fixedInstance whenUsed
+    export const PageUp = new KeyButton(Key.PageUp);
+
+    //% fixedInstance whenUsed
+    export const SemiColon = new KeyButton(Key.SemiColon);
+
+    //% fixedInstance whenUsed
+    export const Apostrophe = new KeyButton(Key.Apostrophe);
+
+    //% fixedInstance whenUsed
+    export const Comma = new KeyButton(Key.Comma);
+
+    //% fixedInstance whenUsed
+    export const Period = new KeyButton(Key.Period);
+
+    //% fixedInstance whenUsed
+    export const ForwardSlash = new KeyButton(Key.ForwardSlash);
+
+    //% fixedInstance whenUsed
+    export const PageDown = new KeyButton(Key.PageDown);
+
+    //% fixedInstance whenUsed
+    export const End = new KeyButton(Key.End);
+
+    //% fixedInstance whenUsed
+    export const Home = new KeyButton(Key.Home);
+
+    //% fixedInstance whenUsed
+    export const Any = new KeyButton(0);
+}

--- a/libs/browser-events/pxt.json
+++ b/libs/browser-events/pxt.json
@@ -1,0 +1,14 @@
+{
+    "name": "browser-events",
+    "description": "A package for interacting with browser-only functionality like keyboard and mouse events",
+    "files": [
+        "browserEvents.cpp",
+        "browserEvents.ts",
+        "keyboard.ts",
+        "shims.d.ts"
+    ],
+    "public": true,
+    "dependencies": {
+        "core": "file:../core"
+    }
+}

--- a/libs/browser-events/shims.d.ts
+++ b/libs/browser-events/shims.d.ts
@@ -1,0 +1,13 @@
+declare namespace browserEvents {
+    //% shim=browserEvents::mouseX
+    function mouseX(): number;
+    //% shim=browserEvents::mouseY
+    function mouseY(): number;
+    //% shim=browserEvents::wheelDx
+    function wheelDx(): number;
+    //% shim=browserEvents::wheelDy
+    function wheelDy(): number;
+    //% shim=browserEvents::wheelDz
+    function wheelDz(): number;
+
+}

--- a/libs/browser-events/sim/browserEvent.ts
+++ b/libs/browser-events/sim/browserEvent.ts
@@ -1,0 +1,21 @@
+namespace pxsim.browserEvents {
+    export function mouseX() {
+        return (pxsim.board() as BrowserEventsBoard).mouseState.mouseX();
+    }
+
+    export function mouseY() {
+        return (pxsim.board() as BrowserEventsBoard).mouseState.mouseY();
+    }
+
+    export function wheelDx() {
+        return (pxsim.board() as BrowserEventsBoard).mouseState.wheelDx();
+    }
+
+    export function wheelDy() {
+        return (pxsim.board() as BrowserEventsBoard).mouseState.wheelDy();
+    }
+
+    export function wheelDz() {
+        return (pxsim.board() as BrowserEventsBoard).mouseState.wheelDz();
+    }
+}

--- a/libs/browser-events/sim/keyboard.ts
+++ b/libs/browser-events/sim/keyboard.ts
@@ -1,0 +1,256 @@
+namespace pxsim.browserEvents {
+    export enum Key {
+        Zero = 48,
+        One = 49,
+        Two = 50,
+        Three = 51,
+        Four = 52,
+        Five = 53,
+        Six = 54,
+        Seven = 55,
+        Eight = 56,
+        Nine = 57,
+        BackTick = 192,
+        Hyphen = 189,
+        Equals = 187,
+        Q = 81,
+        W = 87,
+        E = 69,
+        R = 82,
+        T = 84,
+        Y = 89,
+        U = 85,
+        I = 73,
+        O = 79,
+        P = 80,
+        OpenBracket = 219,
+        CloseBracket = 221,
+        BackSlash = 220,
+        A = 65,
+        S = 83,
+        D = 68,
+        F = 70,
+        G = 71,
+        H = 72,
+        Space = 32,
+        PageUp = 33,
+        J = 74,
+        K = 75,
+        L = 76,
+        SemiColon = 186,
+        Apostrophe = 222,
+        Z = 90,
+        X = 88,
+        C = 67,
+        V = 86,
+        B = 66,
+        N = 78,
+        M = 77,
+        Comma = 188,
+        Period = 190,
+        ForwardSlash = 191,
+        Shift = 16,
+        Enter = 13,
+        CapsLock = 20,
+        Tab = 9,
+        Control = 17,
+        Meta = 91,
+        Alt = 18,
+        ArrowUp = 38,
+        ArrowDown = 40,
+        ArrowLeft = 37,
+        ArrowRight = 39,
+        PageDown = 34,
+        End = 35,
+        Home = 36
+    }
+
+    export function onKeyboardEvent(event: KeyboardEvent, pressed: boolean) {
+        if (pressed) {
+            board().bus.queue(6866, getValueForKey(event));
+        }
+        else {
+            board().bus.queue(6867, getValueForKey(event));
+        }
+    }
+
+    export function getValueForKey(event: KeyboardEvent) {
+        switch (event.key) {
+            case "0":
+            case ")":
+                return Key.Zero;
+            case "1":
+            case "!":
+                return Key.One;
+            case "2":
+            case "@":
+                return Key.Two;
+            case "3":
+            case "#":
+                return Key.Three;
+            case "4":
+            case "$":
+                return Key.Four;
+            case "5":
+            case "%":
+                return Key.Five;
+            case "6":
+            case "^":
+                return Key.Six;
+            case "7":
+            case "&":
+                return Key.Seven;
+            case "8":
+            case "*":
+                return Key.Eight;
+            case "9":
+            case "(":
+                return Key.Nine;
+            case "`":
+            case "~":
+                return Key.BackTick;
+            case "-":
+            case "_":
+                return Key.Hyphen;
+            case "=":
+            case "+":
+                return Key.Equals;
+            case "Q":
+            case "q":
+                return Key.Q;
+            case "W":
+            case "w":
+                return Key.W;
+            case "E":
+            case "e":
+                return Key.E;
+            case "R":
+            case "r":
+                return Key.R;
+            case "T":
+            case "t":
+                return Key.T;
+            case "Y":
+            case "y":
+                return Key.Y;
+            case "U":
+            case "u":
+                return Key.U;
+            case "I":
+            case "i":
+                return Key.I;
+            case "O":
+            case "o":
+                return Key.O;
+            case "P":
+            case "p":
+                return Key.P;
+            case "[":
+            case "{":
+                return Key.OpenBracket;
+            case "]":
+            case "}":
+                return Key.CloseBracket;
+            case "\\":
+            case "|":
+                return Key.BackSlash;
+            case "A":
+            case "a":
+                return Key.A;
+            case "S":
+            case "s":
+                return Key.S;
+            case "D":
+            case "d":
+                return Key.D;
+            case "F":
+            case "f":
+                return Key.F;
+            case "G":
+            case "g":
+                return Key.G;
+            case "H":
+            case "h":
+                return Key.H;
+            case " ":
+                return Key.Space;
+            case "PageUp":
+                return Key.PageUp;
+            case "J":
+            case "j":
+                return Key.J;
+            case "K":
+            case "k":
+                return Key.K;
+            case "L":
+            case "l":
+                return Key.L;
+            case ";":
+            case ":":
+                return Key.SemiColon;
+            case "'":
+            case "\"":
+                return Key.Apostrophe;
+            case "Z":
+            case "z":
+                return Key.Z;
+            case "X":
+            case "x":
+                return Key.X;
+            case "C":
+            case "c":
+                return Key.C;
+            case "V":
+            case "v":
+                return Key.V;
+            case "B":
+            case "b":
+                return Key.B;
+            case "N":
+            case "n":
+                return Key.N;
+            case "M":
+            case "m":
+                return Key.M;
+            case ",":
+            case "<":
+                return Key.Comma;
+            case ".":
+            case ">":
+                return Key.Period;
+            case "/":
+            case "?":
+                return Key.ForwardSlash;
+            case "Shift":
+                return Key.Shift;
+            case "Enter":
+                return Key.Enter;
+            case "CapsLock":
+                return Key.CapsLock;
+            case "Tab":
+                return Key.Tab;
+            case "Control":
+                return Key.Control;
+            case "Meta":
+                return Key.Meta;
+            case "Alt":
+                return Key.Alt;
+            case "ArrowUp":
+                return Key.ArrowUp;
+            case "ArrowDown":
+                return Key.ArrowDown;
+            case "ArrowLeft":
+                return Key.ArrowLeft;
+            case "ArrowRight":
+                return Key.ArrowRight;
+            case "PageDown":
+                return Key.PageDown;
+            case "End":
+                return Key.End;
+            case "Home":
+                return Key.Home;
+            default:
+                return 0;
+        }
+    }
+}

--- a/libs/browser-events/sim/mouseState.ts
+++ b/libs/browser-events/sim/mouseState.ts
@@ -1,0 +1,81 @@
+namespace pxsim.browserEvents {
+    export interface BrowserEventsBoard extends CommonBoard {
+        mouseState: MouseState;
+    }
+
+    const THROTTLE_INTERVAL = 50;
+
+    export type MouseEvent = "pointerdown" | "pointerup" | "pointermove" | "pointerleave" | "pointerenter" | "pointercancel" | "pointerover" | "pointerout";
+    export class MouseState {
+        protected x: number;
+        protected y: number;
+
+        protected dx: number;
+        protected dy: number;
+        protected dz: number;
+
+        protected onMove = pxsim.U.throttle(() => {
+            board().bus.queue(
+                6859,
+                0
+            );
+        }, THROTTLE_INTERVAL, true);
+
+        protected onWheel = pxsim.U.throttle(() => {
+            board().bus.queue(
+                6865,
+                0
+            );
+        }, THROTTLE_INTERVAL, true);
+
+        onEvent(event: PointerEvent, x: number, y: number) {
+            this.x = x;
+            this.y = y;
+
+            const events = [
+                "pointerdown",
+                "pointerup",
+                "pointermove",
+                "pointerleave",
+                "pointerenter",
+                "pointercancel",
+                "pointerover",
+                "pointerout",
+            ];
+
+            // We add 1 to the button here because the left button is 0 and
+            // that's used as a wildcard in our event bus
+            board().bus.queue(
+                6857 + events.indexOf(event.type),
+                (event.button || 0) + 1
+            );
+        }
+
+        onWheelEvent(dx: number, dy: number, dz: number) {
+            this.dx = dx;
+            this.dy = dy;
+            this.dz = dz;
+            this.onWheel();
+        }
+
+        mouseX() {
+            return this.x || 0;
+        }
+
+        mouseY() {
+            return this.y || 0;
+        }
+
+        wheelDx() {
+            return this.dx || 0;
+        }
+
+        wheelDy() {
+            return this.dy || 0;
+        }
+
+        wheelDz() {
+            return this.dz || 0;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a browser-only extension that enables support for keyboard and mouse events.

There are two more PRs for this, one in pxt-arcade and one in pxt-arcade-sim.

The API for keyboard keys treats each key as an individual controller button. There is no "get last character typed" block because this API is not meant for typing text, just letting the player have extra button options (typing in our sim would be super cumbersome anyhow given that we have keys that map to special functions like taking a screenshot).

Also, as an added safety feature all keyboard and mouse events are disabled in mutliplayer (the code doing the disabling is in pxt-arcade-sim).

![image](https://github.com/microsoft/pxt-common-packages/assets/13754588/830bca55-f70a-4042-b007-66aeddc74173)

![image](https://github.com/microsoft/pxt-common-packages/assets/13754588/803322ae-bea3-456e-bf86-6da8cd687d8d)
