### PR TITLE
change system keyboard to default and add sim API for localizing system keyboard instructions

### DIFF
--- a/libs/game/numberprompt.ts
+++ b/libs/game/numberprompt.ts
@@ -4,21 +4,21 @@ namespace game {
      * Ask the player for a number value.
      * @param message The message to display on the text-entry screen
      * @param answerLength The maximum number of digits the user can enter (1 - 10)
-     * @param useSystemKeyboard Use the computer keyboard for typing if the game is being played in the simulator
+     * @param useOnScreenKeyboard Force the simulator to use the on-screen keyboard for text entry
      */
     //% weight=10 help=game/ask-for-number
     //% blockId=gameaskfornumber
-    //% block="ask for number $message || and max length $answerLength use system keyboard $useSystemKeyboard"
+    //% block="ask for number $message || and max length $answerLength use on-screen keyboard $useOnScreenKeyboard"
     //% message.shadow=text
     //% message.defl=""
     //% answerLength.defl="6"
     //% answerLength.min=1
     //% answerLength.max=10
     //% group="Prompt"
-    export function askForNumber(message: any, answerLength = 6, useSystemKeyboard = false) {
+    export function askForNumber(message: any, answerLength = 6, useOnScreenKeyboard = false) {
         answerLength = Math.max(0, Math.min(10, answerLength));
         let p = new game.NumberPrompt();
-        const result = p.show(console.inspect(message), answerLength, useSystemKeyboard);
+        const result = p.show(console.inspect(message), answerLength, useOnScreenKeyboard);
         return parseFloat(result);
     }
 

--- a/libs/game/prompt.ts
+++ b/libs/game/prompt.ts
@@ -19,20 +19,20 @@ namespace game {
      * Ask the player for a string value.
      * @param message The message to display on the text-entry screen
      * @param answerLength The maximum number of characters the user can enter (1 - 24)
-     * @param useSystemKeyboard Use the computer keyboard for typing if the game is being played in the simulator
+     * @param useOnScreenKeyboard Force the simulator to use the on-screen keyboard for text entry
      */
     //% weight=10 help=game/ask-for-string
     //% blockId=gameaskforstring
-    //% block="ask for string $message || and max length $answerLength use system keyboard $useSystemKeyboard"
+    //% block="ask for string $message || and max length $answerLength use on-screen keyboard $useOnScreenKeyboard"
     //% message.shadow=text
     //% message.defl=""
     //% answerLength.defl="12"
     //% answerLength.min=1
     //% answerLength.max=24
     //% group="Prompt"
-    export function askForString(message: any, answerLength = 12, useSystemKeyboard = false) {
+    export function askForString(message: any, answerLength = 12, useOnScreenKeyboard = false) {
         let p = new game.Prompt();
-        const result = p.show(console.inspect(message), answerLength, useSystemKeyboard);
+        const result = p.show(console.inspect(message), answerLength, useOnScreenKeyboard);
         return result;
     }
 
@@ -161,7 +161,7 @@ namespace game {
             this.selectionEnd = 0;
         }
 
-        show(message: string, answerLength: number, useSystemKeyboard = false) {
+        show(message: string, answerLength: number, useOnScreenKeyboard = false) {
             this.message = message;
             this.answerLength = answerLength;
 
@@ -171,7 +171,7 @@ namespace game {
             this.createRenderable();
             this.confirmPressed = false;
 
-            if (useSystemKeyboard && control.deviceDalVersion() === "sim" && helpers._isSystemKeyboardSupported()) {
+            if (!useOnScreenKeyboard && control.deviceDalVersion() === "sim" && helpers._isSystemKeyboardSupported()) {
                 this.useSystemKeyboard = true;
                 helpers._promptForText(this.answerLength, this.numbersOnly());
                 this.selectionEnd = 0;

--- a/libs/game/prompt.ts
+++ b/libs/game/prompt.ts
@@ -228,7 +228,7 @@ namespace game {
             }
 
             const promptText = new sprites.RenderText(this.message, CONTENT_WIDTH);
-            const systemKeyboardText = new sprites.RenderText("Type your response using your keyboard and hit ENTER", CONTENT_WIDTH);
+            let systemKeyboardText: sprites.RenderText;
 
             this.renderable = scene.createRenderable(-1, () => {
                 promptText.draw(screen, (screen.width >> 1) - (promptText.width >> 1), CONTENT_TOP, this.theme.colorPrompt, 0, 2)
@@ -238,6 +238,10 @@ namespace game {
                     this.drawKeyboard();
                     this.drawBottomBar();
                     return;
+                }
+
+                if (!systemKeyboardText) {
+                    systemKeyboardText = new sprites.RenderText(helpers._getLocalizedInstructions(), CONTENT_WIDTH);
                 }
 
                 screen.fillRect(0, screen.height - (PADDING << 1) - systemKeyboardText.height, screen.width, screen.height, this.theme.colorBottomBackground);

--- a/libs/game/systemKeyboard.cpp
+++ b/libs/game/systemKeyboard.cpp
@@ -16,6 +16,11 @@ char* getTextPromptString() {
 }
 
 //%
+char* getLocalizedInstructions() {
+    return NULL;
+}
+
+//%
 int getTextPromptSelectionStart() {
     return 0;
 }

--- a/libs/game/systemKeyboard.d.ts
+++ b/libs/game/systemKeyboard.d.ts
@@ -12,6 +12,9 @@ declare namespace helpers {
     //% shim=Keyboard::getTextPromptString
     function _getTextPromptString(): string;
 
+    //% shim=Keyboard::getLocalizedInstructions
+    function _getLocalizedInstructions(): string;
+
     //% shim=Keyboard::getTextPromptSelectionStart
     function _getTextPromptSelectionStart(): number;
 


### PR DESCRIPTION
requires https://github.com/microsoft/pxt-arcade-sim/pull/111

this is the main part of https://github.com/microsoft/pxt-arcade/issues/6810

adds a new sim API for localizing the system keyboard instruction text and flips the default for that ask for string/number blocks to using the keyboard for text entry. the wording for the new option is "use on-screen keyboard"


here's the current block:
![arcade-screenshot (64)](https://github.com/user-attachments/assets/452a99ef-354f-492e-93a0-3883deaee746)

and here's the new one:
![arcade-screenshot (63)](https://github.com/user-attachments/assets/7d05b58c-403b-4517-9b4c-3af47f890be5)


