### PR TITLE
Game over block: made saveAllScores take the scoring method

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -372,6 +372,15 @@ namespace game {
         _gameOverImpl(true, player);
     }
 
+    function _mapScoreTypeToString(scoreType: ScoringType): string {
+        switch (scoreType) {
+            case ScoringType.HighScore: return "highscore";
+            case ScoringType.LowScore: return "lowscore";
+            case ScoringType.None: return "none";
+            default: return "none";
+        }
+    }
+
     function _gameOverImpl(win: boolean, winnerOverride?: number) {
         init();
         if (__isOver) return;
@@ -389,7 +398,8 @@ namespace game {
             const scores = playersWithScores.map(player => new GameOverPlayerScore(player.number, player.impl.score(), player === winner));
 
             // Save all scores. Dependency Note: this action triggers Kiosk to exit the simulator and show the high score screen.
-            info.saveAllScores();
+            const scoreTypeString = _mapScoreTypeToString(goc.scoringType);
+            info.saveAllScores(scoreTypeString);
 
             // Save high score if this was a judged game and there was a winner (don't save in the LOSE case).
             if (judged && winner) {

--- a/libs/game/info.ts
+++ b/libs/game/info.ts
@@ -241,7 +241,7 @@ namespace info {
         return players ? players.filter(item => item.impl.hasScore()) : [];
     }
 
-    export function saveAllScores() {
+    export function saveAllScores(scoringType: string) {
         const allScoresKey = "all-scores";
         let allScores: number[];
         const pws = playersWithScores();
@@ -252,7 +252,12 @@ namespace info {
             allScores = [];
         }
 
-        settings.writeJSON(allScoresKey, allScores);
+        const scoresObj = {
+            "allScores": allScores,
+            "scoringType": allScores.length ? scoringType : "None"
+        }
+
+        settings.writeJSON(allScoresKey, scoresObj);
     }
 
     export function winningPlayer(): PlayerInfo {


### PR DESCRIPTION
Needed for: https://github.com/microsoft/pxt/pull/10041

This is a small change to the game over block to include the scoring method in the event that game over sends to the simulator. The event that was modified only gets used by the kiosk.