### PR TITLE
Fix simulator restart not stopping all concurrent sound threads

### DIFF
--- a/libs/mixer/sim/music.ts
+++ b/libs/mixer/sim/music.ts
@@ -1,9 +1,11 @@
 namespace pxsim.music {
     export function playInstructions(b: RefBuffer) {
+        setupOnStopAll();
         return AudioContextManager.playInstructionsAsync(b.data)
     }
 
     export function queuePlayInstructions(when: number, b: RefBuffer) {
+        setupOnStopAll();
         AudioContextManager.queuePlayInstructions(when, b)
     }
 
@@ -30,19 +32,27 @@ namespace pxsim.music {
         sequencer: Sequencer;
     }
 
-    let sequencers: SequencerWithId[];
-    let nextSequencerId = 0;
+    let onStopAllSetup = false;
+
+    function setupOnStopAll() {
+        if (!onStopAllSetup) {
+            onStopAllSetup = true;
+            pxsim.AudioContextManager.onStopAll(() => {
+                AudioContextManager.muteAllChannels();
+                if (sequencers) {
+                    for (const seq of sequencers) {
+                        seq.sequencer.stop();
+                        seq.sequencer.dispose();
+                    }
+                    sequencers = [];
+                }
+            })
+        }
+    }
 
     export async function _createSequencer(): Promise<number> {
+        setupOnStopAll();
         if (!sequencers) {
-            pxsim.AudioContextManager.onStopAll(() => {
-                for (const seq of sequencers) {
-                    seq.sequencer.stop();
-                    seq.sequencer.dispose();
-                }
-                sequencers = [];
-            })
-
             sequencers = [];
         }
         const res = {

--- a/libs/mixer/sim/music.ts
+++ b/libs/mixer/sim/music.ts
@@ -32,6 +32,8 @@ namespace pxsim.music {
         sequencer: Sequencer;
     }
 
+    let sequencers: SequencerWithId[];
+    let nextSequencerId = 0;
     let onStopAllSetup = false;
 
     function setupOnStopAll() {


### PR DESCRIPTION
Fixes issue #7552 in microsoft/pxt-arcade.

The `onStopAll` callback in the mixer simulator code was only set up when sequencers were created, and it only stopped sequencer-based audio. Direct calls to `music.playInstructions()` bypassed this mechanism and weren't stopped on simulator restart.

### Fix
- Added a `setupOnStopAll()` function that ensures the `onStopAll` callback is registered to call `AudioContextManager.muteAllChannels()` when the simulator stops audio.
- Modified `playInstructions()` and `queuePlayInstructions()` to call `setupOnStopAll()`, ensuring the callback is set up whenever these functions are used.
- Enhanced the `onStopAll` callback to call `muteAllChannels()` in addition to stopping sequencers.

This ensures that all concurrent sound threads are properly stopped when the simulator restarts, resolving the sound stacking issue.