### PR TITLE
add date APIs to browser events extension

### DIFF
--- a/libs/browser-events/browserEvents.cpp
+++ b/libs/browser-events/browserEvents.cpp
@@ -26,4 +26,44 @@ int wheelDy() {
 int wheelDz() {
     return -1;
 }
+
+//%
+int currentTime() {
+    return -1;
+}
+
+//%
+int getYear(int time) {
+    return -1;
+}
+
+//%
+int getMonth(int time) {
+    return -1;
+}
+
+//%
+int getDayOfMonth(int time) {
+    return -1;
+}
+
+//%
+int getDayOfWeek(int time) {
+    return -1;
+}
+
+//%
+int getHours(int time) {
+    return -1;
+}
+
+//%
+int getMinutes(int time) {
+    return -1;
+}
+
+//%
+int getSeconds(int time) {
+    return -1;
+}
 }

--- a/libs/browser-events/shims.d.ts
+++ b/libs/browser-events/shims.d.ts
@@ -10,4 +10,20 @@ declare namespace browserEvents {
     //% shim=browserEvents::wheelDz
     function wheelDz(): number;
 
+    //% shim=browserEvents::currentTime
+    function currentTime(): number;
+    //% shim=browserEvents::getYear
+    function getYear(time: number): number;
+    //% shim=browserEvents::getMonth
+    function getMonth(time: number): number;
+    //% shim=browserEvents::getDayOfMonth
+    function getDayOfMonth(time: number): number;
+    //% shim=browserEvents::getDayOfWeek
+    function getDayOfWeek(time: number): number;
+    //% shim=browserEvents::getHours
+    function getHours(time: number): number;
+    //% shim=browserEvents::getMinutes
+    function getMinutes(time: number): number;
+    //% shim=browserEvents::getSeconds
+    function getSeconds(time: number): number;
 }

--- a/libs/browser-events/sim/time.ts
+++ b/libs/browser-events/sim/time.ts
@@ -1,0 +1,33 @@
+namespace pxsim.browserEvents {
+    export function currentTime(): number {
+        return Date.now();
+    }
+
+    export function getYear(time: number): number {
+        return new Date(time).getFullYear();
+    }
+
+    export function getMonth(time: number): number {
+        return new Date(time).getMonth();
+    }
+
+    export function getDayOfMonth(time: number): number {
+        return new Date(time).getDate();
+    }
+
+    export function getDayOfWeek(time: number): number {
+        return new Date(time).getDay();
+    }
+
+    export function getHours(time: number): number {
+        return new Date(time).getHours();
+    }
+
+    export function getMinutes(time: number): number {
+        return new Date(time).getMinutes();
+    }
+
+    export function getSeconds(time: number): number {
+        return new Date(time).getSeconds();
+    }
+}


### PR DESCRIPTION
adds date APIs to the browser-events extension. these let you get the current time in milliseconds since the epoch and also break that time into its constituent parts using the local browser/system settings. this is currently javascript only, but i might add blocks later. also this does nothing on hardware (obviously)

this is a frequent request on the forum.

![rtc](https://github.com/user-attachments/assets/4d7cce80-1edd-46cf-953a-1cd69f3a97cb)
