### PR TITLE
Add clearer message and error code reporting for failed assertions

### DIFF
--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -29,7 +29,7 @@ forever(function () {
 })
 ```
 
-## See also # see also
+## See also #see also
 
 [panic](/reference/control/panic)
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -10,9 +10,6 @@ You can insist that your program will stop at an **assert** block if a certain c
 An 'Assertion failed' message containing the error code number is generated. This message is shown in the problems panel and also output to the the serial port. The format of the message looks like this:
 
 ``Fatal failure: Assertion failed, code=49``
-
-And also in the problems panel, there will be a message displaying "Assertion failed", similar to how the serial output logs the message.
-
 ## Parameters
 
 * **cond**: a [boolean](/types/boolean) where `true` means everything is ok or `false` which means, stop the program!

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -1,19 +1,20 @@
 # assert
 
-Display an error number and stop the program if the assertion condition is false.
+Display a message, error number, and stop the program if the assertion condition is false.
 
 ```sig
 control.assert(false, 0)
 ```
 
-You can insist that your program will stop at an assert block if a certain condition you check is false. The error number in the assert is written to the serial port with a failure message.
+You can insist that your program will stop at an assert block if a certain condition you check is false. 
+An 'Assertion failed' message is shown. The error number in the assert is written to the serial port with a failure message.
 
 ## Parameters
 
 * **cond**: a [boolean](/types/boolean) where true means everything is ok or false which means, stop the program!
 * **code**: an error [number](/types/number) you match to an error situation in your program.
 
-## Example #example
+## Example 
 
 Stop the program if a sensor connected to pin `A0` sends a low (`0`) signal.
 
@@ -24,7 +25,7 @@ forever(function () {
 })
 ```
 
-## See also #seealso
+## See also 
 
 [panic](/reference/control/panic)
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -1,6 +1,6 @@
 # assert
 
-Display a message, error number, and stop the program if the assertion condition is false.
+Display a message, an error number, and stop the program if the assertion condition is false.
 
 ```sig
 control.assert(false, 0)

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -7,7 +7,8 @@ control.assert(false, 0)
 ```
 
 You can insist that your program will stop at an assert block if a certain condition you check is false. 
-An 'Assertion failed' message is shown. The error number in the assert is written to the serial port and the problems panel with a failure message.
+An 'Assertion failed' message is shown in the problems panel and in the serial port. 
+The error number is also shown the serial port and the problems panel with a failure message.
 
 ## Parameters
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -26,3 +26,11 @@ forever(function () {
     pause(1000)
 })
 ```
+
+## See also 
+
+[panic](/reference/control/panic)
+
+```package
+base
+```

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -8,7 +8,7 @@ control.assert(false, 0)
 
 You can insist that your program will stop at an assert block if a certain condition you check is false. 
 An 'Assertion failed' message is shown in the problems panel and in the serial port. 
-The error number is also shown the serial port and the problems panel with a failure message.
+The error number is also shown in the serial port and the problems panel, but with a failure message.
 
 ## Parameters
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -27,7 +27,7 @@ forever(function () {
 })
 ```
 
-## See also 
+## See also # see also
 
 [panic](/reference/control/panic)
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -1,18 +1,19 @@
 # assert
 
-Display an error message, an error number, and stop the program if the assertion condition is false.
+If a condition is false, stop the program and display an error message along with an error code.
 
 ```sig
 control.assert(false, 0)
 ```
 
-You can insist that your program will stop at an assert block if a certain condition you check is false. 
-An 'Assertion failed' message is shown in the problems panel and in the serial port. 
-The error number is also shown in the serial port and the problems panel, but with a failure message.
+You can insist that your program will stop at an **assert** block if a certain condition you check is false. 
+An 'Assertion failed' message containing the error code number is generated. This message is shown in the problems panel and also output to the the serial port. The format of the message looks like this:
+
+``Fatal failure: Assertion failed, code=49``
 
 ## Parameters
 
-* **cond**: a [boolean](/types/boolean) where true means everything is ok or false which means, stop the program!
+* **cond**: a [boolean](/types/boolean) where `true` means everything is ok or `false` which means, stop the program!
 * **code**: an error [number](/types/number) you match to an error situation in your program.
 
 ## Example 
@@ -24,12 +25,4 @@ forever(function () {
     control.assert((pins.A0.digitalRead() == 1), 15)
     pause(1000)
 })
-```
-
-## See also 
-
-[panic](/reference/control/panic)
-
-```package
-base
 ```

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -16,7 +16,7 @@ An 'Assertion failed' message containing the error code number is generated. Thi
 * **cond**: a [boolean](/types/boolean) where `true` means everything is ok or `false` which means, stop the program!
 * **code**: an error [number](/types/number) you match to an error situation in your program.
 
-## Example 
+## Example #example
 
 Stop the program if a sensor connected to pin `A0` sends a low (`0`) signal.
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -1,13 +1,13 @@
 # assert
 
-Display a message, an error number, and stop the program if the assertion condition is false.
+Display an error message, an error number, and stop the program if the assertion condition is false.
 
 ```sig
 control.assert(false, 0)
 ```
 
 You can insist that your program will stop at an assert block if a certain condition you check is false. 
-An 'Assertion failed' message is shown. The error number in the assert is written to the serial port with a failure message.
+An 'Assertion failed' message is shown. The error number in the assert is written to the serial port and the problems panel with a failure message.
 
 ## Parameters
 

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -11,6 +11,8 @@ An 'Assertion failed' message containing the error code number is generated. Thi
 
 ``Fatal failure: Assertion failed, code=49``
 
+And also in the problems panel, there will be a message displaying "Assertion failed", similar to how the serial output logs the message.
+
 ## Parameters
 
 * **cond**: a [boolean](/types/boolean) where `true` means everything is ok or `false` which means, stop the program!

--- a/libs/base/docs/reference/control/assert.md
+++ b/libs/base/docs/reference/control/assert.md
@@ -26,7 +26,7 @@ forever(function () {
 })
 ```
 
-## See also #see also
+## See also #seealso
 
 [panic](/reference/control/panic)
 


### PR DESCRIPTION
Edited file `assert.md` for explaining what the "Assertion failed" message represents in the problems panel.