### PR TITLE
duplicate sprite create on shadow drag

### DIFF
--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -56,6 +56,7 @@ namespace sprites {
     //% blockAliasFor="sprites.create"
     //% expandableArgumentMode=toggle
     //% weight=99 help=sprites/create
+    //% duplicateShadowOnDrag
     export function __create(img: Image, kind?: number): Sprite {
         return sprites.create(img, kind);
     }

--- a/libs/multiplayer/player.ts
+++ b/libs/multiplayer/player.ts
@@ -435,7 +435,7 @@ namespace mp {
     //% blockId=mp_setPlayerSprite
     //% block="set $player sprite to $sprite"
     //% player.shadow=mp_playerSelector
-    //% sprite.shadow=spritescreate
+    //% sprite.shadow=spritescreatenoset
     //% group=Player
     //% weight=120
     //% blockGap=8


### PR DESCRIPTION
* Update the **spritecreatenoset** block def to duplicate on shadow drag.
* Update the **mp_setPlayerSprite** block def to use **spritecreatenoset** as a shadow block.

Fixes https://github.com/microsoft/pxt-arcade/issues/5597
