### PR TITLE
Add an error message in the problems panel for when the condition is false.

### DIFF
--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -171,7 +171,7 @@ namespace control {
     export declare function programName(): string;
 
     //% shim=control::_ramSize
-   declare function _ramSize(): number
+   declare function _ramSize(): number;
     
     /** Returns estimated size of memory in bytes. */
     export function ramSize() {

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -176,7 +176,7 @@ namespace control {
     /** Returns estimated size of memory in bytes. */
     export function ramSize() {
         return getConfigValue(DAL.CFG_RAM_BYTES, 0) || _ramSize();
-    }
+     }
 
     /** Runs the function and returns run time in microseconds. */
     export function benchmark(f: () => void) {

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -81,7 +81,7 @@ namespace control {
             ? `Assertion failed, code: ${code})`
             : `Assertion failed`
 
-        console.log("Assertion failed")
+        console.log(msg)
         if (code !== undefined) console.log(code)
         dmesg(msg)
         _throwValue(msg)

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -83,7 +83,6 @@ namespace control {
         console.log("Assertion failed")
         if (code !== undefined) console.log(code)
         dmesg(msg)
-        debugger
         _throwValue(msg)
     }
    }

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -78,7 +78,7 @@ namespace control {
        // adapted this idea from how real browsers work and optionally kept the code parameter for convenience
     if (!cond) {
         const msg = code !== undefined
-            ? `Assertion failed, code: ${code})`
+            ? `Assertion failed, code: ${code}`
             : `Assertion failed`
         console.log(msg)
         dmesg(msg)

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -64,14 +64,20 @@ namespace control {
     //% shim=pxtrt::panic
     export function panic(code: number) { }
 
+    //% shim=U::userError
+    function _throwValue(msg: string) { }
+
     /**
-     * Display an error code and stop the program when the assertion is `false`.
+     * Display a message, an error code, and stop the program when the assertion is `false`.
      */
     //% help=control/assert weight=30
     //% blockId="control_assert" block="assert %cond|with value %code"
     export function assert(cond: boolean, code: number) {
         if (!cond) {
-            fail("Assertion failed, code=" + code)
+            console.log("Assertion failed")
+            console.log(code)
+            dmesg("Assertion failed: " + code)
+            _throwValue("Assertion failed: " + code)
         }
     }
 

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -75,9 +75,10 @@ namespace control {
     //% help=control/assert weight=30
     //% blockId="control_assert" block="assert %cond|with value %code"
     export function assert(cond: boolean, code?: number) {
+       // adapted this idea from how real browsers work and optionally kept the code parameter for convenience
     if (!cond) {
         const msg = code !== undefined
-            ? `Assertion failed (code ${code})`
+            ? `Assertion failed, code: ${code})`
             : `Assertion failed`
 
         console.log("Assertion failed")

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -69,7 +69,8 @@ namespace control {
     function _throwValue(msg: string) { }
 
     /**
-     * Display a message, an error code, and stop the program when the assertion is `false`.
+     * Display an error message, an error code, and stop the program when the assertion is `false`.
+      @code (optional) an error number to display. eg: 5
      */
     //% help=control/assert weight=30
     //% blockId="control_assert" block="assert %cond|with value %code"
@@ -82,6 +83,7 @@ namespace control {
         console.log("Assertion failed")
         if (code !== undefined) console.log(code)
         dmesg(msg)
+        debugger
         _throwValue(msg)
     }
    }
@@ -169,10 +171,8 @@ namespace control {
     export declare function programName(): string;
 
     //% shim=control::_ramSize
-    function _ramSize() {
-        return 32 * 1024 * 1024;
-    }
-
+   declare function _ramSize(): number
+    
     /** Returns estimated size of memory in bytes. */
     export function ramSize() {
         return getConfigValue(DAL.CFG_RAM_BYTES, 0) || _ramSize();

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -74,10 +74,10 @@ namespace control {
     //% blockId="control_assert" block="assert %cond|with value %code"
     export function assert(cond: boolean, code: number) {
         if (!cond) {
-            console.log("Assertion failed")
+            console.log("Assertion failed. CODE:")
             console.log(code)
-            dmesg("Assertion failed: " + code)
-            _throwValue("Assertion failed: " + code)
+            dmesg("Assertion failed. CODE: " + code)
+            _throwValue("Assertion failed. CODE: " + code)
         }
     }
 

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -72,14 +72,19 @@ namespace control {
      */
     //% help=control/assert weight=30
     //% blockId="control_assert" block="assert %cond|with value %code"
-    export function assert(cond: boolean, code: number) {
-        if (!cond) {
-            console.log("Assertion failed. CODE:")
-            console.log(code)
-            dmesg("Assertion failed. CODE: " + code)
-            _throwValue("Assertion failed. CODE: " + code)
-        }
+    export function assert(cond: boolean, code?: number) {
+    if (!cond) {
+        const msg = code !== undefined
+            ? `Assertion failed (code ${code})`
+            : `Assertion failed`
+
+        console.log("Assertion failed")
+        if (code !== undefined) console.log(code)
+        dmesg(msg)
+        _throwValue(msg)
     }
+   }
+
 
     export function fail(message: string) {
         console.log("Fatal failure: ")

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -77,6 +77,8 @@ namespace control {
     export function assert(cond: boolean, code?: number) {
          if (!cond) {
          // adapted this idea from how real browsers work and optionally kept the code parameter for clearer diagnostics
+         // added the message also because the original one for receiving the message is only logged
+         // in the console, not together in the panel
          const msg = code !== undefined
             ? `Assertion failed, code: ${code}`
             : `Assertion failed`

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -80,9 +80,7 @@ namespace control {
         const msg = code !== undefined
             ? `Assertion failed, code: ${code})`
             : `Assertion failed`
-
         console.log(msg)
-        if (code !== undefined) console.log(code)
         dmesg(msg)
         _throwValue(msg)
     }

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -55,6 +55,7 @@ namespace control {
 
         UNHANDLED_EXCEPTION = 999,
     }
+    
     /**
      * Display an error code and stop the program.
      * @param code an error number to display. eg: 5
@@ -84,7 +85,6 @@ namespace control {
         _throwValue(msg)
     }
    }
-
 
     export function fail(message: string) {
         console.log("Fatal failure: ")

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -75,16 +75,17 @@ namespace control {
     //% help=control/assert weight=30
     //% blockId="control_assert" block="assert %cond|with value %code"
     export function assert(cond: boolean, code?: number) {
-       // adapted this idea from how real browsers work and optionally kept the code parameter for convenience
-    if (!cond) {
-        const msg = code !== undefined
+         if (!cond) {
+         // adapted this idea from how real browsers work and optionally kept the code parameter for clearer diagnostics
+         const msg = code !== undefined
             ? `Assertion failed, code: ${code}`
             : `Assertion failed`
-        console.log(msg)
-        dmesg(msg)
-        _throwValue(msg)
+       
+         console.log(msg)
+         dmesg(msg)
+         _throwValue(msg)
+         }
     }
-   }
 
     export function fail(message: string) {
         console.log("Fatal failure: ")

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -13,7 +13,7 @@ You can insist that your program will stop at an assert block if a certain condi
 * **cond**: a [boolean](/types/boolean) where true means everything is ok or false which means, stop the program!
 * **code**: an optional parameter for displaying an error [number](/types/number) you match to an error situation in your program.
 
-## Example #example
+## Example 
 
 Stop the program if a sensor connected to pin `A0` sends a low (`0`) signal.
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -1,6 +1,6 @@
 # assert
 
-Display a message, error number, and stop the program if the assertion condition is false.
+Display an error message, error number, and stop the program if the assertion condition is false.
 
 ```sig
 control.assert(false, 0)

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -11,7 +11,7 @@ You can insist that your program will stop at an assert block if a certain condi
 ## Parameters
 
 * **cond**: a [boolean](/types/boolean) where true means everything is ok or false which means, stop the program!
-* **code**: an error [number](/types/number) you match to an error situation in your program.
+* **code**: an optional parameter for displaying an error [number](/types/number) you match to an error situation in your program.
 
 ## Example #example
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -24,7 +24,7 @@ forever(function () {
 })
 ```
 
-## See also #seealso
+## See also
 
 [panic](/reference/control/panic)
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -1,6 +1,6 @@
 # assert
 
-Display an error number and stop the program if the assertion condition is false.
+Display a message, error number, and stop the program if the assertion condition is false.
 
 ```sig
 control.assert(false, 0)


### PR DESCRIPTION
Added an error message in the problems panel so users can immediately see the assertion failure message there, instead of needing to always inspect it in the console log panel every time. The difference is that this function adds a panic code merged in the problems panel.

Behaves similar to the image below.
<img width="699" height="177" alt="image" src="https://github.com/user-attachments/assets/5870e4e8-019d-4de6-8a15-f92f869f0b35" />
