### PR TITLE
update sample frequency for NRF

### DIFF
--- a/libs/mixer---nrf52/SoundOutput.h
+++ b/libs/mixer---nrf52/SoundOutput.h
@@ -6,7 +6,7 @@ class SoundOutput {
   public:
     NRF52PWM dac;
 
-    SoundOutput(DataSource &data) : dac(NRF_PWM0, data) {
+    SoundOutput(DataSource &data) : dac(NRF_PWM0, data, 44100) {
         dac.setDecoderMode( PWM_DECODER_LOAD_Common );
         dac.connectPin(*LOOKUP_PIN(JACK_SND), 0);
     }

--- a/libs/mixer/melody.h
+++ b/libs/mixer/melody.h
@@ -114,7 +114,7 @@ class WSynthesizer
 #endif
         while (sz--) {
 #if defined(NRF52_SERIES)
-            *dp = ((*dp + (1 << (OUTPUT_BITS - 1))) * mul) >> OUTPUT_BITS;
+            *dp = ((-*dp + (1 << (OUTPUT_BITS - 1))) * mul) >> OUTPUT_BITS;
 #else
             *dp += 1 << (OUTPUT_BITS - 1);
 #endif

--- a/libs/mixer/melody.h
+++ b/libs/mixer/melody.h
@@ -114,7 +114,7 @@ class WSynthesizer
 #endif
         while (sz--) {
 #if defined(NRF52_SERIES)
-            *dp = ((-*dp + (1 << (OUTPUT_BITS - 1))) * mul) >> OUTPUT_BITS;
+            *dp = ((*dp + (1 << (OUTPUT_BITS - 1))) * mul) >> OUTPUT_BITS;
 #else
             *dp += 1 << (OUTPUT_BITS - 1);
 #endif


### PR DESCRIPTION
Joe pointed out that need to drive PWM at higher frequency for better sound (as in pxt-microbit). This change only affects the NRF (microbit shield).