### PR TITLE
address some bits of feedback on the browser events extension

### DIFF
--- a/libs/browser-events/browserEvents.cpp
+++ b/libs/browser-events/browserEvents.cpp
@@ -28,6 +28,10 @@ int wheelDz() {
 }
 
 //%
+void _setCursorVisible(bool visible) {
+}
+
+//%
 int currentTime() {
     return -1;
 }

--- a/libs/browser-events/browserEvents.ts
+++ b/libs/browser-events/browserEvents.ts
@@ -4,29 +4,47 @@
 //% block="Browser Events"
 namespace browserEvents {
     export enum Event {
+        //% block="pointer down"
         PointerDown = 6857,
+        //% block="pointer up"
         PointerUp = 6858,
+        //% block="pointer move"
         PointerMove = 6859,
+        //% block="pointer leave"
         PointerLeave = 6860,
+        //% block="pointer enter"
         PointerEnter = 6861,
+        //% block="pointer cancel"
         PointerCancel = 6862,
+        //% block="pointer over"
         PointerOver = 6863,
+        //% block="pointer out"
         PointerOut = 6864,
+        //% block="wheel"
         Wheel = 6865,
+        //% block="key down"
         KeyDown = 6866,
+        //% block="key up"
         KeyUp = 6867
     }
 
     export enum MouseButtonId {
+        //% block="left"
         Left = 1,
+        //% block="right"
         Right = 3,
+        //% block="wheel"
         Wheel = 2,
+        //% block="back"
         Back = 4,
+        //% block="forward"
         Forward = 5
     }
 
     export enum MouseButtonEvent {
+        //% block="pressed"
         Pressed = Event.PointerDown,
+        //% block="released"
         Released = Event.PointerUp,
     }
 
@@ -145,6 +163,14 @@ namespace browserEvents {
         control.onEvent(Event.Wheel, 0, () => {
             handler(wheelDx(), wheelDy(), wheelDz());
         });
+    }
+
+    //% blockId=browserEvents_setCursorVisible
+    //% block="set cursor visible $visible"
+    //% group="Mouse"
+    //% weight=0
+    export function setCursorVisible(visible: boolean) {
+        _setCursorVisible(visible);
     }
 
     //% fixedInstance whenUsed block="left"

--- a/libs/browser-events/keyboard.ts
+++ b/libs/browser-events/keyboard.ts
@@ -62,12 +62,22 @@ namespace browserEvents {
         ArrowRight = 39,
         PageDown = 34,
         End = 35,
-        Home = 36
+        Home = 36,
+        LeftShift = 1016,
+        RightShift = 1017,
+        LeftControl = 1018,
+        RightControl = 1019,
+        Backspace = 8,
+        Delete = 46,
     }
 
     export enum KeyEvent {
+        //% block="pressed"
         Pressed,
-        Released
+        //% block="released"
+        Released,
+        //% block="repeat"
+        Repeat
     }
 
     export function keyToString(key: Key) {
@@ -198,44 +208,171 @@ namespace browserEvents {
                 return "-";
             case Key.Equals:
                 return "=";
+            case Key.LeftShift:
+                return "LeftShift";
+            case Key.RightShift:
+                return "RightShift";
+            case Key.LeftControl:
+                return "LeftControl";
+            case Key.RightControl:
+                return "RightControl";
+            case Key.Backspace:
+                return "Backspace";
+            case Key.Delete:
+                return "Delete";
         }
     }
 
+    //% whenUsed
+    let _buttonsPendingInit: KeyButton[];
 
-    //% fixedInstances
-    export class KeyButton {
-        protected _pressed: boolean;
+    let defaultRepeatDelay = 500;
+    let defaultRepeatInterval = 30;
+
+    class KeySceneState {
         protected pressHandler: () => void;
         protected pressListeners: (() => void)[];
         protected releaseHandler: () => void;
         protected releaseListeners: (() => void)[];
+        protected repeatHandler: () => void;
+        protected repeatListeners: (() => void)[];
 
         constructor(public id: number) {
-            control.onEvent(Event.KeyUp, this.id, () => this.setPressed(false), 16);
-            control.onEvent(Event.KeyDown, this.id, () => this.setPressed(true), 16);
-
-            this._pressed = false;
             this.pressListeners = [];
             this.releaseListeners = [];
+            this.repeatListeners = [];
+        }
+
+        onEvent(event: KeyEvent, handler: () => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressHandler = handler;
+            }
+            else if (event === KeyEvent.Released) {
+                this.releaseHandler = handler;
+            }
+            else {
+                this.repeatHandler = handler;
+            }
+        }
+
+        addEventListener(event: KeyEvent, handler: () => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressListeners.push(handler);
+            }
+            else if (event === KeyEvent.Released) {
+                this.releaseListeners.push(handler);
+            }
+            else {
+                this.repeatListeners.push(handler);
+            }
+        }
+
+        removeEventListener(event: KeyEvent, handler: () => void) {
+            if (event === KeyEvent.Pressed) {
+                this.pressListeners = this.pressListeners.filter(p => p !== handler);
+            }
+            else if (event === KeyEvent.Released) {
+                this.releaseListeners = this.releaseListeners.filter(p => p !== handler);;
+            }
+            else {
+                this.repeatListeners = this.repeatListeners.filter(p => p !== handler);
+            }
+        }
+
+        raiseButtonPressed() {
+            if (this.pressHandler) {
+                this.pressHandler();
+            }
+            for (const handler of this.pressListeners) {
+                handler();
+            }
+        }
+
+        raiseButtonReleased() {
+            if (this.releaseHandler) {
+                this.releaseHandler();
+            }
+            for (const handler of this.releaseListeners) {
+                handler();
+            }
+        }
+
+        raiseButtonRepeat() {
+            if (this.repeatHandler) {
+                this.repeatHandler();
+            }
+            for (const handler of this.repeatListeners) {
+                handler();
+            }
+        }
+    }
+
+    //% fixedInstances
+    export class KeyButton {
+        protected _pressed: boolean;
+        public repeatDelay: number;
+        public repeatInterval: number;
+        private _repeatCount: number;
+        private _pressedElapsed: number;
+
+        protected sceneStack: KeySceneState[];
+
+        protected get state(): KeySceneState {
+            return this.sceneStack[this.sceneStack.length - 1];
+        }
+
+        constructor(public id: number) {
+            // use internalOnEvent so that events fire regardless of the current scen
+            control.internalOnEvent(Event.KeyUp, this.id, () => this.setPressed(false), 16);
+            control.internalOnEvent(Event.KeyDown, this.id, () => this.setPressed(true), 16);
+            this._pressed = false;
+
+            // this code may run before game/scene.ts, in which case calling this.__registerUpdate
+            // will trigger an exception. to prevent that, start a thread that pauses until we
+            // detect that an event context has been registered and then call it
+            if (control.eventContext()) {
+                this.__registerUpdate();
+            }
+            else {
+                if (!_buttonsPendingInit) {
+                    _buttonsPendingInit = [];
+                    control.runInBackground(() => {
+                        pauseUntil(() => !!control.eventContext());
+                        for (const button of _buttonsPendingInit) {
+                            button.__registerUpdate();
+                        }
+                        _buttonsPendingInit = undefined;
+                    });
+                }
+                _buttonsPendingInit.push(this);
+            }
+
+            this.sceneStack = [new KeySceneState(id)];
+
+            game.addScenePushHandler(() => {
+                this.sceneStack.push(new KeySceneState(id));
+                this.__registerUpdate();
+            });
+            game.addScenePopHandler(() => {
+                this.sceneStack.pop();
+                if (this.sceneStack.length === 0) {
+                    this.sceneStack = [new KeySceneState(id)];
+                    this.__registerUpdate();
+                }
+            });
         }
 
         setPressed(pressed: boolean) {
+            if (this._pressed === pressed) return;
+
             this._pressed = pressed;
             if (pressed) {
-                if (this.pressHandler) {
-                    this.pressHandler();
-                }
-                for (const handler of this.pressListeners) {
-                    handler();
-                }
+                this._repeatCount = 0;
+                this._pressedElapsed = 0;
+                this.state.raiseButtonPressed();
             }
             else {
-                if (this.releaseHandler) {
-                    this.releaseHandler();
-                }
-                for (const handler of this.releaseListeners) {
-                    handler();
-                }
+                this.state.raiseButtonReleased();
             }
         }
 
@@ -244,12 +381,7 @@ namespace browserEvents {
         //% group="Keyboard"
         //% weight=100
         onEvent(event: KeyEvent, handler: () => void) {
-            if (event === KeyEvent.Pressed) {
-                this.pressHandler = handler;
-            }
-            else {
-                this.releaseHandler = handler;
-            }
+            this.state.onEvent(event, handler);
         }
 
         //% blockId=browserEvents_key_isPressed
@@ -269,21 +401,33 @@ namespace browserEvents {
         }
 
         addEventListener(event: KeyEvent, handler: () => void) {
-            if (event === KeyEvent.Pressed) {
-                this.pressListeners.push(handler);
-            }
-            else {
-                this.releaseListeners.push(handler);
-            }
+            this.state.addEventListener(event, handler);
         }
 
         removeEventListener(event: KeyEvent, handler: () => void) {
-            if (event === KeyEvent.Pressed) {
-                this.pressListeners = this.pressListeners.filter(p => p !== handler);
+            this.state.removeEventListener(event, handler);
+        }
+
+        __update() {
+            const delay = this.repeatDelay === undefined ? defaultRepeatDelay : this.repeatDelay;
+            const interval = this.repeatInterval === undefined ? defaultRepeatInterval : this.repeatInterval;
+            if (!this._pressed) return;
+            this._pressedElapsed += game.eventContext().deltaTimeMillis;
+
+            // inital delay
+            if (this._pressedElapsed < delay)
+                return;
+
+            // repeat count for this step
+            const count = Math.floor((this._pressedElapsed - delay - interval) / interval);
+            if (count != this._repeatCount) {
+                this._repeatCount = count;
+                this.state.raiseButtonRepeat();
             }
-            else {
-                this.releaseListeners = this.releaseListeners.filter(p => p !== handler);
-            }
+        }
+
+        __registerUpdate() {
+            game.eventContext().registerFrameHandler(scene.CONTROLLER_PRIORITY, () => this.__update());
         }
     }
 
@@ -477,5 +621,34 @@ namespace browserEvents {
     export const Home = new KeyButton(Key.Home);
 
     //% fixedInstance whenUsed
+    export const LeftShift = new KeyButton(Key.LeftShift);
+
+    //% fixedInstance whenUsed
+    export const RightShift = new KeyButton(Key.RightShift);
+
+    //% fixedInstance whenUsed
+    export const LeftControl = new KeyButton(Key.LeftControl);
+
+    //% fixedInstance whenUsed
+    export const RightControl = new KeyButton(Key.RightControl);
+
+    //% fixedInstance whenUsed
+    export const Backspace = new KeyButton(Key.Backspace);
+
+    //% fixedInstance whenUsed
+    export const Delete = new KeyButton(Key.Delete);
+
+    //% fixedInstance whenUsed
     export const Any = new KeyButton(0);
+
+    //% blockId=browser_events_setKeyboardRepeatDefault
+    //% block="set keyboard repeat delay $delay ms interval $interval ms"
+    //% delay.defl=500
+    //% interval.defl=30
+    //% group="Keyboard"
+    //% weight=0
+    export function setKeyboardRepeatDefault(delay: number, interval: number) {
+        defaultRepeatDelay = Math.max(delay, 0);
+        defaultRepeatInterval = Math.max(interval, 1);
+    }
 }

--- a/libs/browser-events/shims.d.ts
+++ b/libs/browser-events/shims.d.ts
@@ -9,6 +9,8 @@ declare namespace browserEvents {
     function wheelDy(): number;
     //% shim=browserEvents::wheelDz
     function wheelDz(): number;
+    //% shim=browserEvents::_setCursorVisible
+    function _setCursorVisible(visible: boolean): void;
 
     //% shim=browserEvents::currentTime
     function currentTime(): number;

--- a/libs/browser-events/sim/keyboard.ts
+++ b/libs/browser-events/sim/keyboard.ts
@@ -62,15 +62,44 @@ namespace pxsim.browserEvents {
         ArrowRight = 39,
         PageDown = 34,
         End = 35,
-        Home = 36
+        Home = 36,
+        LeftShift = 1016,
+        RightShift = 1017,
+        LeftControl = 1018,
+        RightControl = 1019,
+        Backspace = 8,
+        Delete = 46,
     }
 
     export function onKeyboardEvent(event: KeyboardEvent, pressed: boolean) {
+        const eventValue = getValueForKey(event);
+
+        fireEvent(eventValue as Key, pressed);
+
+        if (eventValue === Key.Shift) {
+            if (event.location === event.DOM_KEY_LOCATION_LEFT) {
+                fireEvent(Key.LeftShift, pressed);
+            }
+            else if (event.location === event.DOM_KEY_LOCATION_RIGHT) {
+                fireEvent(Key.RightShift, pressed);
+            }
+        }
+        if (eventValue === Key.Control) {
+            if (event.location === event.DOM_KEY_LOCATION_LEFT) {
+                fireEvent(Key.LeftControl, pressed);
+            }
+            else if (event.location === event.DOM_KEY_LOCATION_RIGHT) {
+                fireEvent(Key.RightControl, pressed);
+            }
+        }
+    }
+
+    function fireEvent(key: Key, pressed: boolean) {
         if (pressed) {
-            board().bus.queue(6866, getValueForKey(event));
+            board().bus.queue(6866, key);
         }
         else {
-            board().bus.queue(6867, getValueForKey(event));
+            board().bus.queue(6867, key);
         }
     }
 
@@ -249,6 +278,10 @@ namespace pxsim.browserEvents {
                 return Key.End;
             case "Home":
                 return Key.Home;
+            case "Delete":
+                return Key.Delete;
+            case "Backspace":
+                return Key.Backspace;
             default:
                 return 0;
         }


### PR DESCRIPTION
this PR does a few things to address various bits of feedback from the forum

* fixes the casing on all of the event names to be consistent with our other event blocks
* adds a few missing keys to the keyboard events: delete, backspace, left shift, right shift, left control, right control
* adds a `setCursorVisible` API that lets you hide the mouse cursor on the game screen
* adds a "repeat" event to the keyboard events along with a new block for setting the delay/interval (just like in controller)
* makes the keyboard events play nicely with push/pop scene. previously it only worked for the bottom scene

note that i added backspace, but i think backspace is mapped to the simulator restart by default so that needs to be remapped before people actually use it in their programs. i think we have an extension for doing that, right?

also this PR requires my changes to pxt-arcade-sim which are currently also in pr