### PR TITLE
Add parameter labels for input names

### DIFF
--- a/libs/base/console.ts
+++ b/libs/base/console.ts
@@ -55,6 +55,7 @@ namespace console {
     //% weight=90
     //% help=console/log blockGap=8
     //% blockId=console_log block="console log $value"
+    //% value.label="value"
     //% value.shadow=text
     export function log(value: any): void {
         add(ConsolePriority.Log, value);
@@ -68,6 +69,7 @@ namespace console {
     //% weight=88 blockGap=8
     //% help=console/log-value
     //% blockId=console_log_value block="console|log value %name|= %value"
+    //% name.label="name" value.label="value"
     //% name.shadow=text
     //% value.shadow=math_number
     export function logValue(name: any, value: any): void {

--- a/libs/base/control.cpp
+++ b/libs/base/control.cpp
@@ -42,6 +42,7 @@ namespace control {
     */
     //% help=control/wait-micros weight=29 async
     //% blockId="control_wait_us" block="wait (µs)%micros"
+    //% micros.label="microseconds"
     void waitMicros(int micros) {
         sleep_us(micros);
     }
@@ -60,6 +61,7 @@ namespace control {
     */
     //% help=control/wait-for-event async
     //% blockId=control_wait_for_event block="wait for event|from %src|with value %value"
+    //% src.label="source" value.label="value"
     void waitForEvent(int src, int value) {
         pxt::waitForEvent(src, value);
     }

--- a/libs/base/control.ts
+++ b/libs/base/control.ts
@@ -61,6 +61,7 @@ namespace control {
      */
     //% help=control/panic weight=29
     //% blockId="control_panic" block="panic %code"
+    //% code.label="code"
     //% shim=pxtrt::panic
     export function panic(code: number) { }
 
@@ -69,6 +70,7 @@ namespace control {
      */
     //% help=control/assert weight=30
     //% blockId="control_assert" block="assert %cond|with value %code"
+    //% cond.label="condition" code.label="code"
     export function assert(cond: boolean, code: number) {
         if (!cond) {
             fail("Assertion failed, code=" + code)
@@ -184,6 +186,7 @@ namespace control {
  */
 //% help=text/convert-to-text weight=1
 //% block="convert $value=math_number to text"
+//% value.label="value"
 //% blockId=variable_to_text blockNamespace="text"
 function convertToText(value: any): string {
     return "" + value;

--- a/libs/base/eventcontext.ts
+++ b/libs/base/eventcontext.ts
@@ -5,6 +5,7 @@ namespace control {
      * @param value the event value to match
      */
     //% weight=20 blockGap=8 blockId="control_on_event" block="on event|from %src|with value %value"
+    //% src.label="source" value.label="value"
     //% blockExternalInputs=1
     //% help="control/on-event"
     export function onEvent(src: number, value: number, handler: () => void, flags = 16) { // EVENT_LISTENER_DEFAULT_FLAGS

--- a/libs/base/loops.cpp
+++ b/libs/base/loops.cpp
@@ -18,6 +18,7 @@ void forever(Action a) {
  */
 //% help=loops/pause weight=99 deprecated=true
 //% async block="pause %pause=timePicker|ms"
+//% ms.label="value"
 //% blockId=device_pause_deprecated
 void pause(int ms) {
     if (ms < 0) return;

--- a/libs/base/math.ts
+++ b/libs/base/math.ts
@@ -34,6 +34,7 @@ namespace Math {
      */
     //% help=math/map weight=10 blockGap=8
     //% blockId=math_map block="map %value|from low %fromLow|high %fromHigh|to low %toLow|high %toHigh"
+    //% value.label="value" fromLow.label="from low" fromHigh.label="from high" toLow.label="to low" toHigh.label="to high"
     //% inlineInputMode=inline
     export function map(value: number, fromLow: number, fromHigh: number, toLow: number, toHigh: number): number {
         return ((value - fromLow) * (toHigh - toLow)) / (fromHigh - fromLow) + toLow;
@@ -47,6 +48,7 @@ namespace Math {
      */
     //% help=math/constrain weight=11 blockGap=8
     //% blockId="math_constrain_value" block="constrain %value|between %low|and %high"
+    //% value.label="value" low.label="minimum" high.label="maximum"
     export function constrain(value: number, low: number, high: number): number {
         return value < low ? low : value > high ? high : value;
     }

--- a/libs/base/pause.ts
+++ b/libs/base/pause.ts
@@ -4,6 +4,7 @@
  */
 //% help=loops/pause weight=99
 //% async block="pause %pause=timePicker|ms"
+//% ms.label="value"
 //% blockId=device_pause blockNamespace="loops"
 function pause(ms: number): void {
     loops.pause(ms);

--- a/libs/color/colors.ts
+++ b/libs/color/colors.ts
@@ -73,6 +73,7 @@ namespace color {
      * @param blue value of the blue channel between 0 and 255. eg: 255
      */
     //% blockId="colorsrgb" block="red %red|green %green|blue %blue"
+    //% red.label="red" green.label="green" blue.label="blue"
     //% red.min=0 red.max=255 green.min=0 green.max=255 blue.min=0 blue.max=255
     //% help="colors/rgb"
     //% weight=19 blockGap=8
@@ -105,6 +106,7 @@ namespace color {
      */
 
     //% blockId="colorshsv" block="hue %hue|sat %sat|val %val"
+    //% hue.label="hue" sat.label="saturation" val.label="brightness"
     //% hue.min=0 hue.max=255 sat.min=0 sat.max=255 val.min=0 val.max=255
     //% help="colors/hsv"
     //% weight=17
@@ -161,6 +163,7 @@ namespace color {
      * @param brightness the amount of brightness to apply to the color, eg: 128
      */
     //% blockId="colorsfade" block="fade %color=neopixel_colors|by %brightness"
+    //% color.label="color" brightness.label="brightness"
     //% brightness.min=0 brightness.max=255
     //% help="light/fade"
     //% group="Color" weight=18 blockGap=8

--- a/libs/microphone/microphone.cpp
+++ b/libs/microphone/microphone.cpp
@@ -43,6 +43,7 @@ int soundLevel() {
 */
 //% help=input/set-loud-sound-threshold
 //% blockId=input_set_loud_sound_threshold block="set loud sound threshold %value"
+//% value.label="value"
 //% parts="microphone"
 //% value.min=1 value.max=255
 //% group="More" weight=14 blockGap=8

--- a/libs/radio-broadcast/radio-broadcast.ts
+++ b/libs/radio-broadcast/radio-broadcast.ts
@@ -17,6 +17,7 @@ namespace radio {
      * @param msg 
      */
     //% blockId=radioBroadcastMessage block="radio send $msg"
+    //% msg.label="message"
     //% msg.shadow=radioMessageCode draggableParameters
     //% weight=200
     //% blockGap=8
@@ -33,6 +34,7 @@ namespace radio {
      * @param handler 
      */
     //% blockId=radioOnMessageReceived block="on radio $msg received"
+    //% msg.label="message"
     //% msg.shadow=radioMessageCode draggableParameters
     //% weight=199
     //% help=radio/on-received-message

--- a/libs/radio/radio.cpp
+++ b/libs/radio/radio.cpp
@@ -151,6 +151,7 @@ CODAL_RADIO* getRadio() {
     * Sends an event over radio to neigboring devices
     */
     //% blockId=radioRaiseEvent block="radio raise event|from source %src=control_event_source_id|with value %value=control_event_value_id"
+    //% src.label="source" value.label="value"
     //% blockExternalInputs=1
     //% advanced=true
     //% weight=1
@@ -236,6 +237,7 @@ CODAL_RADIO* getRadio() {
     //% help=radio/set-group
     //% weight=100
     //% blockId=radio_set_group block="radio set group %ID"
+    //% id.label="value"
     //% id.min=0 id.max=255
     //% group="Group"
     void setGroup(int id) {
@@ -253,6 +255,7 @@ CODAL_RADIO* getRadio() {
     //% help=radio/set-transmit-power
     //% weight=9 blockGap=8
     //% blockId=radio_set_transmit_power block="radio set transmit power %power"
+    //% power.label="value"
     //% power.min=0 power.max=7
     //% advanced=true
     void setTransmitPower(int power) {
@@ -270,6 +273,7 @@ CODAL_RADIO* getRadio() {
     //% help=radio/set-frequency-band
     //% weight=8 blockGap=8
     //% blockId=radio_set_frequency_band block="radio set frequency band %band"
+    //% band.label="value"
     //% band.min=0 band.max=83
     //% advanced=true
     void setFrequencyBand(int band) {

--- a/libs/radio/radio.ts
+++ b/libs/radio/radio.ts
@@ -146,6 +146,7 @@ namespace radio {
     //% help=radio/received-packet
     //% blockGap=8
     //% blockId=radio_received_packet block="received packet %type=radio_packet_property" blockGap=16
+    //% type.label="property"
     //% group="Receive"
     //% weight=16
     export function receivedPacket(type: number) {
@@ -280,6 +281,7 @@ namespace radio {
     //% help=radio/send-number
     //% weight=60
     //% blockId=radio_datagram_send block="radio send number %value" blockGap=8
+    //% value.label="value"
     //% group="Send"
     export function sendNumber(value: number) {
         let packet: RadioPacket;
@@ -305,6 +307,7 @@ namespace radio {
     //% help=radio/send-value
     //% weight=59
     //% blockId=radio_datagram_send_value block="radio send|value %name|= %value" blockGap=8
+    //% name.label="name" value.label="value"
     //% group="Send"
     export function sendValue(name: string, value: number) {
         let packet: RadioPacket;
@@ -328,6 +331,7 @@ namespace radio {
     //% help=radio/send-string
     //% weight=58
     //% blockId=radio_datagram_send_string block="radio send string %msg"
+    //% value.label="value"
     //% msg.shadowOptions.toString=true
     //% group="Send"
     export function sendString(value: string) {
@@ -356,6 +360,7 @@ namespace radio {
     //% help=radio/set-transmit-serial-number
     //% weight=8 blockGap=8
     //% blockId=radio_set_transmit_serial_number block="radio set transmit serial number %transmit"
+    //% transmit.label="value"
     //% advanced=true
     export function setTransmitSerialNumber(transmit: boolean) {
         transmittingSerial = transmit;

--- a/libs/servo/servo.ts
+++ b/libs/servo/servo.ts
@@ -29,6 +29,7 @@ namespace servos {
          */
         //% weight=100 help=servos/set-angle
         //% blockId=servoservosetangle block="set %servo angle to %degrees=protractorPicker °"
+        //% degrees.label="angle"
         //% degrees.defl=90
         //% servo.fieldEditor="gridpicker"
         //% servo.fieldOptions.width=220
@@ -60,6 +61,7 @@ namespace servos {
          */
         //% weight=99 help=servos/run
         //% blockId=servoservorun block="continuous %servo run at %speed=speedPicker \\%"
+        //% speed.label="speed"
         //% servo.fieldEditor="gridpicker"
         //% servo.fieldOptions.width=220
         //% servo.fieldOptions.columns=2
@@ -83,6 +85,7 @@ namespace servos {
 
         //% weight=10 help=servos/set-pulse
         //% blockId=servoservosetpulse block="set %servo pulse to %micros μs"
+        //% micros.label="microseconds"
         //% micros.min=500 micros.max=2500
         //% micros.defl=1500
         //% servo.fieldEditor="gridpicker"
@@ -140,6 +143,7 @@ namespace servos {
          */
         //% help=servos/set-range
         //% blockId=servosetrange block="set %servo range from %minAngle to %maxAngle"
+        //% minAngle.label="minimum angle" maxAngle.label="maximum angle"
         //% minAngle.min=0 minAngle.max=90
         //% maxAngle.min=90 maxAngle.max=180 maxAngle.defl=180
         //% servo.fieldEditor="gridpicker"
@@ -159,6 +163,7 @@ namespace servos {
          */
         //% help=servos/set-stop-on-neutral
         //% blockId=servostoponneutral block="set %servo stop on neutral %enabled"
+        //% enabled.label="on"
         //% enabled.shadow=toggleOnOff
         //% group="Configuration"
         //% blockGap=8


### PR DESCRIPTION
This PR uses the mechanism added in https://github.com/microsoft/pxt/pull/11334 to create sensible input names for block inputs for screen reader users. The impact of these changes is currently limited to move mode where the block has more than one input. However, in the next Blockly release, these names will be surfaced when screen reader users focus an input via keyboard navigation. As such, I've opened this PR as a draft to provide visibility of these changes ahead of time for review and feedback.

Example of how this will work:
<img width="447" height="272" alt="Screenshot 2026-06-24 at 15 27 56" src="https://github.com/user-attachments/assets/fe5d1fe9-c297-432d-8ba4-9daae31641fc" />

Current output on beta:
<img width="315" height="281" alt="Screenshot 2026-06-24 at 15 28 28" src="https://github.com/user-attachments/assets/a9fd5c5d-9469-4ca9-9336-d09564450f47" />

The parameter label creation was AI-assisted and manually reviewed.