### PR TITLE
replace pxt_powi implementation with better one

### DIFF
--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1353,6 +1353,7 @@ TNumber pow(TNumber x, TNumber y) {
     }
     if (dx == 0) {
         if (dy < 0) {
+            // positive infinity
             return fromDouble(HUGE_VAL);
         }
         return x;

--- a/libs/base/core.cpp
+++ b/libs/base/core.cpp
@@ -1338,8 +1338,26 @@ namespace Math_ {
 //%
 TNumber pow(TNumber x, TNumber y) {
 #ifdef PXT_POWI
-    // regular pow() from math.h is 4k of code
-    return fromDouble(__builtin_powi(toDouble(x), toInt(y)));
+    // regular pow() from math.h is 4k of code, but it can
+    // also be expressed as exp(y * log(x)) which is less
+    // performant than pow() but doesn't increase code size
+    double dx = toDouble(x);
+    double dy = toDouble(y);
+
+    // shortcut to integer pow if y is an integer
+    if (::floor(dy) == dy) {
+        return fromDouble(__builtin_powi(dx, dy));
+    }
+    if (dx > 0) {
+        return fromDouble(::exp(dy * ::log(dx)));
+    }
+    if (dx == 0) {
+        if (dy < 0) {
+            return fromDouble(HUGE_VAL);
+        }
+        return x;
+    }
+    return fromDouble(::log(dx));
 #else
     return fromDouble(::pow(toDouble(x), toDouble(y)));
 #endif


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-microbit/issues/2192

We've long had an optional define (`PXT_POWI`) which can be used to prevent the compile from pulling in the std implementation of `pow` (which is 4k of code by itself). As far as I know, this flag is only actually used in the pxt-microbit to prevent hex size issues with the v1 micro:bit.

The historic PXT_POWI implementation casts the exponent to an integer which obviously provides pretty inaccurate results. This new implementation instead takes advantage of the fact that for positive non-zero x values:
```
Math.pow(x, y) = Math.exp(y * Math.log(x))
```

`exp` and `log` are already pulled into the hex, so this doesn't increase the hex file size at all (i verified this locally)

this is mostly based on @martinwork's [implementation](https://github.com/martinwork/pxt-math-power/blob/f3b8dad63088878252e0896b4be3f50e9d9ac4e2/math-power.cpp#L14) with some extra handling when x=0