### PR TITLE
Remove mixer libs dependencies on game package

### DIFF
--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -174,7 +174,10 @@ namespace game {
         const oldScene = game.currentScene()
         particles.clearAll();
         particles.disableAll();
-        if (!_sceneStack) _sceneStack = [];
+        if (!_sceneStack) {
+            _sceneStack = [];
+            music._initializeSceneStack(game.addScenePushHandler, game.addScenePopHandler);
+        }
         _sceneStack.push(_scene);
         init(/** forceNewScene **/ true);
 
@@ -300,7 +303,7 @@ namespace game {
     /**
      * Set the message that displays when the game is over
      * @param win whether the message should show on a win (true) or lose (false)
-     * @param message 
+     * @param message
      */
     //% blockId=game_setgameovermessage
     //% block="use message $message for $win"

--- a/libs/mixer/playable.ts
+++ b/libs/mixer/playable.ts
@@ -32,12 +32,16 @@ namespace music {
     function _init() {
         if (stateStack) return;
         stateStack = [new PlayableState()];
+    }
 
-        game.addScenePushHandler(() => {
+    export function _initializeSceneStack(addScenePushHandler: (handler: () => void) => void, addScenePopHandler: (handler: () => void) => void) {
+        _init();
+
+        addScenePushHandler(() => {
             stateStack.push(new PlayableState());
         });
 
-        game.addScenePopHandler(() => {
+        addScenePopHandler(() => {
             stateStack.pop();
             if (stateStack.length === 0) stateStack.push(new PlayableState());
         });

--- a/libs/mixer/soundEffect.ts
+++ b/libs/mixer/soundEffect.ts
@@ -307,7 +307,7 @@ namespace music {
         if (res.waveShape === WaveShape.Noise) {
             // The primary waveforms don't produce sounds that are similar to noise,
             // but adding an effect sorta does
-            if (Math.percentChance(20)) {
+            if (Math.random() < 0.2) {
                 res.waveShape = randomWave();
                 res.effect = randomEffect();
             }
@@ -317,7 +317,7 @@ namespace music {
 
             // Adding an effect can drastically alter the sound, so keep it
             // at a low percent chance unless there already is one
-            if (res.effect !== SoundExpressionEffect.None || Math.percentChance(10)) {
+            if (res.effect !== SoundExpressionEffect.None || Math.random() < 0.1) {
                 res.effect = randomEffect();
             }
         }


### PR DESCRIPTION
fixes the two places where the mixer lib has a dependency on the game package, which it doesn't actually need and is preventing maker from building. i should have fixed this a while ago...