### PR TITLE
match hardware limits on image width/height in sim

### DIFF
--- a/libs/game/sprite.ts
+++ b/libs/game/sprite.ts
@@ -316,6 +316,10 @@ class Sprite extends sprites.BaseSprite {
     constructor(img: Image) {
         super(scene.SPRITE_Z);
 
+        if (!img) {
+            throw "Sprite image cannot be undefined or null";
+        }
+
         this._x = Fx8(screen.width - img.width >> 1);
         this._y = Fx8(screen.height - img.height >> 1);
         this._lastX = this._x;

--- a/libs/screen/sim/image.ts
+++ b/libs/screen/sim/image.ts
@@ -1393,9 +1393,10 @@ namespace pxsim.image {
 
 
     export function create(w: number, h: number) {
-        // truncate decimal sizes
-        w |= 0
-        h |= 0
+        w |= 0;
+        h |= 0;
+        if (w < 0 || h < 0 || w > 2000 || h > 2000)
+            return undefined;
         return new RefImage(w, h, getScreenState().bpp())
     }
 


### PR DESCRIPTION
reported on the forum here: https://forum.makecode.com/t/makecode-crashes-when-filling-and-image-that-has-negative-size/37137

also adds an error message in the sprite constructor for when the image is null or undefined instead of a more arcane internal error message. unfortunately, not localizable (yet)