### PR TITLE
Pass on the message bus listener flags in the sim

### DIFF
--- a/libs/base/sim/control.ts
+++ b/libs/base/sim/control.ts
@@ -1,7 +1,7 @@
 namespace pxsim.pxtcore {
     // TODO: add in support for mode, as in CODAL
     export function registerWithDal(id: number, evid: number, handler: RefAction, mode: number = 0) {
-        board().bus.listen(id, evid, handler);
+        board().bus.listen(id, evid, handler, mode);
     }
 
     export function deepSleep() {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "libs/**/*"
   ],
   "dependencies": {
-    "pxt-core": "10.2.2"
+    "pxt-core": "10.2.3"
   },
   "devDependencies": {
     "typescript": "^4.2.3"


### PR DESCRIPTION
This is part two of the fix for https://github.com/microsoft/pxt-microbit/issues/5709

Requires this PR (build will probably break until this gets merged/bumped):

https://github.com/microsoft/pxt/pull/10054