### PR TITLE
optimize sprite overlap step

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -270,6 +270,7 @@ class Sprite extends sprites.BaseSprite {
 
     _hitbox: game.Hitbox;
     _overlappers: number[];
+    _alreadyChecked: number[];
     _kindsOverlappedWith: number[];
 
     flags: number

--- a/libs/game/spritemap.ts
+++ b/libs/game/spritemap.ts
@@ -65,8 +65,8 @@ namespace sprites {
             const areaWidth = tMap ? tMap.areaWidth() : screen.width;
             const areaHeight = tMap ? tMap.areaHeight() : screen.height;
 
-            this.cellWidth = Math.clamp(8, areaWidth >> 2, maxWidth * 2);
-            this.cellHeight = Math.clamp(8, areaHeight >> 2, maxHeight * 2);
+            this.cellWidth = Math.clamp(8, areaWidth >> 2, maxWidth << 1);
+            this.cellHeight = Math.clamp(8, areaHeight >> 2, maxHeight << 1);
             this.rowCount = Math.idiv(areaHeight, this.cellHeight);
             this.columnCount = Math.idiv(areaWidth, this.cellWidth);
         }

--- a/libs/game/spritemap.ts
+++ b/libs/game/spritemap.ts
@@ -5,6 +5,7 @@ namespace sprites {
         private rowCount: number;
         private columnCount: number;
         private buckets: Sprite[][];
+        filledBuckets: Sprite[][];
 
         constructor() {
             this.buckets = [];
@@ -72,6 +73,7 @@ namespace sprites {
 
         clear() {
             this.buckets = [];
+            this.filledBuckets = [];
         }
 
         private key(x: number, y: number): number {
@@ -83,8 +85,10 @@ namespace sprites {
         private insertAtKey(x: number, y: number, sprite: Sprite) {
             const k = this.key(x, y);
             let bucket = this.buckets[k];
-            if (!bucket)
+            if (!bucket) {
                 bucket = this.buckets[k] = [];
+                this.filledBuckets.push(bucket);
+            }
             if (bucket.indexOf(sprite) < 0)
                 bucket.push(sprite);
         }


### PR DESCRIPTION
@jwunderl and i were playing with the physics engine on livestream yesterday and discovered that the biggest performance bottleneck in games with lots of overlapping sprites was our SpriteMap's overlaps function. for those who haven't looked at this code before, we use a form of spatial hashing in our overlap detection where we divide the screen/tilemap into buckets and then place each sprite into every bucket it overlaps with. then, during the overlap step in our physics engine we loop over all moving sprites and build up a list of potential overlappers by merging all of the buckets that the sprite is in. this ends up being faster than the N^2 alternative for games with lots of sprites but just barely because merging those buckets is expensive and we end up doing it several times per frame.

this PR restructures that code so that now we just keep track of all the filled buckets as we insert sprites into the map and loop over those buckets instead of looping over the sprites. this eliminates all the bucket merging and results in a _huge_ performance increase. i also now store a list of already checked sprites so that we don't duplicate work

here is the test program i was using:

https://makecode.com/_g2wWrcPgrF8q

i want to do some more detailed testing on different scenarios, but i think this is safe to check in for now.