### PR TITLE
[pxt-cli] bump version to v12.3.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pxt-common-packages",
-  "version": "12.3.30",
+  "version": "12.3.31",
   "description": "Microsoft MakeCode (PXT) common packages",
   "keywords": [
     "MakeCode",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `pxt bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.