### PR TITLE
fix pause until bug, change pointer events back

### DIFF
--- a/libs/browser-events/browserEvents.ts
+++ b/libs/browser-events/browserEvents.ts
@@ -4,8 +4,8 @@
 //% block="Browser Events"
 namespace browserEvents {
     export enum Event {
-        PointerDown = 6858,
-        PointerUp = 6857,
+        PointerDown = 6857,
+        PointerUp = 6858,
         PointerMove = 6859,
         PointerLeave = 6860,
         PointerEnter = 6861,
@@ -39,8 +39,8 @@ namespace browserEvents {
         protected releaseListeners: ((x: number, y: number) => void)[];
 
         constructor(public id: number) {
-            control.internalOnEvent(Event.PointerDown, this.id, () => this.setPressed(false), 16);
-            control.internalOnEvent(Event.PointerUp, this.id, () => this.setPressed(true), 16);
+            control.internalOnEvent(Event.PointerDown, this.id, () => this.setPressed(true), 16);
+            control.internalOnEvent(Event.PointerUp, this.id, () => this.setPressed(false), 16);
 
             this._pressed = false;
             this.pressListeners = [];
@@ -93,12 +93,12 @@ namespace browserEvents {
         //% block="pause until $this mouse button is $event"
         //% group="Mouse"
         //% weight=30
-        pauseUntil(event: KeyEvent) {
+        pauseUntil(event: MouseButtonEvent) {
             control.waitForEvent(event, this.id)
         }
 
-        addEventListener(event: KeyEvent, handler: (x: number, y: number) => void) {
-            if (event === KeyEvent.Pressed) {
+        addEventListener(event: MouseButtonEvent, handler: (x: number, y: number) => void) {
+            if (event === MouseButtonEvent.Pressed) {
                 this.pressListeners.push(handler);
             }
             else {
@@ -106,8 +106,8 @@ namespace browserEvents {
             }
         }
 
-        removeEventListener(event: KeyEvent, handler: (x: number, y: number) => void) {
-            if (event === KeyEvent.Pressed) {
+        removeEventListener(event: MouseButtonEvent, handler: (x: number, y: number) => void) {
+            if (event === MouseButtonEvent.Pressed) {
                 this.pressListeners = this.pressListeners.filter(p => p !== handler);
             }
             else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/6884

There are three bugs in this issue. One and three I technically already addressed here: https://github.com/microsoft/pxt-common-packages/pull/1508, but when testing and poking for _this_ bug, I realized that the pointer events had the correct associated numbers and we were actually handling the pressed state wrong. I just assumed that flipping them would be the solution since that was the fix for the mouse and wheel bug also fixed in the above PR. By flipping them, I actually introduced the same bug in the more generic `browswerEvents` block. I've switched the numbers back and fixed where the actual problem was with pressed so all of the events blocks behave as expected now.

Bug 2 in that issue helped reveal the problems above and is also fixed by using `MouseButtonEvent` rather than `KeyEvent`. `KeyEvent` still has pressed and released, but `MouseButtonEvent` has the correct event number that we want, so I made sure that all places with `KeyEvent` has been replaced with `MouseButtonEvent`.