### PR TITLE
add a math constants block

### DIFF
--- a/libs/base/math.ts
+++ b/libs/base/math.ts
@@ -1,12 +1,27 @@
 namespace Math {
-
-    export const E = 2.718281828459045;
-    export const LN2 = 0.6931471805599453;
-    export const LN10 = 2.302585092994046;
-    export const LOG2E = 1.4426950408889634;
-    export const LOG10E = 0.4342944819032518;
+    //% blockIdentity="Math._constant"
+    //% block="π"
     export const PI = 3.141592653589793;
+    //% blockIdentity="Math._constant"
+    //% block="e"
+    export const E = 2.718281828459045;
+    //% blockIdentity="Math._constant"
+    //% block="ln(2)"
+    export const LN2 = 0.6931471805599453;
+    //% blockIdentity="Math._constant"
+    //% block="ln(10)"
+    export const LN10 = 2.302585092994046;
+    //% blockIdentity="Math._constant"
+    //% block="log₂(e)"
+    export const LOG2E = 1.4426950408889634;
+    //% blockIdentity="Math._constant"
+    //% block="log₁₀(e)"
+    export const LOG10E = 0.4342944819032518;
+    //% blockIdentity="Math._constant"
+    //% block="√½"
     export const SQRT1_2 = 0.7071067811865476;
+    //% blockIdentity="Math._constant"
+    //% block="√2"
     export const SQRT2 = 1.4142135623730951;
 
     /**
@@ -22,7 +37,7 @@ namespace Math {
     //% inlineInputMode=inline
     export function map(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
-    }    
+    }
 
     /**
      * Constrains a number to be within a range
@@ -59,7 +74,7 @@ namespace Math {
         let b = b_m16[s2];
         let m16 = b_m16[s2+1];
         let mx = (m16 * secoffset) >> 4;
-        
+
         let y = mx + b;
         if( theta & 0x80 ) y = -y;
 
@@ -69,12 +84,20 @@ namespace Math {
     }
 
     /**
-     * Returns the cosine of an input angle. This is an 8-bit approximation. 
+     * Returns the cosine of an input angle. This is an 8-bit approximation.
      * @param theta input angle from 0-255
      */
     //% help=math/icos weight=10 advanced=true blockGap=8
     export function icos(theta: number) {
         return isin(theta + 16384);
+    }
+
+    //% shim=TD_ID
+    //% block="$MEMBER"
+    //% constantShim
+    //% weight=0
+    export function _constant(MEMBER: number): number {
+        return MEMBER;
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-microbit/issues/4276

adds a math constants block with all the usual constants, but most importantly pi

we already have all of the trigonometric functions in the toolbox, and you really need PI for them to be useful. 

![image](https://github.com/user-attachments/assets/3b7eed6c-95ff-419b-9b40-bb18fd39c724)
![image](https://github.com/user-attachments/assets/ca6209bb-2f5f-442f-87f6-f47f35fbffcd)
