### PR TITLE
Add support for tilemaps with 4x4 tiles

### DIFF
--- a/libs/game/assetTemplates.ts
+++ b/libs/game/assetTemplates.ts
@@ -15,6 +15,10 @@ function tilemap16(lits: any, ...args: any[]): tiles.TileMapData { return null }
 //% pyConvertToTaggedTemplate
 function tilemap32(lits: any, ...args: any[]): tiles.TileMapData { return null }
 
+//% helper=getTilemapByName
+//% pyConvertToTaggedTemplate
+function tilemap4(lits: any, ...args: any[]): tiles.TileMapData { return null }
+
 namespace assets {
     //% helper=getTilemapByName
     //% pyConvertToTaggedTemplate

--- a/libs/game/tilemap.ts
+++ b/libs/game/tilemap.ts
@@ -1,4 +1,6 @@
 enum TileScale {
+    //% block="4x4"
+    Four = 2,
     //% block="8x8"
     Eight = 3,
     //% block="16x16"


### PR DESCRIPTION
The pxt-common-packages part of https://github.com/microsoft/pxt/pull/9853

This adds no new blocks, but opens up the ability for me to add a block in an extension (like tile util)