### PR TITLE
Fix multiplayer state

### DIFF
--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -49,12 +49,17 @@ namespace mp {
         }
     }
 
+    class StateEntry {
+        constructor(public key: number, public value: number) {
+        }
+    }
+
     /**
      * A player in the game
      */
     export class Player {
         _sprite: Sprite;
-        _state: number[];
+        _state: StateEntry[];
         _index: number;
         _data: any;
         _mwb: boolean;
@@ -153,20 +158,11 @@ namespace mp {
         }
 
         _setState(key: number, val: number) {
-            this._ensureState(key);
-            if (this._state.length > key)
-                this._state[key] = val;
+            this._lookupOrCreateState(key).value = val;
         }
 
         _getState(key: number): number {
-            this._ensureState(key);
-            return (this._state.length > key) ? this._state[key] : 0;
-        }
-
-        _ensureState(key: number) {
-            if (!this._state) this._state = [];
-            if (key < 0 || key > 255) return;
-            while (this._state.length < key) this._state.push(0);
+            return this._lookupOrCreateState(key).value;
         }
 
         _getInfo(): info.PlayerInfo {
@@ -187,6 +183,17 @@ namespace mp {
                 case 3: return controller.player4;
             }
             return undefined;
+        }
+
+        _lookupOrCreateState(key: number) {
+            if (!this._state) this._state = [];
+            for (const entry of this._state) {
+                if (entry.key === key) return entry;
+            }
+
+            const newEntry = new StateEntry(key, 0);
+            this._state.push(newEntry);
+            return newEntry;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/5952

Fixes the player state in the multiplayer extension.

The only actual issue was the check in ensure state (should be `this._state.length <= key`), but I dislike arbitrarily limiting the number of entries to 255 so I reverted the implementation to that of my original extension which uses an array of objects rather than a sparse array of numbers.