### PR TITLE
remove reference to invalid shadow on deprecated block

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -789,7 +789,6 @@ class Sprite extends sprites.BaseSprite {
      */
     //% blockId=spriteobstacle block="%sprite(mySprite) wall hit on %direction"
     //% blockNamespace="scene" group="Locations"
-    //% direction.shadow=tiles_collision_direction_editor
     //% help=sprites/sprite/tile-hit-from
     //% deprecated=1
     tileHitFrom(direction: number): number {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-arcade/issues/6678

this fixes the above issue, which was caused because this deprecated block references a block that doesn't exist anymore.

the larger issue here is that we probably shouldn't be showing deprecated blocks in this scenario in the first place. in the above issue, if you load a tilemap that doesn't filter the toolbox, then we include *all* the blocks in each of the flyouts including deprecated blocks. we probably shouldn't be doing that!

@abchatra this is an exceedingly safe fix so i think we should hotfix it to arcade ASAP to unblock the teacher who is using this