### PR TITLE
fix: prevent overwrite in smartConfigureof cfg0

### DIFF
--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -152,7 +152,7 @@ class WDisplay {
 
             // the device will run without shield when the following is specified in user program:
             // namespace userconfig { export const DISPLAY_CFG0 = 0x02000080 }
-            if (*cfg0 & 0x0200000) {
+            if (*cfg0 & 0x2000000) {
                 DMESG("74HC: no wait requested");
                 return DISPLAY_TYPE_ST7735;
             }

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -170,9 +170,9 @@ class WDisplay {
 
         // SER pin (or first bit of second HC) is orientation
         if (hc & 0x0010)
-            *cfg0 = 0x80;
+            *cfg0 = (*cfg0 & 0xFFFFFF00) | 0x80; // change to prevent overwrite of offset bytes
         else
-            *cfg0 = 0x40;
+            *cfg0 = (*cfg0 & 0xFFFFFF00) | 0x40; // change to prevent overwrite of offset bytes 
 
         uint32_t configId = (hc & 0xe0) >> 5;
 

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -152,7 +152,7 @@ class WDisplay {
 
             // the device will run without shield when the following is specified in user program:
             // namespace userconfig { export const DISPLAY_CFG0 = 0x02000080 }
-            if (*cfg0 & 0x2000000) {
+            if (*cfg0 & 0x0200000) {
                 DMESG("74HC: no wait requested");
                 return DISPLAY_TYPE_ST7735;
             }
@@ -170,9 +170,9 @@ class WDisplay {
 
         // SER pin (or first bit of second HC) is orientation
         if (hc & 0x0010)
-            *cfg0 = (*cfg0 & 0xFFFFFF00) | 0x80; // change to prevent overwrite of offset bytes
+            *cfg0 |= 0x80;
         else
-            *cfg0 = (*cfg0 & 0xFFFFFF00) | 0x40; // change to prevent overwrite of offset bytes 
+            *cfg0 |= 0x40;
 
         uint32_t configId = (hc & 0xe0) >> 5;
 


### PR DESCRIPTION
As mentioned in this issue https://github.com/microsoft/pxt-arcade/issues/6438 changing the CFG0 bytes does not lead to the desired change in e.g. the offset values for the display when the display type is set to 4242 (Smart Display). I could trace this down to the smartConfigure function, in which in line 173 or 175 the content of the cfg0 variable is currently rewritten to either 0x80 or 0x40. Since the smartConfigure function is called before the offset values are read out (line 82), the rewriting leads to an erasure of the offset values. My proposed fix is to bitmask writing the cfg0 variable to keep all bytes despite the LSB.

Edit: Another way of fixing this issue could also be to extract the offset values before calling the smartConfigure function.