### PR TITLE
fix queueing of browser events and handle scenes with the mouse

### DIFF
--- a/libs/browser-events/sim/keyboard.ts
+++ b/libs/browser-events/sim/keyboard.ts
@@ -96,10 +96,10 @@ namespace pxsim.browserEvents {
 
     function fireEvent(key: Key, pressed: boolean) {
         if (pressed) {
-            board().bus.queue(6866, key);
+            board().bus.queue(INTERNAL_KEY_DOWN, key);
         }
         else {
-            board().bus.queue(6867, key);
+            board().bus.queue(INTERNAL_KEY_UP, key);
         }
     }
 

--- a/libs/browser-events/sim/mouseState.ts
+++ b/libs/browser-events/sim/mouseState.ts
@@ -5,6 +5,11 @@ namespace pxsim.browserEvents {
 
     const THROTTLE_INTERVAL = 50;
 
+    export const INTERNAL_KEY_DOWN = 6870;
+    export const INTERNAL_KEY_UP = 6871;
+    export const INTERNAL_POINTER_DOWN = 6868;
+    export const INTERNAL_POINTER_UP = 6869;
+
     export type MouseEvent = "pointerdown" | "pointerup" | "pointermove" | "pointerleave" | "pointerenter" | "pointercancel" | "pointerover" | "pointerout";
     export class MouseState {
         protected x: number;
@@ -43,10 +48,19 @@ namespace pxsim.browserEvents {
                 "pointerout",
             ];
 
+            let eventId = 6857 + events.indexOf(event.type);
+
+            if (event.type === "pointerdown") {
+                eventId = INTERNAL_POINTER_DOWN;
+            }
+            else if (event.type === "pointerup") {
+                eventId = INTERNAL_POINTER_UP;
+            }
+
             // We add 1 to the button here because the left button is 0 and
             // that's used as a wildcard in our event bus
             board().bus.queue(
-                6857 + events.indexOf(event.type),
+                eventId,
                 (event.button || 0) + 1
             );
         }


### PR DESCRIPTION
this fixes a bug reported on the forum here: https://forum.makecode.com/t/browser-events-extension-bug/35709

basically the bug worked like this:
1. someone presses a button and the simulator fires the pressed event
2. the game engine updates the pressed state of the button to true and invokes the user's button handler
3. the button handler pauses for some amount of time
4. the button is released and the simulator fires the released event
5. the game engine updates the pressed state of the button to false
6. the user presses the button a second time
7. because the button handler from step 3 is still paused, the pressed event is queued by the event bus
8. the button is released
9. the handler from step 3 finishes pausing and the queued event from step 7 is invoked
10. the game engine updates the button to "pressed" even though the corresponding released event already fired in step 8. the button is now stuck in the "pressed" state


to fix it, i did the same thing that we do for controller buttons which is to create separate internal events for pressed/released that we can subscribe to in the game engine (whereas the public pressed/released events are subscribed to by the user code). this prevents the queueing behavior from delaying the update of the button state.

i also refactored the mouse button code so that it too handles scene push/pop, which i forgot to do  in https://github.com/microsoft/pxt-common-packages/pull/1514