### PR TITLE
Restore parts annotations on digital pin APIs (breadboard LED / slide switch)

### DIFF
--- a/libs/core/pinsDigital.cpp
+++ b/libs/core/pinsDigital.cpp
@@ -34,6 +34,7 @@ namespace DigitalInOutPinMethods {
  */
 //% help=pins/digital-read weight=61
 //% blockId=device_get_digital_pin block="digital read|pin %name" blockGap=8
+//% parts="slideswitch" trackArgs=0
 //% blockNamespace=pins
 //% name.fieldEditor="gridpicker"
 //% name.fieldOptions.width=220
@@ -64,6 +65,7 @@ void digitalWrite(DigitalInOutPin name, bool value) {
 */
 //% help=pins/on-pulsed weight=16 blockGap=8
 //% blockId=pins_on_pulsed block="on|pin %pin|pulsed %pulse"
+//% parts="slideswitch" trackArgs=0
 //% blockNamespace=pins
 //% pin.fieldEditor="gridpicker"
 //% pin.fieldOptions.width=220
@@ -79,6 +81,7 @@ void onPulsed(DigitalInOutPin pin, PulseValue pulse, Action body) {
 */
 //% help=pins/on-event weight=20 blockGap=8
 //% blockId=pinsonevent block="on|pin %pin|%event"
+//% parts="slideswitch" trackArgs=0
 //% blockNamespace=pins
 //% pin.fieldEditor="gridpicker"
 //% pin.fieldOptions.width=220

--- a/libs/core/pinsDigital.cpp
+++ b/libs/core/pinsDigital.cpp
@@ -49,6 +49,7 @@ bool digitalRead(DigitalInOutPin name) {
     */
 //% help=pins/digital-write weight=60
 //% blockId=device_set_digital_pin block="digital write|pin %name|to %value=toggleHighLow"
+//% parts="led" trackArgs=0
 //% blockNamespace=pins
 //% name.fieldEditor="gridpicker"
 //% name.fieldOptions.width=220


### PR DESCRIPTION
## Problem

Writing to a digital pin used to add a breadboard with an LED wired to that pin in the MakeCode Maker simulator; reading a pin added a slide switch. Both regressed — no parts or breadboard appear. Reported in microsoft/pxt-maker#408.

## Root cause

#1203 (External simulators, Dec 2020) removed `//% parts="led" trackArgs=0` from `digitalWrite` and `//% parts="slideswitch" trackArgs=0` from `digitalRead`/`onPulsed`/`onEvent`, in favor of the declarative `instantiation` metadata in `pxtparts.json` (which #1203 left in place, e.g. `instantiation.fullyQualifiedName: "DigitalInOutPin.digitalWrite"` on the `led` part).

However, pxt-core's `computeUsedParts` builds the simulator parts list **only** from `//% parts=` annotations on used symbols — it never consults the pxtparts.json instantiation metadata. With the annotations gone, `led`/`slideswitch` never enter the parts list, so the allocator never places them and the breadboard stays hidden. Parts that kept their annotations (`microservo`, `neopixel`) continue to work, which is why only the pin-level parts disappeared.

## Fix

Two commits restoring exactly the annotations #1203 removed from `pinsDigital.cpp`:
1. `parts="led" trackArgs=0` on `digitalWrite`
2. `parts="slideswitch" trackArgs=0` on `digitalRead`, `onPulsed`, `onEvent`

This matches the mechanism the surviving parts use today. (A more complete alternative would be teaching `computeUsedParts` in pxt-core to honor pxtparts.json `instantiation` metadata — happy to discuss, but this restores the long-standing behavior with minimal risk.)

Note: the same #1203 change also removed `parts="photocell"` from `analogRead` and `parts="analogled"` from `analogWrite` in `pinsAnalog.cpp`; this PR deliberately scopes to the digital APIs reported in #408, but can extend to those if preferred.

## Verification

Applied to a local pxt-maker build (pxt-core 13.1.5 / pxt-common-packages 13.2.3 — annotation sites identical to master): `digital write pin A0 → HIGH` now renders the breadboard with an LED wired to A0 via a resistor, and `digital read pin` places a slide switch. Neopixel and servo part allocation unaffected.

Fixes microsoft/pxt-maker#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)