### PR TITLE
PyBadge fix greyscale appearance

### DIFF
--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -35,9 +35,10 @@ class WDisplay {
 
 #ifdef USE_RGB444
     // RGB444 streaming path for ST7735 panels lacking the RGBSET LUT (see #6861)
-    SPI *spi_;
-    Pin *dcPin_;
-    Pin *csPin_;
+    SPI *spi_ = NULL;
+    Pin *dcPin_ = NULL;
+    Pin *csPin_ = NULL;
+    bool rgb444_ = false;
     uint8_t pal4R_[16], pal4G_[16], pal4B_[16];
 
     inline void wrCmd1(uint8_t cmd, uint8_t a0) {
@@ -96,6 +97,21 @@ class WDisplay {
             target_panic(PANIC_SCREEN_ERROR);
         }
 
+#ifdef USE_RGB444
+        // Runtime scope: RGB444 only on known Adafruit boards. Current Adafruit
+        // bootloaders publish VID:PID (VID 0x239A) as the board-id; older ones
+        // (which new boards still ship with) published fixed per-model ids, listed
+        // below. Unknown or absent ids keep the stock RGBSET path (e.g. Kitronik).
+        uint32_t boardId = (uint32_t)getConfig(CFG_BOOTLOADER_BOARD_ID, 0);
+        rgb444_ = spi_ && ((boardId >> 16) == 0x239A || // current Adafruit (VID:PID)
+                           boardId == 0x18591ab9 ||     // PyBadge/LC/PyGamer (2019)
+                           boardId == 0x75fdeb5f ||     // PyBadge
+                           boardId == 0x3f05ba69 ||     // PyBadge LC
+                           boardId == 0x2dd7a88c ||     // PyGamer
+                           boardId == 0x2b9e3d05 ||     // Feather M4 Arcade
+                           boardId == 0x7a236324);      // ItsyBitsy M4 Arcade
+#endif
+
         if (dispTp == DISPLAY_TYPE_ST7735)
             lcd = new ST7735(*io, *LOOKUP_PIN(DISPLAY_CS), *LOOKUP_PIN(DISPLAY_DC));
         else if (dispTp == DISPLAY_TYPE_ILI9341) {
@@ -148,7 +164,7 @@ class WDisplay {
             lcd->configure(madctl, frmctr1);
 
 #ifdef USE_RGB444
-            if (!doubleSize) {
+            if (rgb444_ && !doubleSize) {
                 // 12bpp RGB444 mode: lets us stream color without the RGBSET LUT
                 wrCmd1(0x3A, 0x03); // COLMOD
                 wrCmd1(0x20, 0x00); // INVOFF
@@ -423,7 +439,7 @@ void updateScreen(Image_ img) {
         display->waitForSendDone();
 
 #ifdef USE_RGB444
-        if (display->lcd && !display->doubleSize) {
+        if (display->rgb444_ && display->lcd && !display->doubleSize) {
             memcpy(display->screenBuf, img->pix(), img->pixLength());
             display->setAddrMain();
             display->sendIndexedImage444(display->screenBuf, display->width, display->displayHeight);
@@ -456,11 +472,14 @@ void updateScreen(Image_ img) {
         memcpy(display->screenBuf, img->pix(), img->pixLength());
         display->setAddrStatus();
 #ifdef USE_RGB444
-        display->sendIndexedImage444(display->screenBuf, display->width, barHeight);
-#else
-        display->sendIndexedImage(display->screenBuf, img->width(), img->height(), NULL);
-        display->waitForSendDone();
+        if (display->rgb444_) {
+            display->sendIndexedImage444(display->screenBuf, display->width, barHeight);
+        } else
 #endif
+        {
+            display->sendIndexedImage(display->screenBuf, img->width(), img->height(), NULL);
+            display->waitForSendDone();
+        }
         display->setAddrMain();
         display->lastStatus = NULL;
     }

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -33,6 +33,7 @@ class WDisplay {
     bool doubleSize;
     uint32_t palXOR;
 
+#ifdef USE_RGB444
     // RGB444 streaming path for ST7735 panels lacking the RGBSET LUT (see #6861)
     SPI *spi_;
     Pin *dcPin_;
@@ -44,6 +45,7 @@ class WDisplay {
         dcPin_->setDigitalValue(1); spi_->write(a0);
         csPin_->setDigitalValue(1);
     }
+#endif
 
     WDisplay() {
         uint32_t cfg2 = getConfig(CFG_DISPLAY_CFG2, 0x0);
@@ -78,9 +80,11 @@ class WDisplay {
             spi = new CODAL_SPI(*LOOKUP_PIN(DISPLAY_MOSI), *miso, *LOOKUP_PIN(DISPLAY_SCK));
 #endif
             io = new SPIScreenIO(*spi);
+#ifdef USE_RGB444
             spi_ = spi;
             dcPin_ = LOOKUP_PIN(DISPLAY_DC);
             csPin_ = LOOKUP_PIN(DISPLAY_CS);
+#endif
         } else if (conn == 1) {
 #ifdef CODAL_CREATE_PARALLEL_SCREEN_IO
             io = CODAL_CREATE_PARALLEL_SCREEN_IO(cfg2 & 0xffffff, PIN(DISPLAY_MOSI),
@@ -143,11 +147,13 @@ class WDisplay {
             lcd->init();
             lcd->configure(madctl, frmctr1);
 
+#ifdef USE_RGB444
             if (!doubleSize) {
                 // 12bpp RGB444 mode: lets us stream color without the RGBSET LUT
                 wrCmd1(0x3A, 0x03); // COLMOD
                 wrCmd1(0x20, 0x00); // INVOFF
             }
+#endif
         }
 
         width = getConfig(CFG_DISPLAY_WIDTH, 160);
@@ -268,28 +274,34 @@ class WDisplay {
 #endif
     }
 
+#ifdef USE_RGB444
     // Stream a 4bpp indexed image as RGB444 over SPI (replaces the RGBSET LUT path).
+    // Batches up to 3 lines per SPI transfer to reduce per-transfer overhead.
     void sendIndexedImage444(const uint8_t *src, int W, int H) {
-        static uint8_t line444[(3 * 160) / 2]; // 160 = max ST7735 width
+        static uint8_t buf444[3 * (3 * 160) / 2]; // 160 = max ST7735 width
         const int bytesPerRow = (W + 1) >> 1;
         dcPin_->setDigitalValue(0);
         csPin_->setDigitalValue(0);
         spi_->write(0x2C); // RAMWR
         dcPin_->setDigitalValue(1);
+        int out = 0;
         for (int y = 0; y < H; y++) {
             const uint8_t *row = src + y * bytesPerRow;
-            int out = 0;
             for (int x = 0; x < W; x += 2) {
                 uint8_t b = *row++;
                 uint8_t i0 = b & 0x0F, i1 = (b >> 4) & 0x0F;
-                line444[out++] = (pal4R_[i0] << 4) | pal4G_[i0];
-                line444[out++] = (pal4B_[i0] << 4) | pal4R_[i1];
-                line444[out++] = (pal4G_[i1] << 4) | pal4B_[i1];
+                buf444[out++] = (pal4R_[i0] << 4) | pal4G_[i0];
+                buf444[out++] = (pal4B_[i0] << 4) | pal4R_[i1];
+                buf444[out++] = (pal4G_[i1] << 4) | pal4B_[i1];
             }
-            spi_->transfer((uint8_t *)line444, out, NULL, 0);
+            if (out + 3 * (W + 1) / 2 > (int)sizeof(buf444) || y == H - 1) {
+                spi_->transfer((uint8_t *)buf444, out, NULL, 0);
+                out = 0;
+            }
         }
         csPin_->setDigitalValue(1);
     }
+#endif
 };
 
 SINGLETON_IF_PIN(WDisplay, DISPLAY_MOSI);
@@ -358,9 +370,11 @@ void setPalette(Buffer buf) {
         display->currPalette[i] =
             (buf->data[i * 3] << 16) | (buf->data[i * 3 + 1] << 8) | (buf->data[i * 3 + 2] << 0);
         display->currPalette[i] ^= display->palXOR;
+#ifdef USE_RGB444
         display->pal4R_[i] = (display->currPalette[i] >> 20) & 0xF;
         display->pal4G_[i] = (display->currPalette[i] >> 12) & 0xF;
         display->pal4B_[i] = (display->currPalette[i] >> 4) & 0xF;
+#endif
     }
     display->newPalette = true;
 }
@@ -405,18 +419,30 @@ void updateScreen(Image_ img) {
             img->height() * mult != display->displayHeight)
             target_panic(PANIC_SCREEN_ERROR);
 
+        // DMESG("wait for done");
         display->waitForSendDone();
-        memcpy(display->screenBuf, img->pix(), img->pixLength());
 
+#ifdef USE_RGB444
         if (display->lcd && !display->doubleSize) {
+            memcpy(display->screenBuf, img->pix(), img->pixLength());
             display->setAddrMain();
             display->sendIndexedImage444(display->screenBuf, display->width, display->displayHeight);
-        } else {
+        } else
+#endif
+        {
             auto palette = display->currPalette;
-            if (display->newPalette)
+
+            if (display->newPalette) {
                 display->newPalette = false;
-            else if (!display->smart)
-                palette = NULL;
+            } else {
+                // smart mode always sends palette
+                if (!display->smart)
+                    palette = NULL;
+            }
+
+            memcpy(display->screenBuf, img->pix(), img->pixLength());
+
+            // DMESG("send");
             display->sendIndexedImage(display->screenBuf, img->width(), img->height(), palette);
         }
     }
@@ -429,7 +455,12 @@ void updateScreen(Image_ img) {
             target_panic(PANIC_SCREEN_ERROR);
         memcpy(display->screenBuf, img->pix(), img->pixLength());
         display->setAddrStatus();
+#ifdef USE_RGB444
         display->sendIndexedImage444(display->screenBuf, display->width, barHeight);
+#else
+        display->sendIndexedImage(display->screenBuf, img->width(), img->height(), NULL);
+        display->waitForSendDone();
+#endif
         display->setAddrMain();
         display->lastStatus = NULL;
     }

--- a/libs/screen---st7735/screen.cpp
+++ b/libs/screen---st7735/screen.cpp
@@ -33,6 +33,18 @@ class WDisplay {
     bool doubleSize;
     uint32_t palXOR;
 
+    // RGB444 streaming path for ST7735 panels lacking the RGBSET LUT (see #6861)
+    SPI *spi_;
+    Pin *dcPin_;
+    Pin *csPin_;
+    uint8_t pal4R_[16], pal4G_[16], pal4B_[16];
+
+    inline void wrCmd1(uint8_t cmd, uint8_t a0) {
+        dcPin_->setDigitalValue(0); csPin_->setDigitalValue(0); spi_->write(cmd);
+        dcPin_->setDigitalValue(1); spi_->write(a0);
+        csPin_->setDigitalValue(1);
+    }
+
     WDisplay() {
         uint32_t cfg2 = getConfig(CFG_DISPLAY_CFG2, 0x0);
         int conn = cfg2 >> 24;
@@ -66,6 +78,9 @@ class WDisplay {
             spi = new CODAL_SPI(*LOOKUP_PIN(DISPLAY_MOSI), *miso, *LOOKUP_PIN(DISPLAY_SCK));
 #endif
             io = new SPIScreenIO(*spi);
+            spi_ = spi;
+            dcPin_ = LOOKUP_PIN(DISPLAY_DC);
+            csPin_ = LOOKUP_PIN(DISPLAY_CS);
         } else if (conn == 1) {
 #ifdef CODAL_CREATE_PARALLEL_SCREEN_IO
             io = CODAL_CREATE_PARALLEL_SCREEN_IO(cfg2 & 0xffffff, PIN(DISPLAY_MOSI),
@@ -127,6 +142,12 @@ class WDisplay {
 
             lcd->init();
             lcd->configure(madctl, frmctr1);
+
+            if (!doubleSize) {
+                // 12bpp RGB444 mode: lets us stream color without the RGBSET LUT
+                wrCmd1(0x3A, 0x03); // COLMOD
+                wrCmd1(0x20, 0x00); // INVOFF
+            }
         }
 
         width = getConfig(CFG_DISPLAY_WIDTH, 160);
@@ -246,6 +267,29 @@ class WDisplay {
         return 0;
 #endif
     }
+
+    // Stream a 4bpp indexed image as RGB444 over SPI (replaces the RGBSET LUT path).
+    void sendIndexedImage444(const uint8_t *src, int W, int H) {
+        static uint8_t line444[(3 * 160) / 2]; // 160 = max ST7735 width
+        const int bytesPerRow = (W + 1) >> 1;
+        dcPin_->setDigitalValue(0);
+        csPin_->setDigitalValue(0);
+        spi_->write(0x2C); // RAMWR
+        dcPin_->setDigitalValue(1);
+        for (int y = 0; y < H; y++) {
+            const uint8_t *row = src + y * bytesPerRow;
+            int out = 0;
+            for (int x = 0; x < W; x += 2) {
+                uint8_t b = *row++;
+                uint8_t i0 = b & 0x0F, i1 = (b >> 4) & 0x0F;
+                line444[out++] = (pal4R_[i0] << 4) | pal4G_[i0];
+                line444[out++] = (pal4B_[i0] << 4) | pal4R_[i1];
+                line444[out++] = (pal4G_[i1] << 4) | pal4B_[i1];
+            }
+            spi_->transfer((uint8_t *)line444, out, NULL, 0);
+        }
+        csPin_->setDigitalValue(1);
+    }
 };
 
 SINGLETON_IF_PIN(WDisplay, DISPLAY_MOSI);
@@ -314,6 +358,9 @@ void setPalette(Buffer buf) {
         display->currPalette[i] =
             (buf->data[i * 3] << 16) | (buf->data[i * 3 + 1] << 8) | (buf->data[i * 3 + 2] << 0);
         display->currPalette[i] ^= display->palXOR;
+        display->pal4R_[i] = (display->currPalette[i] >> 20) & 0xF;
+        display->pal4G_[i] = (display->currPalette[i] >> 12) & 0xF;
+        display->pal4B_[i] = (display->currPalette[i] >> 4) & 0xF;
     }
     display->newPalette = true;
 }
@@ -358,23 +405,20 @@ void updateScreen(Image_ img) {
             img->height() * mult != display->displayHeight)
             target_panic(PANIC_SCREEN_ERROR);
 
-        // DMESG("wait for done");
         display->waitForSendDone();
-
-        auto palette = display->currPalette;
-
-        if (display->newPalette) {
-            display->newPalette = false;
-        } else {
-            // smart mode always sends palette
-            if (!display->smart)
-                palette = NULL;
-        }
-
         memcpy(display->screenBuf, img->pix(), img->pixLength());
 
-        // DMESG("send");
-        display->sendIndexedImage(display->screenBuf, img->width(), img->height(), palette);
+        if (display->lcd && !display->doubleSize) {
+            display->setAddrMain();
+            display->sendIndexedImage444(display->screenBuf, display->width, display->displayHeight);
+        } else {
+            auto palette = display->currPalette;
+            if (display->newPalette)
+                display->newPalette = false;
+            else if (!display->smart)
+                palette = NULL;
+            display->sendIndexedImage(display->screenBuf, img->width(), img->height(), palette);
+        }
     }
 
     if (display->lastStatus && !display->doubleSize && !display->smart) {
@@ -385,8 +429,7 @@ void updateScreen(Image_ img) {
             target_panic(PANIC_SCREEN_ERROR);
         memcpy(display->screenBuf, img->pix(), img->pixLength());
         display->setAddrStatus();
-        display->sendIndexedImage(display->screenBuf, img->width(), img->height(), NULL);
-        display->waitForSendDone();
+        display->sendIndexedImage444(display->screenBuf, display->width, barHeight);
         display->setAddrMain();
         display->lastStatus = NULL;
     }


### PR DESCRIPTION
Fixes microsoft/pxt-arcade#6861

Newer [PyBadge](https://www.adafruit.com/product/4200) and [PyBadge LC](https://www.adafruit.com/product/3939) units (shipping since January 2025) use an ST7735 panel variant that ignores the **RGBSET** palette register MakeCode Arcade relies on, so games render in inverted greyscale even though color is fine in the bootloader, CircuitPython, and Arduino. The variant can't be detected at runtime.

This drops RGBSET and streams **RGB444** color directly, which works on both the old and new panels, so it's applied unconditionally (gated on `lcd && !doubleSize`, leaving the ILI9341 and micro:bit paths untouched).

Investigation and proof-of-concept are **@adamwolf's** ([1e2cfa4](https://github.com/microsoft/pxt-common-packages/commit/1e2cfa405c90b23eaa22cf4f3c37a6acb5fef1c7)) please keep his authorship; this is his commit cleaned up and confirmed on affected hardware. Forum users have independently verified that patched builds restore color on their own boards ([1](https://forums.adafruit.com/viewtopic.php?t=224200), [2](https://forums.adafruit.com/viewtopic.php?t=224264)).


<img width="640" height="441" alt="pybadge-LC" src="https://github.com/user-attachments/assets/baf26442-4b14-4c6a-b9c3-1c4768bde774" />
