### PR TITLE
add rotation property to sprites

### DIFF
--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -88,15 +88,15 @@ namespace game {
         overlapsWith(other: Hitbox): boolean {
             this.updateIfInvalid();
             other.updateIfInvalid();
-            if (this.contains(other.left, other.top)) return true;
-            if (this.contains(other.left, other.bottom)) return true;
-            if (this.contains(other.right, other.top)) return true;
-            if (this.contains(other.right, other.bottom)) return true;
-            if (other.contains(this.left, this.top)) return true;
-            if (other.contains(this.left, this.bottom)) return true;
-            if (other.contains(this.right, this.top)) return true;
-            if (other.contains(this.right, this.bottom)) return true;
-            return false;
+            if (
+                this.left > other.right ||
+                this.top > other.bottom ||
+                this.right < other.left ||
+                this.bottom < other.top
+            ) {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/libs/game/hitbox.ts
+++ b/libs/game/hitbox.ts
@@ -105,6 +105,10 @@ namespace game {
         if (s._hitbox && s._hitbox.isValid())
             return s._hitbox;
 
+        if (s._rotatedBBox) {
+            return new Hitbox(s, Fx8(s._rotatedBBox.width), Fx8(s._rotatedBBox.height), Fx.zeroFx8, Fx.zeroFx8);
+        }
+
         const i = s.image;
         let minX = Fx8(i.width);
         let minY = Fx8(i.height);

--- a/libs/game/pxt.json
+++ b/libs/game/pxt.json
@@ -14,6 +14,7 @@
         "hitbox.ts",
         "renderText.ts",
         "spritesay.ts",
+        "rotation.ts",
         "sprites.ts",
         "sprite.ts",
         "extendableSprite.ts",

--- a/libs/game/rotation.ts
+++ b/libs/game/rotation.ts
@@ -1,0 +1,194 @@
+namespace sprites {
+    export class RotatedBoundingBox {
+        protected _x: number;
+        protected _y: number;
+        protected _rotation: number;
+
+        protected points: number[];
+        protected cornerDistance: number;
+        protected cornerAngle: number;
+        width: number;
+        height: number;
+
+        public get cx() {
+            return this._x;
+        }
+
+        public set cx(value: number) {
+            this.setPosition(value, this._y);
+        }
+
+        public get cy() {
+            return this._y;
+        }
+
+        public set cy(value: number) {
+            this.setPosition(this._x, value);
+        }
+
+        public get x0(): number {
+            return this.points[0];
+        }
+
+        public get y0(): number {
+            return this.points[1];
+        }
+
+        public get x1(): number {
+            return this.points[2];
+        }
+
+        public get y1(): number {
+            return this.points[3];
+        }
+
+        public get x2(): number {
+            return this.points[4];
+        }
+
+        public get y2(): number {
+            return this.points[5];
+        }
+
+        public get x3(): number {
+            return this.points[6];
+        }
+
+        public get y3(): number {
+            return this.points[7];
+        }
+
+        public get rotation() {
+            return this._rotation;
+        }
+
+        public set rotation(value: number) {
+            this.setRotation(value);
+        }
+
+        constructor(
+            x: number,
+            y: number,
+            width: number,
+            height: number
+        ) {
+            this._x = x;
+            this._y = y;
+            this.points = [];
+            this._rotation = 0;
+            this.setDimensions(width, height);
+        }
+
+        setDimensions(width: number, height: number) {
+            width /= 2;
+            height /= 2;
+
+            this.cornerDistance = Math.sqrt(
+                width * width + height * height
+            );
+            this.cornerAngle = Math.atan2(height, width);
+            this.setRotation(this._rotation);
+        }
+
+        setRotation(angle: number) {
+            this._rotation = angle;
+            this.points[0] = this._x + Math.cos(this.cornerAngle + angle) * this.cornerDistance;
+            this.points[1] = this._y + Math.sin(this.cornerAngle + angle) * this.cornerDistance;
+            this.points[2] = this._x + Math.cos(Math.PI - this.cornerAngle + angle) * this.cornerDistance;
+            this.points[3] = this._y + Math.sin(Math.PI - this.cornerAngle + angle) * this.cornerDistance;
+            this.points[4] = this._x + Math.cos(Math.PI + this.cornerAngle + angle) * this.cornerDistance;
+            this.points[5] = this._y + Math.sin(Math.PI + this.cornerAngle + angle) * this.cornerDistance;
+            this.points[6] = this._x + Math.cos(-this.cornerAngle + angle) * this.cornerDistance;
+            this.points[7] = this._y + Math.sin(-this.cornerAngle + angle) * this.cornerDistance;
+
+            let minX = this.points[0];
+            let maxX = this.points[0];
+            let minY = this.points[1];
+            let maxY = this.points[1];
+
+            for (let i = 2; i < 8; i += 2) {
+                minX = Math.min(minX, this.points[i]);
+                maxX = Math.max(maxX, this.points[i]);
+                minY = Math.min(minY, this.points[i + 1]);
+                maxY = Math.max(maxY, this.points[i + 1]);
+            }
+
+            this.width = maxX - minX;
+            this.height = maxY - minY;
+        }
+
+        setPosition(x: number, y: number) {
+            const dx = x - this._x;
+            const dy = y - this._y;
+            for (let i = 0; i < 8; i += 2) {
+                this.points[i] += dx;
+                this.points[i + 1] += dy;
+            }
+            this._x = x;
+            this._y = y;
+        }
+
+        overlaps(other: RotatedBoundingBox): boolean {
+            return doRectanglesIntersect(this.points, other.points);
+        }
+
+        overlapsAABB(left: number, top: number, right: number, bottom: number) {
+            return doRectanglesIntersect(
+                this.points,
+                [
+                    left, top,
+                    right, top,
+                    right, bottom,
+                    left, bottom
+                ]
+            );
+        }
+    }
+
+    // adapted from https://stackoverflow.com/questions/10962379/how-to-check-intersection-between-2-rotated-rectangles
+    // but optimized for rectangles
+    function doRectanglesIntersect(a: number[], b: number[]) {
+        const rects = [a, b];
+
+        for (const rect of rects) {
+            // we only need to check the first two sides because the
+            // normals are the same for the other two
+            for (let pointIndex = 0; pointIndex < 4; pointIndex += 2) {
+                const normalX = rect[pointIndex + 3] - rect[pointIndex + 1];
+                const normalY = rect[pointIndex] - rect[pointIndex + 2];
+
+                let minA: number = undefined;
+                let maxA: number = undefined;
+                let minB: number = undefined;
+                let maxB: number = undefined;
+
+                for (let i = 0; i < 8; i += 2) {
+                    const projected = normalX * a[i] + normalY * a[i + 1];
+
+                    if (minA === undefined || projected < minA) {
+                        minA = projected;
+                    }
+                    if (maxA == undefined || projected > maxA) {
+                        maxA = projected;
+                    }
+                }
+
+                for (let i = 0; i < 8; i += 2) {
+                    const projected = normalX * b[i] + normalY * b[i + 1];
+
+                    if (minB === undefined || projected < minB) {
+                        minB = projected;
+                    }
+                    if (maxB == undefined || projected > maxB) {
+                        maxB = projected;
+                    }
+                }
+
+                if (maxA < minB || maxB < minA) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/libs/game/rotation.ts
+++ b/libs/game/rotation.ts
@@ -139,8 +139,8 @@ namespace sprites {
                 maxY = Math.max(maxY, this.points[i + 1]);
             }
 
-            this._width = maxX - minX;
-            this._height = maxY - minY;
+            this._width = (maxX - minX) | 0;
+            this._height = (maxY - minY) | 0;
         }
     }
 

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -744,10 +744,39 @@ class Sprite extends sprites.BaseSprite {
             return false;
         else if (this._rotatedBBox) {
             if (other._rotatedBBox) {
-                return this._rotatedBBox.overlaps(other._rotatedBBox);
+                if (this._rotatedBBox.overlaps(other._rotatedBBox)) {
+                    return helpers.checkOverlapsTwoScaledRotatedImages(
+                        other.image,
+                        this.left - other.left,
+                        this.top - other.top,
+                        other.sx,
+                        other.sy,
+                        other.rotation,
+                        this.image,
+                        this.sx,
+                        this.sy,
+                        this.rotation
+                    );
+                }
+                else {
+                    return false;
+                }
             }
             else {
-                return this._rotatedBBox.overlapsAABB(other.left, other.top, other.right, other.bottom);
+                if (this._rotatedBBox.overlapsAABB(other.left, other.top, other.right, other.bottom)) {
+                    return helpers.checkOverlapsScaledRotatedImage(
+                        other.image,
+                        this.left - other.left,
+                        this.top - other.top,
+                        this.image,
+                        this.sx,
+                        this.sy,
+                        this.rotation
+                    );
+                }
+                else {
+                    return false;
+                }
             }
         }
         else if (other._rotatedBBox) {

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -362,7 +362,7 @@ class Sprite extends sprites.BaseSprite {
     }
 
     calcDimensionalHash() {
-        return this._image.revision() + Fx.toIntShifted(this._width, 8) + Fx.toIntShifted(this._height, 16);
+        return this._image.revision() + Fx.toIntShifted(this._width, 8) + Fx.toIntShifted(this._height, 16) + this.rotation;
     }
 
     resetHitbox() {
@@ -728,7 +728,9 @@ class Sprite extends sprites.BaseSprite {
             return false
         if (this.flags & sprites.Flag.HitboxOverlaps || other.flags & sprites.Flag.HitboxOverlaps)
             return other._hitbox.overlapsWith(this._hitbox);
-        if (this._rotatedBBox) {
+        if (!other._hitbox.overlapsWith(this._hitbox))
+            return false;
+        else if (this._rotatedBBox) {
             if (other._rotatedBBox) {
                 return this._rotatedBBox.overlaps(other._rotatedBBox);
             }
@@ -739,8 +741,6 @@ class Sprite extends sprites.BaseSprite {
         else if (other._rotatedBBox) {
             return other.overlapsWith(this);
         }
-        if (!other._hitbox.overlapsWith(this._hitbox))
-            return false;
         else if (!this.isScaled() && !other.isScaled()) {
             return other._image.overlapsWith(
                 this._image,
@@ -1160,7 +1160,7 @@ class Sprite extends sprites.BaseSprite {
 
     protected drawSprite(drawLeft: number, drawTop: number) {
         if (this._rotatedBBox) {
-            helpers.imageDrawRotateScaled(
+            helpers.imageDrawScaledRotated(
                 screen,
                 drawLeft,
                 drawTop,

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -1167,8 +1167,7 @@ class Sprite extends sprites.BaseSprite {
                 this._image,
                 this.sx,
                 this.sy,
-                this.rotation,
-                true
+                this.rotation
             );
         }
         else if (!this.isScaled())

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -223,6 +223,18 @@ class Sprite extends sprites.BaseSprite {
         this.y = y;
         this.x = x;
     }
+
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="scale" callInDebugger
+    get scale(): number {
+        return Math.max(this.sx, this.sy);
+    }
+    //% group="Physics" blockSetVariable="mySprite"
+    //% blockCombine block="scale"
+    set scale(v: number) {
+        this.sx = this.sy = v;
+    }
+
     //% group="Physics" blockSetVariable="mySprite"
     //% blockCombine block="rotation (radians)" callInDebugger
     get rotation(): number {
@@ -243,14 +255,14 @@ class Sprite extends sprites.BaseSprite {
     }
 
     //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="scale" callInDebugger
-    get scale(): number {
-        return Math.max(this.sx, this.sy);
+    //% blockCombine block="rotation (degrees)" callInDebugger
+    get rotationDegrees(): number {
+        return this.rotation * 180 / Math.PI;
     }
     //% group="Physics" blockSetVariable="mySprite"
-    //% blockCombine block="scale"
-    set scale(v: number) {
-        this.sx = this.sy = v;
+    //% blockCombine block="rotation (degrees)"
+    set rotationDegrees(v: number) {
+        this.rotation = v * Math.PI / 180;
     }
 
     private _data: any;

--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -116,7 +116,6 @@ class Sprite extends sprites.BaseSprite {
     //% blockCombine block="x"
     set x(v: number) {
         this.left = v - (this.width / 2)
-        this.resetBBoxPosition();
     }
 
     //% group="Physics" blockSetVariable="mySprite"
@@ -128,7 +127,6 @@ class Sprite extends sprites.BaseSprite {
     //% blockCombine block="y"
     set y(v: number) {
         this.top = v - (this.height / 2)
-        this.resetBBoxPosition();
     }
 
     //% group="Physics" blockSetVariable="mySprite"
@@ -236,7 +234,7 @@ class Sprite extends sprites.BaseSprite {
         const x = this.x;
         const y = this.y;
         if (!this._rotatedBBox) {
-            this._rotatedBBox = new sprites.RotatedBoundingBox(this.x, this.y, this.width, this.height);
+            this._rotatedBBox = new sprites.RotatedBoundingBox(this, this.width, this.height);
         }
         this._rotatedBBox.setRotation(v);
         this.recalcSize();
@@ -391,8 +389,6 @@ class Sprite extends sprites.BaseSprite {
     protected recalcSize(): void {
         if (this._rotatedBBox) {
             this._rotatedBBox.setDimensions(this._image.width * this.sx, this._image.height * this.sy);
-            this._rotatedBBox.setPosition(this.x, this.y);
-
             this._width = Fx8(this._rotatedBBox.width);
             this._height = Fx8(this._rotatedBBox.height);
         }
@@ -1188,11 +1184,5 @@ class Sprite extends sprites.BaseSprite {
                 0, 0,
                 this._image.width, this._image.height,
                 true, false);
-    }
-
-    protected resetBBoxPosition() {
-        if (this._rotatedBBox) {
-            this._rotatedBBox.setPosition(this.x, this.y);
-        }
     }
 }

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1193,7 +1193,7 @@ ParsedShearArgs parseShearArgs(Image_ src, pxt::RefCollection *args, int argInde
     angle = fmod(angle, TWO_PI);
 
     if (angle < 0) {
-        angle = angle + PI;
+        angle = angle + TWO_PI;
     }
 
     if (angle > HALF_PI && angle <= THREE_HALF_PI) {

--- a/libs/screen/image.cpp
+++ b/libs/screen/image.cpp
@@ -1,5 +1,4 @@
 #include "pxt.h"
-#include <limits>
 
 
 #if IMAGE_BITS == 1

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -165,6 +165,15 @@ namespace helpers {
     //% shim=ImageMethods::_blit
     declare function _blit(img: Image, src: Image, args: number[]): boolean;
 
+    //% shim=ImageMethods::_drawScaledRotatedImage
+    declare function _drawScaledRotatedImage(img: Image, src: Image, args: number[]): void;
+
+    //% shim=ImageMethods::_scaledRotatedImageDimensions
+    declare function _scaledRotatedImageDimensions(img: Image, args: number[], result: Buffer): void;
+
+    //% shim=ImageMethods::_checkRotatedScaledOverlap
+    declare function _checkRotatedScaledOverlap(dst: Image, src: Image, args: number[]): boolean;
+
     //% shim=ImageMethods::_fillTriangle
     declare function _fillTriangle(img: Image, args: number[]): void;
 
@@ -278,6 +287,45 @@ namespace helpers {
         _blitArgs[7] = y3;
         _blitArgs[8] = col;
         _fillPolygon4(img, _blitArgs);
+    }
+
+    export function imageDrawRotateScaled(dest: Image, destX: number, destY: number, src: Image, sx: number, sy: number, angle: number, transparent: boolean) {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = destX | 0;
+        _blitArgs[1] = destY | 0;
+        _blitArgs[2] = sx;
+        _blitArgs[3] = sy;
+        _blitArgs[4] = angle;
+        _blitArgs[5] = transparent ? 1 : 0;
+        _drawScaledRotatedImage(dest, src, _blitArgs);
+    }
+
+    export function imageOverlapsRotateScaled(dest: Image, xDst: number, yDst: number, sxDst: number, syDst: number, angleDst: number, src: Image, sxSrc: number, sySrc: number, angleSrc: number) {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = xDst | 0;
+        _blitArgs[1] = yDst | 0;
+        _blitArgs[2] = sxDst;
+        _blitArgs[3] = syDst;
+        _blitArgs[4] = angleDst;
+        _blitArgs[5] = sxSrc;
+        _blitArgs[6] = sySrc;
+        _blitArgs[7] = angleSrc;
+
+        return _checkRotatedScaledOverlap(dest, src, _blitArgs);
+    }
+
+    export function scaledRotatedImageDimensions(img: Image, sx: number, sy: number, angle: number) {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = sx;
+        _blitArgs[1] = sy;
+        _blitArgs[2] = angle;
+        const result = control.createBuffer(4);
+        _scaledRotatedImageDimensions(img, _blitArgs, result);
+
+        return {
+            width: result.getNumber(NumberFormat.UInt16LE, 0),
+            height: result.getNumber(NumberFormat.UInt16LE, 2)
+        };
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -168,6 +168,12 @@ namespace helpers {
     //% shim=ImageMethods::_drawScaledRotatedImage
     declare function _drawScaledRotatedImage(img: Image, src: Image, args: number[]): void;
 
+    //% shim=ImageMethods::_checkOverlapsScaledRotatedImage
+    declare function _checkOverlapsScaledRotatedImage(img: Image, src: Image, args: number[]): boolean;
+
+    //% shim=ImageMethods::_checkOverlapsTwoScaledRotatedImages
+    declare function _checkOverlapsTwoScaledRotatedImages(img: Image, src: Image, args: number[]): boolean;
+
     //% shim=ImageMethods::_fillTriangle
     declare function _fillTriangle(img: Image, args: number[]): void;
 
@@ -291,6 +297,29 @@ namespace helpers {
         _blitArgs[3] = sy;
         _blitArgs[4] = angle;
         _drawScaledRotatedImage(dest, src, _blitArgs);
+    }
+
+    export function checkOverlapsScaledRotatedImage(dest: Image, destX: number, destY: number, src: Image, sx: number, sy: number, angle: number) {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = destX | 0;
+        _blitArgs[1] = destY | 0;
+        _blitArgs[2] = sx;
+        _blitArgs[3] = sy;
+        _blitArgs[4] = angle;
+        return _checkOverlapsScaledRotatedImage(dest, src, _blitArgs);
+    }
+
+    export function checkOverlapsTwoScaledRotatedImages(dest: Image, destX: number, destY: number, destSx: number, destSy: number, destAngle: number, src: Image, sx: number, sy: number, angle: number) {
+        _blitArgs = _blitArgs || [];
+        _blitArgs[0] = destX | 0;
+        _blitArgs[1] = destY | 0;
+        _blitArgs[2] = destSx;
+        _blitArgs[3] = destSy;
+        _blitArgs[4] = destAngle;
+        _blitArgs[5] = sx;
+        _blitArgs[6] = sy;
+        _blitArgs[7] = angle;
+        return _checkOverlapsTwoScaledRotatedImages(dest, src, _blitArgs);
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -168,12 +168,6 @@ namespace helpers {
     //% shim=ImageMethods::_drawScaledRotatedImage
     declare function _drawScaledRotatedImage(img: Image, src: Image, args: number[]): void;
 
-    //% shim=ImageMethods::_scaledRotatedImageDimensions
-    declare function _scaledRotatedImageDimensions(img: Image, args: number[], result: Buffer): void;
-
-    //% shim=ImageMethods::_checkRotatedScaledOverlap
-    declare function _checkRotatedScaledOverlap(dst: Image, src: Image, args: number[]): boolean;
-
     //% shim=ImageMethods::_fillTriangle
     declare function _fillTriangle(img: Image, args: number[]): void;
 
@@ -298,34 +292,6 @@ namespace helpers {
         _blitArgs[4] = angle;
         _blitArgs[5] = transparent ? 1 : 0;
         _drawScaledRotatedImage(dest, src, _blitArgs);
-    }
-
-    export function imageOverlapsRotateScaled(dest: Image, xDst: number, yDst: number, sxDst: number, syDst: number, angleDst: number, src: Image, sxSrc: number, sySrc: number, angleSrc: number) {
-        _blitArgs = _blitArgs || [];
-        _blitArgs[0] = xDst | 0;
-        _blitArgs[1] = yDst | 0;
-        _blitArgs[2] = sxDst;
-        _blitArgs[3] = syDst;
-        _blitArgs[4] = angleDst;
-        _blitArgs[5] = sxSrc;
-        _blitArgs[6] = sySrc;
-        _blitArgs[7] = angleSrc;
-
-        return _checkRotatedScaledOverlap(dest, src, _blitArgs);
-    }
-
-    export function scaledRotatedImageDimensions(img: Image, sx: number, sy: number, angle: number) {
-        _blitArgs = _blitArgs || [];
-        _blitArgs[0] = sx;
-        _blitArgs[1] = sy;
-        _blitArgs[2] = angle;
-        const result = control.createBuffer(4);
-        _scaledRotatedImageDimensions(img, _blitArgs, result);
-
-        return {
-            width: result.getNumber(NumberFormat.UInt16LE, 0),
-            height: result.getNumber(NumberFormat.UInt16LE, 2)
-        };
     }
 
     /**

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -283,14 +283,13 @@ namespace helpers {
         _fillPolygon4(img, _blitArgs);
     }
 
-    export function imageDrawRotateScaled(dest: Image, destX: number, destY: number, src: Image, sx: number, sy: number, angle: number, transparent: boolean) {
+    export function imageDrawRotateScaled(dest: Image, destX: number, destY: number, src: Image, sx: number, sy: number, angle: number) {
         _blitArgs = _blitArgs || [];
         _blitArgs[0] = destX | 0;
         _blitArgs[1] = destY | 0;
         _blitArgs[2] = sx;
         _blitArgs[3] = sy;
         _blitArgs[4] = angle;
-        _blitArgs[5] = transparent ? 1 : 0;
         _drawScaledRotatedImage(dest, src, _blitArgs);
     }
 

--- a/libs/screen/image.ts
+++ b/libs/screen/image.ts
@@ -283,7 +283,7 @@ namespace helpers {
         _fillPolygon4(img, _blitArgs);
     }
 
-    export function imageDrawRotateScaled(dest: Image, destX: number, destY: number, src: Image, sx: number, sy: number, angle: number) {
+    export function imageDrawScaledRotated(dest: Image, destX: number, destY: number, src: Image, sx: number, sy: number, angle: number) {
         _blitArgs = _blitArgs || [];
         _blitArgs[0] = destX | 0;
         _blitArgs[1] = destY | 0;

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -991,27 +991,24 @@ namespace pxsim.ImageMethods {
             }
         }
 
-        const rotatedWidth = maxX - minX + 1;
-        const rotatedHeight = maxY - minY + 1;
-
         dst.makeWritable();
 
-        for (let x = 0; x < rotatedWidth; x++) {
-            for (let y = 0; y < rotatedHeight; y++) {
-                let ox = (x + minX) - (y + minY) * xShear;
-                const oy = (y + minY) - ox * yShear
-                ox = ox - oy * xShear;
+        for (let x = 0; x < scaledWidth; x++) {
+            for (let y = 0; y < scaledHeight; y++) {
+                let newX = (x + y * xShear) | 0;
+                const newY = (y + newX * yShear) | 0
+                newX = (newX + newY * xShear) | 0;
 
                 let color: number;
                 if (flip) {
-                    color = getPixel(src, (scaledWidth - ox - 1) / sx, (scaledHeight - oy - 1) / sy);
+                    color = getPixel(src, (scaledWidth - x - 1) / sx, (scaledHeight - y - 1) / sy);
                 }
                 else {
-                    color = getPixel(src, ox / sx, oy / sy);
+                    color = getPixel(src, x / sx, y / sy);
                 }
 
                 if (!transparent || color) {
-                    setPixel(dst, xDst + x, yDst + y, color);
+                    setPixel(dst, xDst + newX - minX, yDst + newY - minY, color);
                 }
             }
         }

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -998,7 +998,7 @@ namespace pxsim.ImageMethods {
 
         angle %= TWO_PI;
         if (angle < 0) {
-            angle += Math.PI;
+            angle += TWO_PI;
         }
 
         let flip = false;
@@ -1097,8 +1097,8 @@ namespace pxsim.ImageMethods {
                 for (let x = 0; x < shearArgs.scaledWidth; x += FX_ONE) {
                     let color = getPixel(
                         src,
-                        fxToInt(fxDiv((shearArgs.scaledWidth - x - 1), shearArgs.sx)),
-                        fxToInt(fxDiv((shearArgs.scaledHeight - y - 1), shearArgs.sy))
+                        fxToInt(fxDiv((shearArgs.scaledWidth - x - FX_ONE), shearArgs.sx)),
+                        fxToInt(fxDiv((shearArgs.scaledHeight - y - FX_ONE), shearArgs.sy))
                     );
 
                     if (!color) continue;
@@ -1159,8 +1159,8 @@ namespace pxsim.ImageMethods {
                 for (let x = 0; x < shearArgs.scaledWidth; x += FX_ONE) {
                     let color = getPixel(
                         src,
-                        fxToInt(fxDiv((shearArgs.scaledWidth - x - 1), shearArgs.sx)),
-                        fxToInt(fxDiv((shearArgs.scaledHeight - y - 1), shearArgs.sy))
+                        fxToInt(fxDiv((shearArgs.scaledWidth - x - FX_ONE), shearArgs.sx)),
+                        fxToInt(fxDiv((shearArgs.scaledHeight - y - FX_ONE), shearArgs.sy))
                     );
 
                     if (!color) continue;

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -960,7 +960,7 @@ namespace pxsim.ImageMethods {
         drawScaledRotatedImage(dst, src, args);
     }
 
-    export function drawScaledRotatedImage(dst: RefImage, src: RefImage, args: RefCollection) {// destX: number, destY: number, src: Image, sx: number, sy: number, angle: number) {
+    export function drawScaledRotatedImage(dst: RefImage, src: RefImage, args: RefCollection) {
         const xDst = args.getAt(0) as number;
         const yDst = args.getAt(1) as number;
         const sx = ((args.getAt(2) as number) * FX_ONE);
@@ -971,24 +971,17 @@ namespace pxsim.ImageMethods {
             return;
         }
 
-        // Get the angle into a nice range
         angle %= TWO_PI;
         if (angle < 0) {
             angle += Math.PI;
         }
 
-        // The shear process below only works for -90 to 90.
-        // Outside that range, we need to do a 180 rotation first
         let flip = false;
         if (angle > HALF_PI && angle <= THREE_HALF_PI) {
             flip = true
             angle = (angle + Math.PI) % TWO_PI
         }
 
-        // We're doing 3 shears:
-        // 1. shear x by -tan(angle / 2)
-        // 2. shear y by sin(angle)
-        // 3. shear x by -tan(angle / 2) again
         const xShear = (-Math.tan(angle / 2) * FX_ONE);
         const yShear = (Math.sin(angle) * FX_ONE);
 


### PR DESCRIPTION
this PR adds a new rotation property to sprites. this property works similarly to the two scale properties (sx and sy) but instead of stretching the sprite it rotates it using the "three shears" algorithm. this adds two new properties to the sprite dropdown:


![image](https://github.com/user-attachments/assets/9e764bbb-0c2c-4459-b2fb-880ec76b372c)

they both map to the same thing but obviously use different units. radians is what you want if you're going to be using this with trigonometric functions like sin and cos, but degrees is easier to understand/think about. 

the drawing for the rotation is implemented in c++ with fixed point math and it runs pretty well on hardware, though it's still much slower than non-rotated sprites. however, because we're talking about rotating pixel art here, the results don't always look amazing especially for smaller sprites. for example, here is our friend the duck rotated about 45 degrees:

![image](https://github.com/user-attachments/assets/da21eeb7-e838-49e4-8ce3-ea4d2786ed4f)

however it looks much better for larger sprites:

![image](https://github.com/user-attachments/assets/ce5fc6cd-5ee4-4f44-b47d-39b49a5fb295)

and even better when in motion, which is what i mainly think this will be used for:

![rotating-house](https://github.com/user-attachments/assets/d259568a-9205-4cc9-bd33-10efd56a14a0)

this implementation is also compatible with scaling. scaling is applied *before* rotation, like so:                   

![stretchy-house-final](https://github.com/user-attachments/assets/5762d7fe-9f0d-4c21-98fc-d7b2feee54a7)


now for some caveats:

1. ~in order to make this performant, **sprite overlaps for rotated sprites are *not* pixel-perfect**. instead, they are calculated based on the rotated rectangle of the sprite. this is really only an issue for sprites that have a lot of transparency in their images~
2. **the tilemap hitbox of the rotated sprite is the axis aligned bounding box for the whole rotated image**. for long sprites, this can look a little weird but it's exactly the same as it would be if you were to draw the rotated image for the sprite. see below for an image of what this looks like

and here is the promised picture of the hitbox for a rotated and scaled sprite. the red box indicates the hitbox:

![image](https://github.com/user-attachments/assets/0f9c36c1-71d4-45f8-be02-39e0d997a74e)

